### PR TITLE
fix: sch layout-lint ignores sheet/title-frame & non-part primitives

### DIFF
--- a/internal/app/cmd_sch.go
+++ b/internal/app/cmd_sch.go
@@ -754,7 +754,7 @@ exits non-zero when there are any findings, to use it as a gate.`,
 	// eyeballed. Exits non-zero when overlaps exist → usable as a gate.
 	{
 		var minGap float64
-		var asJSON, allPages bool
+		var asJSON, allPages, includeNonParts bool
 		c := &cobra.Command{
 			Use:   "layout-lint",
 			Short: "Check component placement for bbox overlaps and tight spacing",
@@ -766,6 +766,12 @@ and runs two pairwise checks in Go:
   • overlap  — two component bounding boxes intersect            → ERROR
   • spacing  — bbox gap is below --min-gap (default 2.54mm)      → WARN
 
+Only real parts (componentType "part") are checked by default. The drawing
+sheet / title block (图框) spans the whole page, so including it would false-flag
+an overlap against nearly every component; netflag/netport/netlabel and other
+non-part primitives are likewise excluded. Pass --include-non-parts to score them
+too (e.g. to inspect the sheet bbox).
+
 This is the mechanical ground truth for the place→verify→adjust loop: run it
 after each placement stage, fix every ERROR (move/align/distribute), then re-run.
 Exits non-zero when any overlap is found, so it can gate a workflow.`,
@@ -774,12 +780,13 @@ Exits non-zero when any overlap is found, so it can gate a workflow.`,
   easyeda sch layout-lint --min-gap 5.08
   easyeda sch layout-lint --all-pages --json`,
 			RunE: func(cmd *cobra.Command, args []string) error {
-				return runLayoutLint(cfg, window, minGap, allPages, asJSON, stdout, stderr)
+				return runLayoutLint(cfg, window, minGap, allPages, asJSON, includeNonParts, stdout, stderr)
 			},
 		}
 		c.Flags().Float64Var(&minGap, "min-gap", 2.54, "minimum gap between component bboxes in mm (closer = WARN)")
 		c.Flags().BoolVar(&asJSON, "json", false, "emit the report as JSON")
 		c.Flags().BoolVar(&allPages, "all-pages", false, "lint components across all schematic pages")
+		c.Flags().BoolVar(&includeNonParts, "include-non-parts", false, "also lint non-part primitives (sheet/title-frame, netflag/netport/…); excluded by default")
 		sch.AddCommand(c)
 	}
 

--- a/internal/app/cmd_sch_layout.go
+++ b/internal/app/cmd_sch_layout.go
@@ -27,9 +27,37 @@ type layoutBBox struct {
 
 // layoutComp is the minimal per-component shape layout-lint reasons about.
 type layoutComp struct {
-	ID         string
-	Designator string
-	BBox       *layoutBBox
+	ID            string
+	Designator    string
+	ComponentType string // "part" | "sheet" | "netflag" | "netport" | … (from the connector)
+	BBox          *layoutBBox
+}
+
+// schLayoutPartType is the componentType of a real placed device. Only these
+// participate in placement geometry by default. The drawing sheet / title block
+// (componentType "sheet") spans the whole page, so including it false-flags an
+// overlap against nearly every component; the various flag/label/port primitives
+// (netflag/netport/netlabel/…) are likewise not physical parts. See issue #13.
+const schLayoutPartType = "part"
+
+// filterLayoutComps keeps only real parts unless includeNonParts is set. It
+// returns the kept slice plus the count of excluded non-part primitives (sheet,
+// netflag, netport, …) so the report can disclose what was skipped. Components
+// with an empty componentType are KEPT — an older connector build that doesn't
+// emit the field must not have every component silently dropped.
+func filterLayoutComps(comps []layoutComp, includeNonParts bool) (kept []layoutComp, skipped int) {
+	if includeNonParts {
+		return comps, 0
+	}
+	kept = make([]layoutComp, 0, len(comps))
+	for _, c := range comps {
+		if c.ComponentType == "" || c.ComponentType == schLayoutPartType {
+			kept = append(kept, c)
+			continue
+		}
+		skipped++
+	}
+	return kept, skipped
 }
 
 // layoutFinding is one pairwise issue (overlap or tight spacing).
@@ -44,14 +72,15 @@ type layoutFinding struct {
 
 // layoutReport is the full normalized result of a layout-lint run.
 type layoutReport struct {
-	OK         bool            `json:"ok"`
-	MinGap     float64         `json:"minGap"`
-	Total      int             `json:"componentCount"`
-	WithBBox   int             `json:"withBBox"`
-	NoBBox     []string        `json:"noBBox,omitempty"`
-	Overlaps   []layoutFinding `json:"overlaps"`
-	TightPairs []layoutFinding `json:"tightSpacing"`
-	Summary    string          `json:"summary"`
+	OK              bool            `json:"ok"`
+	MinGap          float64         `json:"minGap"`
+	Total           int             `json:"componentCount"`
+	WithBBox        int             `json:"withBBox"`
+	SkippedNonParts int             `json:"skippedNonParts,omitempty"`
+	NoBBox          []string        `json:"noBBox,omitempty"`
+	Overlaps        []layoutFinding `json:"overlaps"`
+	TightPairs      []layoutFinding `json:"tightSpacing"`
+	Summary         string          `json:"summary"`
 }
 
 // analyzeLayout is the pure core: given components and a min-gap threshold,
@@ -144,7 +173,7 @@ func sortFindings(f []layoutFinding) {
 
 // runLayoutLint fetches components with bbox, analyzes, renders, and returns a
 // non-nil error when overlaps exist so the command exits non-zero (gate-able).
-func runLayoutLint(cfg *appConfig, window string, minGap float64, allPages, asJSON bool, stdout, stderr io.Writer) error {
+func runLayoutLint(cfg *appConfig, window string, minGap float64, allPages, asJSON, includeNonParts bool, stdout, stderr io.Writer) error {
 	payload := map[string]any{"includeBBox": true}
 	if allPages {
 		payload["allPages"] = true
@@ -158,7 +187,9 @@ func runLayoutLint(cfg *appConfig, window string, minGap float64, allPages, asJS
 	if perr != nil {
 		return perr
 	}
-	rep := analyzeLayout(comps, minGap)
+	parts, skipped := filterLayoutComps(comps, includeNonParts)
+	rep := analyzeLayout(parts, minGap)
+	rep.SkippedNonParts = skipped
 
 	if asJSON {
 		enc := json.NewEncoder(stdout)
@@ -190,8 +221,9 @@ func parseLayoutComps(result map[string]any) ([]layoutComp, error) {
 			continue
 		}
 		c := layoutComp{
-			ID:         asString(m["primitiveId"]),
-			Designator: asString(m["designator"]),
+			ID:            asString(m["primitiveId"]),
+			Designator:    asString(m["designator"]),
+			ComponentType: asString(m["componentType"]),
 		}
 		if bm, ok := m["bbox"].(map[string]any); ok {
 			c.BBox = &layoutBBox{
@@ -232,6 +264,9 @@ func renderLayoutReport(rep layoutReport, w io.Writer) {
 	}
 	for _, f := range rep.TightPairs {
 		fmt.Fprintf(w, "  WARN   spacing  %s ↔ %s   (gap %.2fmm < %.2fmm)\n", f.A, f.B, f.Gap, rep.MinGap)
+	}
+	if rep.SkippedNonParts > 0 {
+		fmt.Fprintf(w, "  note: %d non-part primitive(s) excluded (sheet/title-frame, netflag/netport/…); pass --include-non-parts to include\n", rep.SkippedNonParts)
 	}
 	if len(rep.NoBBox) > 0 {
 		fmt.Fprintf(w, "  note: %d component(s) had no bbox (skipped): %v\n", len(rep.NoBBox), rep.NoBBox)

--- a/internal/app/cmd_sch_layout_test.go
+++ b/internal/app/cmd_sch_layout_test.go
@@ -88,6 +88,70 @@ func TestAnalyzeLayout_UnassignedDesignatorFallsBackToID(t *testing.T) {
 	}
 }
 
+func TestFilterLayoutComps_ExcludesNonPartsByDefault(t *testing.T) {
+	comps := []layoutComp{
+		{Designator: "R1", ComponentType: "part", BBox: bb(0, 0, 10, 10)},
+		{Designator: "SHEET", ComponentType: "sheet", BBox: bb(-100, -100, 400, 300)}, // full-page frame
+		{ID: "nf1", ComponentType: "netflag", BBox: bb(0, 0, 2, 2)},
+		{Designator: "C2", ComponentType: "part", BBox: bb(20, 0, 30, 10)},
+	}
+	kept, skipped := filterLayoutComps(comps, false)
+	if len(kept) != 2 {
+		t.Fatalf("expected 2 parts kept, got %d", len(kept))
+	}
+	if skipped != 2 {
+		t.Fatalf("expected 2 non-parts skipped, got %d", skipped)
+	}
+	for _, c := range kept {
+		if c.ComponentType != "part" {
+			t.Errorf("non-part leaked through: %+v", c)
+		}
+	}
+}
+
+func TestFilterLayoutComps_IncludeNonPartsKeepsAll(t *testing.T) {
+	comps := []layoutComp{
+		{Designator: "R1", ComponentType: "part", BBox: bb(0, 0, 10, 10)},
+		{Designator: "SHEET", ComponentType: "sheet", BBox: bb(-100, -100, 400, 300)},
+	}
+	kept, skipped := filterLayoutComps(comps, true)
+	if len(kept) != 2 || skipped != 0 {
+		t.Fatalf("include-non-parts must keep all, got kept=%d skipped=%d", len(kept), skipped)
+	}
+}
+
+func TestFilterLayoutComps_EmptyTypeKept(t *testing.T) {
+	// An older connector that doesn't emit componentType must not have every
+	// component silently dropped.
+	comps := []layoutComp{
+		{Designator: "R1", BBox: bb(0, 0, 10, 10)},
+		{Designator: "C2", BBox: bb(20, 0, 30, 10)},
+	}
+	kept, skipped := filterLayoutComps(comps, false)
+	if len(kept) != 2 || skipped != 0 {
+		t.Fatalf("empty componentType must be kept, got kept=%d skipped=%d", len(kept), skipped)
+	}
+}
+
+func TestFilterLayoutComps_SheetNoLongerFalseOverlaps(t *testing.T) {
+	// Regression for issue #13: a full-page sheet bbox overlaps every real part.
+	// After filtering, the analysis must report a clean layout.
+	comps := []layoutComp{
+		{Designator: "SHEET", ComponentType: "sheet", BBox: bb(-100, -100, 400, 300)},
+		{Designator: "R1", ComponentType: "part", BBox: bb(0, 0, 10, 10)},
+		{Designator: "C2", ComponentType: "part", BBox: bb(20, 0, 30, 10)},
+	}
+	parts, skipped := filterLayoutComps(comps, false)
+	rep := analyzeLayout(parts, 2.54)
+	rep.SkippedNonParts = skipped
+	if !rep.OK {
+		t.Fatalf("expected clean report after excluding sheet, got %+v", rep.Overlaps)
+	}
+	if rep.SkippedNonParts != 1 {
+		t.Errorf("expected SkippedNonParts=1, got %d", rep.SkippedNonParts)
+	}
+}
+
 func TestAnalyzeLayout_NoBBoxSkipped(t *testing.T) {
 	comps := []layoutComp{
 		{Designator: "R1", BBox: bb(0, 0, 10, 10)},

--- a/skills/easyeda-design-flow/SKILL.md
+++ b/skills/easyeda-design-flow/SKILL.md
@@ -60,6 +60,7 @@ S0 预分析 → S1 分页💾 → S2 模块编组 → S3 按组摆放💾 → S
 1. **布局门** `easyeda sch layout-lint`(可加 `--min-gap`、`--all-pages`)
    - **任何 `overlap` ERROR = 必须修**(命令非零退出,可直接当 gate)。
    - `spacing` WARN = 评估是否太挤,外围贴芯片可接受、模块间过近要拉开。
+   - **默认只检真实器件**:图框/标题栏(sheet)与 netflag/netport 等非器件原语已自动排除,不会再误报"器件压图框"(issue #13);要连这些一起检查才加 `--include-non-parts`。
 2. **电气门** `easyeda sch drc`(+ `scripts/lint.sh <project>` 数据 lint)
    - **逐条**输出 `LEVEL <rule> <message> @(x,y)`;命令**仅在 `fatal>0`(error/fatal)时非零退出**,可直接当 gate(`0 fatal` = 过门)。
    - fatal / 未连接网络 = 必须修;`summary.warn` 警告(如未用 IO 悬空)逐条复核、可接受则放行。

--- a/skills/easyeda-schematic/SKILL.md
+++ b/skills/easyeda-schematic/SKILL.md
@@ -140,7 +140,7 @@ easyeda doc switch <P2|PCB1|uuid> --project <名字>   # 切换:按页名/PCB名
 ### 原理图编辑
 
 - `schematic.components.list` — `--include-bbox` 附带每个元件渲染范围 `{minX,minY,maxX,maxY}`(供布局推理);`--include-pins` 附带每脚 `{pinName,pinNumber,x,y,noConnected}`(布线/连通性判断的数据面,布线前读引脚功能名→坐标用它,**不要**再用 `easyeda call schematic.components.list --payload '{"includePins":true}'` 绕过)。两个 flag 可与 `--all-pages` 叠加(输出会显著变大)。
-- **`easyeda sch layout-lint`** — **布局自检**(治覆盖的机械真值)。拉 `components.list --include-bbox`,Go 侧两两几何检查:**bbox 重叠 = ERROR**(命令非零退出,可当门禁)、**间距 < `--min-gap`(默认 2.54mm)= WARN**。`--all-pages`、`--json`。摆放后跑它判覆盖/间距,比肉眼/截图可靠(截图可能 stale)。是 place→verify→adjust 闭环的输入。
+- **`easyeda sch layout-lint`** — **布局自检**(治覆盖的机械真值)。拉 `components.list --include-bbox`,Go 侧两两几何检查:**bbox 重叠 = ERROR**(命令非零退出,可当门禁)、**间距 < `--min-gap`(默认 2.54mm)= WARN**。`--all-pages`、`--json`。**默认只检真实器件(`componentType == "part"`)**:图框/标题栏(sheet)铺满整页、netflag/netport/netlabel 等非器件原语都会被自动排除,否则它们会与几乎每个器件误报重叠(见 issue #13)。需要把这些也纳入检查时加 `--include-non-parts`;被排除的数量会在报告里以 `skippedNonParts` 透明列出。摆放后跑它判覆盖/间距,比肉眼/截图可靠(截图可能 stale)。是 place→verify→adjust 闭环的输入。
 - `schematic.component.place`
 - `schematic.component.modify`
 - `schematic.component.delete` — ⚠️ **只删组件,不删导线/总线/图形**。删完 `schematic.components.list` 只剩 A4 sheet 会让你误以为页面已干净,实际残留导线还在(DRC 仍会报)。要真正清页用 `schematic.page.clear`。


### PR DESCRIPTION
Fixes #13

## 根因
`sch layout-lint` 从 `schematic.components.list` 拉取**全部**组件原语，包含图框/标题栏(`componentType: sheet`)以及 netflag/netport/netlabel 等非器件原语。图框 bbox 铺满整页，导致几乎每个真实器件都被误报为与图框重叠。

连接器侧 `serializeComponent` 早已带出 `componentType`，但 Go 侧 `parseLayoutComps` 把该字段丢弃了——这才是根因所在。

## 改动
- `layoutComp` 增加 `ComponentType` 字段；`parseLayoutComps` 读取 `componentType`。
- 新增 `filterLayoutComps`：默认只保留 `componentType == "part"`，排除 sheet 及各类 flag/label/port。**空 componentType 仍保留**(兼容不发该字段的旧连接器，避免把所有器件静默丢弃)。
- 新增 `--include-non-parts` 开关(默认 false),满足 issue 中"或提供 flag 排除"的诉求。
- 报告新增 `skippedNonParts` 计数,人类可读输出也提示被排除数量,保持透明。
- 同步更新 `easyeda-schematic` / `easyeda-design-flow` Skill(遵循"Skill 优先"准则)。

## 测试
- 新增 4 个单元测试覆盖过滤逻辑(默认排除非器件 / `--include-non-parts` 全保留 / 空类型保留 / sheet 不再误报重叠的回归)。
- `go test ./...` 全绿,`go vet` 无告警,`--help` 正确渲染新 flag。
- **未做**端到端 `docs/test-case-esp32-blink.md` 验证:需要已连接的 EasyEDA Pro 窗口(本环境无),核心逻辑已由纯函数单测覆盖。