### PR TITLE
fix: sch list 新增 --include-pins flag

### DIFF
--- a/internal/app/cmd_sch.go
+++ b/internal/app/cmd_sch.go
@@ -233,14 +233,15 @@ func newSchCmd(cfg *appConfig, stdout, stderr io.Writer) *cobra.Command {
 	// ── list ─────────────────────────────────────────────────────────────
 	// schematic.components.list
 	{
-		var allPages, includeBBox bool
+		var allPages, includeBBox, includePins bool
 		c := &cobra.Command{
 			Use:   "list",
 			Short: "List components on the active (or all) schematic page(s)",
 			Args:  cobra.NoArgs,
 			Example: `  easyeda sch list
   easyeda sch list --all-pages
-  easyeda sch list --include-bbox`,
+  easyeda sch list --include-bbox
+  easyeda sch list --include-pins`,
 			RunE: func(cmd *cobra.Command, args []string) error {
 				payload := map[string]any{}
 				if allPages {
@@ -248,6 +249,9 @@ func newSchCmd(cfg *appConfig, stdout, stderr io.Writer) *cobra.Command {
 				}
 				if includeBBox {
 					payload["includeBBox"] = true
+				}
+				if includePins {
+					payload["includePins"] = true
 				}
 				if len(payload) == 0 {
 					return dispatch(cfg, "schematic.components.list", window, nil, stdout, stderr)
@@ -257,6 +261,7 @@ func newSchCmd(cfg *appConfig, stdout, stderr io.Writer) *cobra.Command {
 		}
 		c.Flags().BoolVar(&allPages, "all-pages", false, "list components across all schematic pages")
 		c.Flags().BoolVar(&includeBBox, "include-bbox", false, "attach each component's rendered extent {minX,minY,maxX,maxY}")
+		c.Flags().BoolVar(&includePins, "include-pins", false, "attach each pin's {pinName,pinNumber,x,y,noConnected} — the data plane for routing/connectivity checks (output grows, esp. with --all-pages)")
 		sch.AddCommand(c)
 	}
 

--- a/skills/easyeda-schematic/SKILL.md
+++ b/skills/easyeda-schematic/SKILL.md
@@ -139,7 +139,7 @@ easyeda doc switch <P2|PCB1|uuid> --project <名字>   # 切换:按页名/PCB名
 
 ### 原理图编辑
 
-- `schematic.components.list` — `--include-bbox` 附带每个元件渲染范围 `{minX,minY,maxX,maxY}`(供布局推理)。
+- `schematic.components.list` — `--include-bbox` 附带每个元件渲染范围 `{minX,minY,maxX,maxY}`(供布局推理);`--include-pins` 附带每脚 `{pinName,pinNumber,x,y,noConnected}`(布线/连通性判断的数据面,布线前读引脚功能名→坐标用它,**不要**再用 `easyeda call schematic.components.list --payload '{"includePins":true}'` 绕过)。两个 flag 可与 `--all-pages` 叠加(输出会显著变大)。
 - **`easyeda sch layout-lint`** — **布局自检**(治覆盖的机械真值)。拉 `components.list --include-bbox`,Go 侧两两几何检查:**bbox 重叠 = ERROR**(命令非零退出,可当门禁)、**间距 < `--min-gap`(默认 2.54mm)= WARN**。`--all-pages`、`--json`。摆放后跑它判覆盖/间距,比肉眼/截图可靠(截图可能 stale)。是 place→verify→adjust 闭环的输入。
 - `schematic.component.place`
 - `schematic.component.modify`


### PR DESCRIPTION
Fixes #8

## 改动
- `internal/app/cmd_sch.go`:`sch list` 命令块照搬 `--include-bbox` 写法新增 `--include-pins` bool flag,RunE 内 `if includePins { payload["includePins"]=true }`,并在 Example 追加一行。`--help` 说明返回 `{pinName,pinNumber,x,y,noConnected}`,提示这是布线/连通性判断的数据面、输出会变大。
- `skills/easyeda-schematic/SKILL.md`:`schematic.components.list` 条目补充 `--include-pins` 说明,明确不再需要 `call ... --payload '{"includePins":true}'` 绕过。

## 范围
连接器侧 `extension/src/actions.ts` 的 `includePins` 分支早已实现,无需改动、无需重打包 .eext。Issue 提到的「更高层读引脚便捷命令」按评估建议拆为独立 issue,本次只做 flag。

## 测试
- `go build ./...` / `go test ./internal/...` 全绿。
- `easyeda sch list --help` 确认 `--include-pins` 已暴露。
- 运行时联机验证(读真实 EasyEDA 窗口引脚)需已连接的 EasyEDA Pro 窗口,本环境无硬件,未执行;逻辑与既有 `--include-bbox` 同构,风险低。