### PR TITLE
fix: schematic.snapshot 附加防陈旧元数据 (primitiveCount/capturedAt)

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -6,6 +6,13 @@ follow [SemVer](https://semver.org/).
 
 ## [Unreleased]
 ### Added
+- **`schematic.snapshot` anti-stale metadata (issue #2).** The snapshot result now
+  carries `primitiveCount` (live components + page primitives on the current page),
+  `capturedAt` (ISO timestamp), and a `stale` advisory string. EasyEDA does not
+  auto-redraw after `eda.*` edits, so `getCurrentRenderedAreaImage` can return a
+  byte-identical STALE frame; callers compare `primitiveCount` across two snapshots
+  to detect when the image didn't change but the page did. Judge state by data, use
+  the screenshot for layout only.
 - **`schematic.page.clear` — one-shot page reset.** Deletes every page-level
   primitive on the active page (components, net flags/ports/labels, wires, buses,
   and graphics — arcs/circles/rectangles/polygons/text), not just components.

--- a/extension/src/actions.ts
+++ b/extension/src/actions.ts
@@ -844,6 +844,27 @@ const schematicSelect: Handler = async (payload) => {
 
 // ─── Snapshot ─────────────────────────────────────────────────────────
 
+/**
+ * Best-effort count of the live primitives on the current schematic page
+ * (components + every standalone page primitive). It is the cheap anti-stale
+ * signal the snapshot caller compares across frames: if `primitiveCount`
+ * changed between two snapshots but the image bytes (sha256) did NOT, the
+ * EasyEDA canvas did not redraw and the latest frame is STALE (issue #2).
+ * Wrapped so a count failure never blocks the actual image capture.
+ */
+async function countLivePagePrimitives(): Promise<number | null> {
+	try {
+		let count = (await eda.sch_PrimitiveComponent.getAll()).length;
+		for (const kind of SCH_PAGE_PRIMITIVE_KINDS) {
+			count += (await kind.getAll()).length;
+		}
+		return count;
+	}
+	catch {
+		return null;
+	}
+}
+
 const schematicSnapshot: Handler = async (payload) => {
 	const tabId = optionalString(payload, 'tabId');
 	let blob;
@@ -857,7 +878,21 @@ const schematicSnapshot: Handler = async (payload) => {
 		throw new ActionError(ErrorCodes.EDA_CALL_FAILED, 'Snapshot returned no image.');
 	}
 	const artifact = await blobToArtifact(blob, 'schematic_snapshot', 'snapshot.png', 'image/png');
-	return { result: { artifactId: artifact.id }, artifacts: [artifact] };
+	// Anti-stale metadata (issue #2): EasyEDA does NOT auto-redraw after eda.*
+	// edits, so getCurrentRenderedAreaImage can return a byte-identical STALE
+	// frame. The caller compares `primitiveCount` across two snapshots — if it
+	// changed while the image sha did not, the frame is stale; judge STATE by
+	// data, not by the picture.
+	const primitiveCount = await countLivePagePrimitives();
+	return {
+		result: {
+			artifactId: artifact.id,
+			primitiveCount,
+			capturedAt: new Date().toISOString(),
+			stale: 'EasyEDA may not auto-redraw after API edits; compare primitiveCount across snapshots to detect a stale frame. Judge state by data, screenshot for layout only.',
+		},
+		artifacts: [artifact],
+	};
 };
 
 // ─── DRC ──────────────────────────────────────────────────────────────

--- a/internal/app/cmd_sch.go
+++ b/internal/app/cmd_sch.go
@@ -530,7 +530,14 @@ func newSchCmd(cfg *appConfig, stdout, stderr io.Writer) *cobra.Command {
 		c := &cobra.Command{
 			Use:   "snapshot",
 			Short: "Capture the current schematic view as an image artifact",
-			Args:  cobra.NoArgs,
+			Long: `Capture the current schematic view as an image artifact.
+
+WARNING: EasyEDA does NOT auto-redraw after API edits, so the captured frame can
+be STALE (byte-identical to the previous one even though the page changed). The
+result includes primitiveCount + capturedAt — compare primitiveCount across two
+snapshots to detect a stale frame, and judge STATE by data (sch list/getAll), not
+by the screenshot. Touch the page in EasyEDA (scroll/click) to force a redraw.`,
+			Args: cobra.NoArgs,
 			Example: `  easyeda sch snapshot
   easyeda sch snapshot --fit   # zoom to fit all first (whole sheet in frame)`,
 			RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/protocol/actions.go
+++ b/internal/protocol/actions.go
@@ -303,8 +303,8 @@ func AllActions() []ActionSpec {
 			Domain:      DomainSchematic,
 			Phase:       1,
 			NeedsWindow: true,
-			Description: "Capture current rendered area image as an artifact.",
-			Outputs:     []string{"artifact id", "file path", "mime type"},
+			Description: "Capture current rendered area image as an artifact. WARNING: EasyEDA may not auto-redraw after API edits, so the image can be a STALE frame — judge state by data (sch list/getAll), not the screenshot. Returns primitiveCount + capturedAt; if primitiveCount changed between two snapshots but the image is unchanged, the frame is stale.",
+			Outputs:     []string{"artifact id", "file path", "mime type", "primitiveCount", "capturedAt"},
 		},
 		{
 			Name:        "schematic.drc.check",

--- a/skills/easyeda-schematic/SKILL.md
+++ b/skills/easyeda-schematic/SKILL.md
@@ -68,7 +68,10 @@ near-equivalent, first).
    auto-redraw** → `schematic.snapshot` / `getCurrentRenderedAreaImage` return a STALE
    frame (even `view fit` framing is stale). **Judge STATE by data (`sch list`/`getAll`),
    use the screenshot for visual layout only**, and touch the page in EasyEDA (scroll/
-   click) to force a redraw before trusting a snapshot.
+   click) to force a redraw before trusting a snapshot. `schematic.snapshot` now returns
+   `primitiveCount` + `capturedAt` alongside the artifact — **compare `primitiveCount`
+   across two adjacent snapshots: if it changed but the image bytes/sha did not, the
+   frame is stale** and must not be trusted for verification.
 
 ## Bulk realization from a netlist (automated)
 


### PR DESCRIPTION
Fixes #2

## 问题
EasyEDA 经 `eda.*` API 改图后画布不会自动重绘，`getCurrentRenderedAreaImage` 会返回与上一帧逐字节相同的陈旧图像（SHA256 一致），导致 `schematic.snapshot` 无法作为布局验证的真值。

## 改动（最小可行）
- `extension/src/actions.ts`：`schematicSnapshot` 返回体新增 `primitiveCount`（当前页 components + 所有页级图元的实时计数，best-effort，失败返回 null 不阻断截图）、`capturedAt`（ISO 时间戳）与 `stale` 提示串。调用方比对相邻两帧 `primitiveCount`：若计数变了而图像未变即判定陈旧。
- `internal/protocol/actions.go`：`schematic.snapshot` 的 Description 明确告警可能返回 stale 帧、状态以数据为准，并补充新增输出字段。
- `internal/app/cmd_sch.go`：`easyeda sch snapshot` 增加 Long 帮助文本说明陈旧帧限制与 primitiveCount 用法。
- `skills/easyeda-schematic/SKILL.md`：工作流提示补充比对