### PR TITLE
fix: 在 CLI 层映射 --kind 简写到连接器枚举 (#6)

### DIFF
--- a/internal/app/cmd_sch.go
+++ b/internal/app/cmd_sch.go
@@ -8,6 +8,49 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// netflagKindAliases maps user-friendly CLI shorthands to the canonical kind
+// enum the connector (extension/src/actions.ts NET_FLAG_KINDS / NET_PORT_KINDS)
+// actually accepts. Canonical names also pass through unchanged so both
+// `--kind gnd` and `--kind ground` work. Keep this list in sync with the
+// connector's accepted set to avoid CLI↔connector drift.
+var netflagKindAliases = map[string]string{
+	// shorthands
+	"gnd":     "ground",
+	"agnd":    "analog_ground",
+	"pgnd":    "protective_ground",
+	"netport": "net_port_bi", // bidirectional port is the most general default
+	// canonical passthrough (connector-native names)
+	"power":             "power",
+	"ground":            "ground",
+	"analog_ground":     "analog_ground",
+	"protective_ground": "protective_ground",
+	"protect_ground":    "protect_ground",
+	"net_port_in":       "net_port_in",
+	"net_port_out":      "net_port_out",
+	"net_port_bi":       "net_port_bi",
+}
+
+// netflagKindHelp is the single source of truth for the --kind help text so the
+// listed values stay in sync with what resolveNetflagKind actually accepts.
+const netflagKindHelp = "flag kind (required). Shorthands: gnd→ground, agnd→analog_ground, " +
+	"pgnd→protective_ground, netport→net_port_bi. Canonical: power, ground, analog_ground, " +
+	"protective_ground, protect_ground, net_port_in, net_port_out, net_port_bi"
+
+// resolveNetflagKind translates a CLI --kind value (shorthand or canonical) to
+// the canonical kind the connector accepts. Unknown values get a friendly CLI
+// error listing every valid value, instead of leaking the raw connector error.
+func resolveNetflagKind(kind string) (string, error) {
+	if canonical, ok := netflagKindAliases[kind]; ok {
+		return canonical, nil
+	}
+	valid := []string{
+		"gnd", "agnd", "pgnd", "netport",
+		"power", "ground", "analog_ground", "protective_ground", "protect_ground",
+		"net_port_in", "net_port_out", "net_port_bi",
+	}
+	return "", fmt.Errorf("unknown --kind %q; expected one of: %v", kind, valid)
+}
+
 // newSchCmd returns the "sch" subcommand group with all schematic actions.
 // --window is a persistent flag on the group so every subcommand inherits it.
 func newSchCmd(cfg *appConfig, stdout, stderr io.Writer) *cobra.Command {
@@ -440,8 +483,12 @@ func newSchCmd(cfg *appConfig, stdout, stderr io.Writer) *cobra.Command {
 				if net == "" {
 					return fmt.Errorf("--net is required")
 				}
+				canonicalKind, err := resolveNetflagKind(kind)
+				if err != nil {
+					return err
+				}
 				payload := map[string]any{
-					"kind": kind,
+					"kind": canonicalKind,
 					"net":  net,
 					"x":    x,
 					"y":    y,
@@ -452,7 +499,7 @@ func newSchCmd(cfg *appConfig, stdout, stderr io.Writer) *cobra.Command {
 				return dispatch(cfg, "schematic.netflag.create", window, payload, stdout, stderr)
 			},
 		}
-		c.Flags().StringVar(&kind, "kind", "", "flag kind: power, gnd, agnd, pgnd, netport, short (required)")
+		c.Flags().StringVar(&kind, "kind", "", netflagKindHelp)
 		c.Flags().StringVar(&net, "net", "", "net name (required)")
 		c.Flags().Float64Var(&x, "x", 0, "X coordinate")
 		c.Flags().Float64Var(&y, "y", 0, "Y coordinate")
@@ -478,10 +525,14 @@ func newSchCmd(cfg *appConfig, stdout, stderr io.Writer) *cobra.Command {
 				if net == "" {
 					return fmt.Errorf("--net is required")
 				}
+				canonicalKind, err := resolveNetflagKind(kind)
+				if err != nil {
+					return err
+				}
 				payload := map[string]any{
 					"pinX": x,
 					"pinY": y,
-					"kind": kind,
+					"kind": canonicalKind,
 					"net":  net,
 				}
 				if cmd.Flags().Changed("direction") {
@@ -498,7 +549,7 @@ func newSchCmd(cfg *appConfig, stdout, stderr io.Writer) *cobra.Command {
 		}
 		c.Flags().Float64Var(&x, "x", 0, "pin X coordinate")
 		c.Flags().Float64Var(&y, "y", 0, "pin Y coordinate")
-		c.Flags().StringVar(&kind, "kind", "", "flag kind: power, gnd, agnd, pgnd, netport (required)")
+		c.Flags().StringVar(&kind, "kind", "", netflagKindHelp)
 		c.Flags().StringVar(&net, "net", "", "net name (required)")
 		c.Flags().StringVar(&direction, "direction", "", "wire direction: up, down, left, right")
 		c.Flags().Float64Var(&offset, "offset", 0, "wire length in schematic units")

--- a/internal/app/cmd_sch_kind_test.go
+++ b/internal/app/cmd_sch_kind_test.go
@@ -1,0 +1,55 @@
+package app
+
+import "testing"
+
+// TestResolveNetflagKind locks the CLI shorthand→canonical mapping so the help
+// text and the connector's accepted enum can't drift apart again (issue #6).
+func TestResolveNetflagKind(t *testing.T) {
+	cases := map[string]string{
+		// shorthands → canonical connector enum
+		"gnd":     "ground",
+		"agnd":    "analog_ground",
+		"pgnd":    "protective_ground",
+		"netport": "net_port_bi",
+		// canonical names pass through unchanged
+		"power":             "power",
+		"ground":            "ground",
+		"analog_ground":     "analog_ground",
+		"protective_ground": "protective_ground",
+		"protect_ground":    "protect_ground",
+		"net_port_in":       "net_port_in",
+		"net_port_out":      "net_port_out",
+		"net_port_bi":       "net_port_bi",
+	}
+	for in, want := range cases {
+		got, err := resolveNetflagKind(in)
+		if err != nil {
+			t.Errorf("resolveNetflagKind(%q) unexpected error: %v", in, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("resolveNetflagKind(%q) = %q, want %q", in, got, want)
+		}
+	}
+
+	// Every value the resolver accepts must be a kind the connector actually
+	// supports (NET_FLAG_KINDS ∪ NET_PORT_KINDS in extension/src/actions.ts).
+	connectorAccepts := map[string]bool{
+		"power": true, "ground": true, "analog_ground": true,
+		"protective_ground": true, "protect_ground": true,
+		"net_port_in": true, "net_port_out": true, "net_port_bi": true,
+	}
+	for _, canonical := range netflagKindAliases {
+		if !connectorAccepts[canonical] {
+			t.Errorf("alias maps to %q which the connector does not accept", canonical)
+		}
+	}
+
+	// Unknown kinds get a friendly CLI error (not leaked to the connector).
+	if _, err := resolveNetflagKind("short"); err == nil {
+		t.Error("resolveNetflagKind(\"short\") expected an error, got nil")
+	}
+	if _, err := resolveNetflagKind("bogus"); err == nil {
+		t.Error("resolveNetflagKind(\"bogus\") expected an error, got nil")
+	}
+}


### PR DESCRIPTION
Fixes #6

## 问题
`easyeda sch connect/netflag --kind gnd` 报 `MISSING_PAYLOAD_FIELD: Unknown kind "gnd"`。CLI `--help` 列的简写枚举(`gnd/agnd/pgnd/netport/short`)与连接器 `connect_pin` 实际接受的枚举(`ground/analog_ground/protective_ground/net_port_*`)漂移,CLI 又把 `--kind` 原样透传不做翻译。

## 修复(CLI 层别名映射,符合「连接器是底层、CLI 面向人」分层)
- 新增 `resolveNetflagKind`(`internal/app/cmd_sch.go`):简写→canonical 映射(`gnd→ground`、`agnd→analog_ground`、`pgnd→protective_ground`、`netport→net_port_bi`),canonical 名(`power`/`ground`/`net_port_in/out/bi`…)原样透传 → `--kind gnd` 与 `--kind ground` 都能工作。
- 未知 `--kind` 在 CLI 层就给出列出全部合法值的友好报错,不再把 raw 连接器错误抛给用户。
- `netflag` 与 `connect` 两处 `RunE` 写 payload 前调用映射;两处 `--help` 改用单一真源常量 `netflagKindHelp`,避免再漂。
- 删除连接器根本不存在的 `short`(原 netflag help 里的误导项)。

## 测试
- 新增 `cmd_sch_kind_test.go`:锁定全部简写/canonical 映射,并断言每个映射目标都在连接器接受集合内(防再漂);未知值返回错误。
- `go test ./...` 全绿;`go vet ./internal/app` 无新增告警;`--help` 输出已核对,列出的每个 kind 均真实可用。

## 未测
连接器侧实际放置 flag 需要已连接的 EasyEDA 窗口(本环境无),但本改动纯属 CLI 层枚举翻译,canonical 值透传后行为与改动前 `--kind ground` 完全一致,连接器逻辑未触碰。