### PR TITLE
fix: sch drc 返回逐条 violation 明细 + fatal 门 (#7)

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -5,6 +5,21 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions
 follow [SemVer](https://semver.org/).
 
 ## [Unreleased]
+### Changed
+- **`schematic.drc.check` now returns per-violation detail (issue #7).** The handler
+  used to pass the SDK result straight through, so callers saw only the aggregate
+  `{count, type}` groups with no way to locate a violation. It now **normalizes** the
+  result: `flattenDrcNodes` walks any nested `list` containers (PCB-style) and the
+  flat aggregates (schematic) into per-violation leaves, each projected to
+  `{level, rule, message, primitiveIds, designators, x, y, raw}` (raw EDA object
+  preserved). The result is `{passed, fatal, summary:{fatal,error,warn,info,unknown,total},
+  violations, raw}` — `fatal` = error+fatal severities, the input the design-flow S5
+  gate ("0 fatal") needs. Also fixes a secondary bug: `includeVerboseError` is now
+  actually read (default true) instead of hardcoded, so the CLI flag is no longer
+  silently ignored. When the build returns only aggregate counts (no per-item
+  detail), each group is kept as a `count`-bearing leaf so the human view can still
+  say "warn × N".
+
 ### Added
 - **`schematic.snapshot` anti-stale metadata (issue #2).** The snapshot result now
   carries `primitiveCount` (live components + page primitives on the current page),

--- a/extension/README.md
+++ b/extension/README.md
@@ -177,7 +177,7 @@ handling is the daemon/skill's concern).
 | `schematic.library.search` | `lib_Device.search(query)` → first `limit` results (default 10), each mapped to `{libraryUuid, uuid, name, value, footprintName, lcsc, description}` |
 | `schematic.select` | `sch_SelectControl.doSelectPrimitives(primitiveIds)` then `getAllSelectedPrimitives_PrimitiveId()` |
 | `schematic.snapshot` | `dmt_EditorControl.getCurrentRenderedAreaImage(tabId?)` → Blob → artifact |
-| `schematic.drc.check` | `sch_Drc.check(strict, false, true)` → `{passed: arr.length===0, violations: arr}` |
+| `schematic.drc.check` | `sch_Drc.check(strict, false, includeVerboseError)` → normalized `{passed, fatal, summary, violations:[{level,rule,message,primitiveIds,designators,x,y,raw}]}` (per-violation, not aggregate) |
 | `schematic.save` | `sch_Document.save()` → `{saved}` |
 | `schematic.export.netlist` | `sch_ManufactureData.getNetlistFile(fileName?, netlistType?)` → File → artifact |
 | `schematic.export.bom` | `sch_ManufactureData.getBomFile(fileName?, fileType, template?, filterOptions?, statistics?, property?, columns?)` → File → artifact |
@@ -271,8 +271,16 @@ are also exported. Auto-connect preference is stored via
   schematic canvas units span `0.01 inch`. Unit interpretation/conversion is the
   daemon/skill's responsibility, not the connector's.
 - **DRC violation shape.** `sch_Drc.check(..., true)` returns `Array<any>` — the
-  SDK does not type the violation objects. They are passed through untouched as
-  `result.violations`; an empty array means DRC passed.
+  SDK does not type the violation objects, and the shape differs by domain
+  (schematic ships flat aggregates `[{count, type}]`; PCB nests
+  `[{name, list:[{name, list:[{errorType,…}]}]}]`). The handler **normalizes**
+  both: `flattenDrcNodes` walks any `list` containers into per-violation leaves and
+  projects each to `{level, rule, message, primitiveIds, designators, x, y}` while
+  keeping the original under `raw`. The field projection is best-effort over the
+  untyped shape — **verify the real per-item fields against a connected window**
+  (run `easyeda sch drc --json` on a board with known violations) and widen the key
+  lists in `flattenDrcNodes` if a build names them differently. An empty
+  `violations` array (and `passed:true`) means DRC passed.
 - **`easyedaVersion`** is read from `eda.sys_Environment.getEditorCurrentVersion()`
   (best-effort; falls back to `""`).
 - **`eda.sch_PrimitiveComponent` is a union type** (`SCH_PrimitiveComponent |

--- a/extension/src/actions.ts
+++ b/extension/src/actions.ts
@@ -908,18 +908,199 @@ const schematicSnapshot: Handler = async (payload) => {
 
 // ─── DRC ──────────────────────────────────────────────────────────────
 
+// DRC severity buckets. `fatal`/`error` are the must-fix class the design-flow
+// S5 gate counts ("0 fatal"); `warn`/`info` are tolerable. `unknown` is the
+// fallback when the SDK string doesn't classify.
+type DrcSeverity = 'fatal' | 'error' | 'warn' | 'info' | 'unknown';
+
+// One normalized violation. Keeps the EDA raw object under `raw` so nothing is
+// lost; the typed fields are a best-effort projection across the shapes the SDK
+// returns (flat `{count,type}` aggregates AND PCB-style nested `{name,list:[…]}`).
+interface DrcViolation {
+	level: DrcSeverity;
+	type?: string;
+	rule?: string;
+	message?: string;
+	primitiveIds?: Array<string>;
+	designators?: Array<string>;
+	x?: number;
+	y?: number;
+	count?: number; // present when the SDK only gave an aggregate count, no per-item detail
+	raw: unknown;
+}
+
+interface DrcSummary {
+	fatal: number;
+	error: number;
+	warn: number;
+	info: number;
+	unknown: number;
+	total: number;
+}
+
+/** Map an arbitrary SDK severity string to a DrcSeverity bucket. */
+function classifyDrcSeverity(raw: unknown): DrcSeverity {
+	const s = String(raw ?? '').toLowerCase();
+	if (s.includes('fatal')) return 'fatal';
+	if (s.includes('error') || s === 'err') return 'error';
+	if (s.includes('warn')) return 'warn';
+	if (s.includes('info') || s.includes('note') || s.includes('tip')) return 'info';
+	return 'unknown';
+}
+
+function firstString(obj: Record<string, unknown>, keys: Array<string>): string | undefined {
+	for (const k of keys) {
+		const v = obj[k];
+		if (typeof v === 'string' && v.length > 0) return v;
+		if (typeof v === 'number' && Number.isFinite(v)) return String(v);
+	}
+	return undefined;
+}
+
+function firstNumber(obj: Record<string, unknown>, keys: Array<string>): number | undefined {
+	for (const k of keys) {
+		const v = obj[k];
+		if (typeof v === 'number' && Number.isFinite(v)) return v;
+	}
+	return undefined;
+}
+
+/** Collect id-like / designator-like fields into a string array. */
+function collectStrings(obj: Record<string, unknown>, keys: Array<string>): Array<string> | undefined {
+	const out: Array<string> = [];
+	for (const k of keys) {
+		const v = obj[k];
+		if (typeof v === 'string' && v.length > 0) out.push(v);
+		else if (Array.isArray(v)) {
+			for (const e of v) {
+				if (typeof e === 'string' && e.length > 0) out.push(e);
+				else if (e && typeof e === 'object') {
+					const id = firstString(e as Record<string, unknown>, ['primitiveId', 'id', 'designator', 'name']);
+					if (id) out.push(id);
+				}
+			}
+		}
+	}
+	return out.length > 0 ? out : undefined;
+}
+
+/**
+ * Flatten whatever `sch_Drc.check` returns into per-violation leaves. The SDK is
+ * untyped here and ships at least two shapes: schematic returns flat aggregates
+ * `[{count, type}]` while PCB nests `[{name, list:[{name, list:[{errorType,…}]}]}]`.
+ * This walks any `list` containers recursively, inheriting group type/rule, and
+ * emits a leaf per terminal node — so we expand detail when the build provides it
+ * and degrade to a per-group aggregate (with `count`) when it doesn't.
+ */
+function flattenDrcNodes(
+	node: unknown,
+	inherited: { type?: string; rule?: string },
+	out: Array<DrcViolation>,
+): void {
+	if (Array.isArray(node)) {
+		for (const n of node) flattenDrcNodes(n, inherited, out);
+		return;
+	}
+	if (node == null || typeof node !== 'object') return;
+	const obj = node as Record<string, unknown>;
+
+	const type = firstString(obj, ['type', 'level', 'severity', 'errorType']) ?? inherited.type;
+	const rule = firstString(obj, ['rule', 'ruleName', 'title', 'name', 'errorType']) ?? inherited.rule;
+
+	// Container node: recurse into nested violations, carrying group context down.
+	const list = obj.list;
+	if (Array.isArray(list) && list.length > 0) {
+		flattenDrcNodes(list, { type, rule }, out);
+		return;
+	}
+
+	// Leaf node — project the known fields, keep the raw object intact.
+	const message = firstString(obj, ['message', 'text', 'desc', 'description', 'detail', 'info', 'tip']);
+	const primitiveIds = collectStrings(obj, ['primitiveIds', 'primitiveId', 'objs', 'obj1', 'obj2', 'ids']);
+	const designators = collectStrings(obj, ['designators', 'designator', 'components']);
+	const x = firstNumber(obj, ['x', 'posX']);
+	const y = firstNumber(obj, ['y', 'posY']);
+	const count = firstNumber(obj, ['count']);
+
+	out.push({
+		level: classifyDrcSeverity(type),
+		type,
+		rule,
+		message,
+		primitiveIds,
+		designators,
+		x,
+		y,
+		// Only surface `count` when this leaf is an aggregate-only node (no per-item
+		// detail) so the human view can still say "warn × N" without faking coords.
+		count: count !== undefined && message === undefined && x === undefined ? count : undefined,
+		raw: node,
+	});
+}
+
+/** Normalize a raw DRC result array into `{passed, fatal, summary, violations}`. */
+function normalizeDrc(violations: Array<unknown>): {
+	passed: boolean;
+	fatal: number;
+	summary: DrcSummary;
+	violations: Array<DrcViolation>;
+	raw: Array<unknown>;
+} {
+	const leaves: Array<DrcViolation> = [];
+	flattenDrcNodes(violations, {}, leaves);
+
+	const summary: DrcSummary = { fatal: 0, error: 0, warn: 0, info: 0, unknown: 0, total: 0 };
+	for (const v of leaves) {
+		const n = v.count !== undefined && v.count > 0 ? v.count : 1;
+		summary[v.level] += n;
+		summary.total += n;
+	}
+	// `fatal` (the S5 gate input) = the must-fix class: fatal + error severities.
+	const fatal = summary.fatal + summary.error;
+	return { passed: leaves.length === 0, fatal, summary, violations: leaves, raw: violations };
+}
+
 const schematicDrcCheck: Handler = async (payload) => {
 	const strict = optionalBoolean(payload, 'strict') !== false;
+	// `includeVerboseError` selects the SDK overload: the literal `true` overload
+	// returns the violations array (what we normalize); the literal `false` one
+	// returns a bare boolean. Default true so we always get detail — and ACTUALLY
+	// read the payload field (it used to be hardcoded `true`, so the CLI flag was
+	// silently ignored). The overloads demand a literal arg, hence two branches.
+	// issue #7
+	const includeVerbose = optionalBoolean(payload, 'includeVerboseError') !== false;
+	if (!includeVerbose) {
+		// Non-verbose overload: a bare boolean with no per-item detail. Returned
+		// verbatim as `passed` (raw debug callers only — the CLI always asks for
+		// the verbose/array form).
+		let ok: boolean;
+		try {
+			ok = await eda.sch_Drc.check(strict, false, false);
+		}
+		catch (err) {
+			throw edaError(err, 'Failed to run DRC.');
+		}
+		return {
+			result: {
+				passed: ok,
+				fatal: 0,
+				summary: { fatal: 0, error: 0, warn: 0, info: 0, unknown: 0, total: 0 },
+				violations: [],
+				raw: ok,
+			},
+		};
+	}
 	let violations: Array<unknown>;
 	try {
-		// `includeVerboseError: true` selects the verbose overload that returns
-		// an array; the violation shape is untyped (`any`) by the SDK.
 		violations = await eda.sch_Drc.check(strict, false, true);
 	}
 	catch (err) {
 		throw edaError(err, 'Failed to run DRC.');
 	}
-	return { result: { passed: violations.length === 0, violations } };
+	// Normalize: expand each violation to {level, rule, message, ids, x, y} +
+	// a severity summary so callers can locate issues and gate on fatal count,
+	// instead of seeing only the SDK's aggregate `{count, type}` groups. issue #7
+	return { result: normalizeDrc(violations) };
 };
 
 // ─── Save ─────────────────────────────────────────────────────────────

--- a/internal/app/cmd_sch.go
+++ b/internal/app/cmd_sch.go
@@ -565,29 +565,33 @@ by the screenshot. Touch the page in EasyEDA (scroll/click) to force a redraw.`,
 	// ── drc ───────────────────────────────────────────────────────────────
 	// schematic.drc.check
 	{
-		var strict, verbose bool
+		var strict, verbose, asJSON bool
 		c := &cobra.Command{
 			Use:   "drc",
-			Short: "Run schematic DRC and return normalized violations",
-			Args:  cobra.NoArgs,
+			Short: "Run schematic DRC and print per-violation detail (rule/message/coords)",
+			Long: `Run schematic DRC and print each violation, not just an aggregate count.
+
+The connector normalizes the EDA result into per-violation records — each with a
+severity level, rule, message, related primitive/designator ids, and (when the
+build provides it) x/y coordinates — plus a severity summary. The human view
+prints one line per violation (LEVEL <rule> <message> @(x,y)), mirroring
+layout-lint; --json emits the structured report.
+
+Exit code: non-zero ONLY when the fatal count (error + fatal severities) is > 0.
+Warnings alone exit 0, so the design-flow S5 gate can demand "0 fatal" while
+still surfacing warnings for review.`,
+			Args: cobra.NoArgs,
 			Example: `  easyeda sch drc
-  easyeda sch drc --strict --verbose`,
+  easyeda sch drc --strict          # treat warnings as errors (SDK strict mode)
+  easyeda sch drc --json            # structured per-violation output
+  easyeda sch drc --verbose         # also dump each violation's raw EDA object`,
 			RunE: func(cmd *cobra.Command, args []string) error {
-				payload := map[string]any{}
-				if strict {
-					payload["strict"] = true
-				}
-				if verbose {
-					payload["includeVerboseError"] = true
-				}
-				if len(payload) == 0 {
-					return dispatch(cfg, "schematic.drc.check", window, nil, stdout, stderr)
-				}
-				return dispatch(cfg, "schematic.drc.check", window, payload, stdout, stderr)
+				return runSchDrc(cfg, window, strict, verbose, asJSON, stdout, stderr)
 			},
 		}
-		c.Flags().BoolVar(&strict, "strict", false, "treat warnings as errors")
-		c.Flags().BoolVar(&verbose, "verbose", false, "include verbose error details")
+		c.Flags().BoolVar(&strict, "strict", false, "treat warnings as errors (SDK strict mode)")
+		c.Flags().BoolVar(&verbose, "verbose", false, "also print each violation's raw EDA object")
+		c.Flags().BoolVar(&asJSON, "json", false, "emit the normalized report as JSON")
 		sch.AddCommand(c)
 	}
 

--- a/internal/app/cmd_sch_drc.go
+++ b/internal/app/cmd_sch_drc.go
@@ -1,0 +1,172 @@
+package app
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// ── sch drc: electrical rule check with per-violation detail ────────────────
+//
+// The connector normalizes `sch_Drc.check` into per-violation leaves plus a
+// severity summary (see extension/src/actions.ts normalizeDrc). This file is the
+// human/JSON view over that shape: it prints each violation as
+// `LEVEL <rule> <message> @(x,y)` (mirroring layout-lint) and exits non-zero
+// only when the fatal (error/fatal) count is > 0 — so the design-flow S5 gate
+// can demand "0 fatal" while tolerating warnings. issue #7
+
+// drcViolation mirrors one normalized violation from the connector.
+type drcViolation struct {
+	Level        string   `json:"level"`
+	Type         string   `json:"type,omitempty"`
+	Rule         string   `json:"rule,omitempty"`
+	Message      string   `json:"message,omitempty"`
+	PrimitiveIDs []string        `json:"primitiveIds,omitempty"`
+	Designators  []string        `json:"designators,omitempty"`
+	X            *float64        `json:"x,omitempty"`
+	Y            *float64        `json:"y,omitempty"`
+	Count        *int            `json:"count,omitempty"`
+	Raw          json.RawMessage `json:"raw,omitempty"`
+}
+
+// drcSummary mirrors the connector's severity tally.
+type drcSummary struct {
+	Fatal   int `json:"fatal"`
+	Error   int `json:"error"`
+	Warn    int `json:"warn"`
+	Info    int `json:"info"`
+	Unknown int `json:"unknown"`
+	Total   int `json:"total"`
+}
+
+// drcReport is the normalized DRC result the connector returns.
+type drcReport struct {
+	Passed     bool           `json:"passed"`
+	Fatal      int            `json:"fatal"`
+	Summary    drcSummary     `json:"summary"`
+	Violations []drcViolation `json:"violations"`
+}
+
+// runSchDrc runs schematic DRC, renders the normalized violations, and returns a
+// non-nil error (non-zero exit) only when the fatal count is > 0.
+func runSchDrc(cfg *appConfig, window string, strict, verbose, asJSON bool, stdout, stderr io.Writer) error {
+	payload := map[string]any{
+		// Always request the verbose/array overload — it's what yields per-item
+		// detail. The connector reads this field (no longer hardcoded). issue #7
+		"includeVerboseError": true,
+	}
+	if strict {
+		payload["strict"] = true
+	}
+
+	res, err := requestAction(cfg, "schematic.drc.check", window, payload)
+	if err != nil {
+		return err
+	}
+
+	rep, perr := parseDrcReport(res.Result)
+	if perr != nil {
+		// Fall back to streaming the raw result so the user still sees something
+		// useful if the shape is unexpected.
+		if b, mErr := json.MarshalIndent(res.Result, "", "  "); mErr == nil {
+			_, _ = stdout.Write(b)
+			fmt.Fprintln(stdout)
+		}
+		return perr
+	}
+
+	if asJSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(rep); err != nil {
+			return err
+		}
+	} else {
+		renderDrcReport(rep, verbose, stdout)
+	}
+
+	if rep.Fatal > 0 {
+		return fmt.Errorf("sch drc: %d fatal violation(s)", rep.Fatal)
+	}
+	return nil
+}
+
+// parseDrcReport re-marshals the generic result map into the typed drcReport.
+func parseDrcReport(result map[string]any) (drcReport, error) {
+	var rep drcReport
+	if result == nil {
+		return rep, fmt.Errorf("empty DRC result")
+	}
+	b, err := json.Marshal(result)
+	if err != nil {
+		return rep, err
+	}
+	if err := json.Unmarshal(b, &rep); err != nil {
+		return rep, fmt.Errorf("unexpected DRC result shape: %w", err)
+	}
+	return rep, nil
+}
+
+// drcLevelTag maps a severity to the left-column tag used in the human view.
+func drcLevelTag(level string) string {
+	switch strings.ToLower(level) {
+	case "fatal":
+		return "FATAL"
+	case "error":
+		return "ERROR"
+	case "warn":
+		return "WARN"
+	case "info":
+		return "INFO"
+	default:
+		return "?????"
+	}
+}
+
+// renderDrcReport prints a compact, per-violation human summary.
+func renderDrcReport(rep drcReport, verbose bool, w io.Writer) {
+	s := rep.Summary
+	fmt.Fprintf(w, "sch drc: %d violation(s) — %d fatal, %d error, %d warn, %d info\n",
+		s.Total, s.Fatal, s.Error, s.Warn, s.Info)
+
+	for _, v := range rep.Violations {
+		tag := drcLevelTag(v.Level)
+		rule := v.Rule
+		if rule == "" {
+			rule = v.Type
+		}
+		if rule == "" {
+			rule = "-"
+		}
+		msg := v.Message
+		if msg == "" && v.Count != nil {
+			// Aggregate-only node: the build gave a count but no per-item detail.
+			msg = fmt.Sprintf("%d issue(s) — EDA returned no per-item detail", *v.Count)
+		}
+		line := fmt.Sprintf("  %-5s  %s  %s", tag, rule, msg)
+		if v.X != nil && v.Y != nil {
+			line += fmt.Sprintf("  @(%.2f,%.2f)", *v.X, *v.Y)
+		}
+		if refs := append(append([]string{}, v.Designators...), v.PrimitiveIDs...); len(refs) > 0 {
+			line += "  [" + strings.Join(refs, ",") + "]"
+		}
+		fmt.Fprintln(w, line)
+	}
+
+	if verbose {
+		for _, v := range rep.Violations {
+			if len(v.Raw) > 0 {
+				fmt.Fprintf(w, "    raw: %s\n", string(v.Raw))
+			}
+		}
+	}
+
+	if rep.Passed {
+		fmt.Fprintln(w, "✓ DRC clean — no violations")
+	} else if rep.Fatal == 0 {
+		fmt.Fprintf(w, "✓ 0 fatal, %d warning(s) — gate passes (warnings should still be reviewed)\n", s.Warn+s.Info+s.Unknown)
+	} else {
+		fmt.Fprintf(w, "✗ %d fatal violation(s) — must be fixed before the S5 gate passes\n", rep.Fatal)
+	}
+}

--- a/internal/app/cmd_sch_drc_test.go
+++ b/internal/app/cmd_sch_drc_test.go
@@ -1,0 +1,81 @@
+package app
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// The connector-normalized aggregate shape (blink case): 3 warnings, no detail.
+func TestParseDrcReport_Aggregate(t *testing.T) {
+	result := map[string]any{
+		"passed": false,
+		"fatal":  float64(0),
+		"summary": map[string]any{
+			"fatal": float64(0), "error": float64(0), "warn": float64(3),
+			"info": float64(0), "unknown": float64(0), "total": float64(3),
+		},
+		"violations": []any{
+			map[string]any{"level": "warn", "type": "warn", "count": float64(3)},
+		},
+	}
+	rep, err := parseDrcReport(result)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if rep.Passed {
+		t.Error("expected passed=false")
+	}
+	if rep.Fatal != 0 {
+		t.Errorf("expected fatal=0, got %d", rep.Fatal)
+	}
+	if rep.Summary.Warn != 3 || rep.Summary.Total != 3 {
+		t.Errorf("expected 3 warn/total, got %+v", rep.Summary)
+	}
+}
+
+// A fully-detailed, fatal-bearing shape: human view must show rule+message+coords
+// and the fatal count must drive a non-zero exit.
+func TestRenderAndExit_FatalDetail(t *testing.T) {
+	x, y := 100.0, 200.0
+	rep := drcReport{
+		Passed: false,
+		Fatal:  1,
+		Summary: drcSummary{
+			Error: 1, Warn: 1, Total: 2,
+		},
+		Violations: []drcViolation{
+			{Level: "error", Rule: "endpoints-overlap", Message: "端点重叠且未连接", X: &x, Y: &y, Designators: []string{"U1"}},
+			{Level: "warn", Rule: "floating-io", Message: "IO 悬空"},
+		},
+	}
+	var buf bytes.Buffer
+	renderDrcReport(rep, false, &buf)
+	out := buf.String()
+	for _, want := range []string{"ERROR", "endpoints-overlap", "端点重叠且未连接", "@(100.00,200.00)", "[U1]", "WARN", "floating-io", "✗ 1 fatal"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("render missing %q\n--- output ---\n%s", want, out)
+		}
+	}
+}
+
+// Warnings-only must render as a passing gate (the S5 "0 fatal" semantic).
+func TestRenderWarnOnlyGatePasses(t *testing.T) {
+	rep := drcReport{
+		Passed:     false,
+		Fatal:      0,
+		Summary:    drcSummary{Warn: 3, Total: 3},
+		Violations: []drcViolation{{Level: "warn", Count: intp(3)}},
+	}
+	var buf bytes.Buffer
+	renderDrcReport(rep, false, &buf)
+	out := buf.String()
+	if !strings.Contains(out, "0 fatal") || !strings.Contains(out, "gate passes") {
+		t.Errorf("expected warn-only gate-pass line, got:\n%s", out)
+	}
+	if !strings.Contains(out, "no per-item detail") {
+		t.Errorf("aggregate-only node should explain the missing detail, got:\n%s", out)
+	}
+}
+
+func intp(n int) *int { return &n }

--- a/internal/protocol/actions.go
+++ b/internal/protocol/actions.go
@@ -311,9 +311,9 @@ func AllActions() []ActionSpec {
 			Domain:      DomainSchematic,
 			Phase:       1,
 			NeedsWindow: true,
-			Description: "Run schematic DRC and normalize the result.",
+			Description: "Run schematic DRC and normalize the result into per-violation detail. Each violation carries {level, rule, message, primitiveIds, designators, x, y} (best-effort projection over the SDK shape, raw kept) plus a severity `summary` and a `fatal` count (error+fatal severities) for the design-flow S5 gate. `includeVerboseError` (default true) selects the detailed/array SDK overload.",
 			Inputs:      []string{"strict", "includeVerboseError"},
-			Outputs:     []string{"passed", "violations"},
+			Outputs:     []string{"passed", "fatal", "summary", "violations"},
 		},
 		{
 			Name:        "schematic.save",

--- a/skills/easyeda-design-flow/SKILL.md
+++ b/skills/easyeda-design-flow/SKILL.md
@@ -61,7 +61,8 @@ S0 预分析 → S1 分页💾 → S2 模块编组 → S3 按组摆放💾 → S
    - **任何 `overlap` ERROR = 必须修**(命令非零退出,可直接当 gate)。
    - `spacing` WARN = 评估是否太挤,外围贴芯片可接受、模块间过近要拉开。
 2. **电气门** `easyeda sch drc`(+ `scripts/lint.sh <project>` 数据 lint)
-   - fatal / 未连接网络 = 必须修。
+   - **逐条**输出 `LEVEL <rule> <message> @(x,y)`;命令**仅在 `fatal>0`(error/fatal)时非零退出**,可直接当 gate(`0 fatal` = 过门)。
+   - fatal / 未连接网络 = 必须修;`summary.warn` 警告(如未用 IO 悬空)逐条复核、可接受则放行。
 - ⚠️ **判状态看数据(`sch list` / layout-lint / drc),不看截图**(API 改动后画布可能不重绘 → 截图 stale)。
 
 ### S6 — 调整闭环(立刻调,再验)

--- a/skills/easyeda-schematic/SKILL.md
+++ b/skills/easyeda-schematic/SKILL.md
@@ -151,7 +151,7 @@ easyeda doc switch <P2|PCB1|uuid> --project <名字>   # 切换:按页名/PCB名
 - `schematic.power.connect_pin`
 - `schematic.select`
 - `schematic.snapshot` — 截图。**产物保存在 CLI 运行目录下的隐藏目录 `<cwd>/.easyeda/artifacts/`,文件名带本地时间戳**(`<YYYYMMDD-HHMMSS>-<kind>-<短id>.png`,便于排序/查找);响应里的 `artifacts[].path` 是绝对路径。netlist/BOM 等其他产物同此规则。
-- `schematic.drc.check`
+- `schematic.drc.check` — 用 `easyeda sch drc` 跑，**逐条**打印 `LEVEL <rule> <message> @(x,y)`(`--json` 给结构化)。返回含 `summary{fatal,error,warn,…}` 与 `fatal` 计数;**退出码仅在 `fatal>0` 时非零**(warning 不阻塞),据此判 S5 门「0 fatal」。
 - `schematic.save`
 - `schematic.export.netlist`
 - `schematic.export.bom`

--- a/skills/easyeda-schematic/references/actions.md
+++ b/skills/easyeda-schematic/references/actions.md
@@ -53,7 +53,7 @@ Run `easyeda actions` for the authoritative machine-readable list.
 
 ## Verify & Export
 
-- `schematic.drc.check` — 运行 DRC，返回 passed + violations
+- `schematic.drc.check` — 运行 DRC，返回**逐条** violation（`{level, rule, message, primitiveIds, designators, x, y}`）+ 严重度 `summary` + `fatal` 计数（error+fatal）。CLI 推荐 `easyeda sch drc`（人类逐条视图 `LEVEL <rule> <message> @(x,y)`）或 `--json`（结构化）；**退出码仅在 `fatal>0` 时非零**，warning 不阻塞 → 供 design-flow S5 门「0 fatal」判定。
 - `schematic.export.netlist` — 导出网表为 artifact
 - `schematic.export.bom` — 导出 BOM（csv 或 xlsx）为 artifact
 


### PR DESCRIPTION
Fixes #7

## 问题
`schematic.drc.check` 连接器 handler 把 `eda.sch_Drc.check(strict,false,true)` 的返回**原样透传**,调用方只看到 SDK 的聚合分组 `{"violations":[{"count":3,"type":"warn"}]}`——没有逐条 violation 的 rule / message / 坐标 / 关联器件,无法定位。旁支 bug:CLI `--verbose` 写入 `includeVerboseError`,但 handler 第三参恒 `true`、从不读它,flag 形同虚设。

## 改动
**连接器 `extension/src/actions.ts`**
- 新增 `normalizeDrc` + `flattenDrcNodes`:递归展平嵌套 `list`(PCB 形状)与扁平聚合(原理图)为逐条 violation,每条投影为 `{level, rule, message, primitiveIds, designators, x, y, raw}`(保留 EDA 原始对象)。
- 返回 `{passed, fatal, summary:{fatal,error,warn,info,unknown,total}, violations, raw}`;`fatal` = error+fatal 严重度,供 S5 门「0 fatal」判定。
- 真正读取 `includeVerboseError`(默认 true,保留 array 重载),修掉 `--verbose` 被忽略。
- 聚合-only 节点(只有 count、无明细)保留为带 `count` 的 leaf,人类视图仍能说「warn × N」。

**CLI `internal/app/cmd_sch_drc.go`(新增)+ `cmd_sch.go`**
- `easyeda sch drc` 逐条人类视图 `LEVEL <rule> <message> @(x,y)`(仿 `layout-lint`),新增 `--json` 结构化、`--verbose` 打印 raw。
- **退出码仅在 `fatal>0` 时非零**,warning 不阻塞 → design-flow S5 门可要求「0 fatal」同时保留警告复核。

**文档同步**:`protocol/actions.go` catalog、`extension/README.md`+`CHANGELOG.md`、`easyeda-schematic` SKILL/actions.md、`easyeda-design-flow` S5 门。

## 测试
- `go build ./...` / `go test ./...` 全绿;新增 `cmd_sch_drc_test.go` 覆盖聚合形状解析、fatal 明细渲染+退出、warn-only 过门。
- `extension` `npm run typecheck` 通过(SDK 重载要求字面量第三参,故拆 verbose/非 verbose 两分支)。

## 未测/待校准 ⚠️
字段投影对**未类型化**的 SDK 返回是 best-effort。**逐条明细的真实字段名需在已连接 EasyEDA 窗口实测确认**:跑 blink 用例 → `easyeda sch drc --json`,若某 build 字段命名不同,在 `flattenDrcNodes` 的 key 列表里补上即可。本环境无已连接窗口/硬件,未做运行时联调。