### PR TITLE
fix: sch check filters stub wire-over-pin false positives + enriches floating-pin detail

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -5,6 +5,18 @@ The format follows [Keep a Changelog](https://keepachangelog.com/); versions
 follow [SemVer](https://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- **`schematic.check` no longer false-flags merged-stub endpoints as `wire-over-pin`,
+  and floating-pin findings now carry component-level detail.** A pin coincident with
+  a wire endpoint or a netflag/netport/netlabel anchor is the legitimate terminus of
+  its own `sch connect` stub; when EasyEDA auto-merges collinear touching stubs into
+  one long wire an inner pin lands in that wire's interior and was wrongly reported as
+  a through-pin short (the official DRC stays clean). Rule 3 now excludes pins that
+  coincide with a wire vertex or a net-marker anchor. Floating-pin findings now include
+  `primitiveId` and a `pinDetails[]` array (`number`, `name`, `x`, `y`) so the `--json`
+  report identifies the component and pin without a second lookup; the text report
+  prints the per-pin name + coordinates and falls back to `primitiveId` when the
+  designator is empty.
 
 ## [0.5.14] - 2026-06-28
 ### Fixed

--- a/extension/src/actions.ts
+++ b/extension/src/actions.ts
@@ -1254,12 +1254,23 @@ const schematicDrcCheck: Handler = async (payload) => {
 // — the exact input schematic.pin.set_no_connect takes, so "find floating → mark
 // NC" is one loop. More rules (empty value, standardization) can be added here.
 
+// Per-pin detail attached to a floating-pin finding so the report is actionable
+// without a second lookup: which pin (number+name) on which primitive, and where.
+interface CheckPinDetail {
+	number: string;
+	name?: string;
+	x: number;
+	y: number;
+}
+
 // One reconstructed design-check finding. Reuses the DRC severity buckets.
 interface CheckFinding {
 	type: string; // 'floating-pin' | 'wire-crossing' | 'wire-over-pin'
 	level: DrcSeverity;
 	designator?: string;
-	pins?: Array<string>;
+	primitiveId?: string; // owning component (floating-pin / wire-over-pin)
+	pins?: Array<string>; // pin numbers — kept flat for `sch no-connect`
+	pinDetails?: Array<CheckPinDetail>; // number+name+coords for each pin
 	count?: number;
 	message?: string;
 	at?: { x: number; y: number }; // location of a crossing / through-pin
@@ -1346,6 +1357,33 @@ const schematicCheck: Handler = async (payload) => {
 	}
 	const segs = collectWireSegments((wires ?? []) as Array<{ getState_Line: () => Array<number> }>);
 
+	// Connection anchors that legitimately terminate a stub but are NOT real pins:
+	// netflag / netport / netlabel components. A pin sitting on one of these (e.g. an
+	// overlapping `sch connect` stub that EasyEDA auto-merged into a collinear wire)
+	// is intentionally connected — it must be excluded from wire-over-pin so the
+	// check agrees with the official DRC instead of flagging the merged stub endpoint.
+	const NET_MARKER_TYPES = new Set(['netflag', 'netport', 'netlabel', 'short_symbol']);
+	const connectionMarkers: Array<{ x: number; y: number }> = [];
+	for (const c of components ?? []) {
+		let type: string;
+		try { type = String(c.getState_ComponentType?.() ?? ''); }
+		catch { continue; }
+		if (!NET_MARKER_TYPES.has(type)) continue;
+		try { connectionMarkers.push({ x: c.getState_X(), y: c.getState_Y() }); }
+		catch { /* marker without coords — skip */ }
+	}
+	// Every wire vertex (segment endpoint). A pin coincident with a wire endpoint is
+	// a legitimate termination/junction even if a merged collinear wire also runs
+	// through it — that's a connection, not a pass-through short.
+	const wireEndpoints: Array<{ x: number; y: number }> = [];
+	for (const s of segs) {
+		wireEndpoints.push({ x: s[0], y: s[1] }, { x: s[2], y: s[3] });
+	}
+	const COINCIDE_TOL = CHECK_EPS * 8;
+	const coincidesWithAnchor = (x: number, y: number): boolean =>
+		connectionMarkers.some(m => Math.hypot(x - m.x, y - m.y) <= COINCIDE_TOL)
+		|| wireEndpoints.some(e => Math.hypot(x - e.x, y - e.y) <= COINCIDE_TOL);
+
 	const findings: Array<CheckFinding> = [];
 	let floatingTotal = 0;
 	let componentsWithFloating = 0;
@@ -1355,14 +1393,16 @@ const schematicCheck: Handler = async (payload) => {
 	for (const c of components ?? []) {
 		// Net flags/ports/labels are components too but have no real pins to float
 		// — getAllPinsByPrimitiveId returns empty for them, so they're skipped.
+		const primitiveId = c.getState_PrimitiveId();
 		let pins;
-		try { pins = await eda.sch_PrimitiveComponent.getAllPinsByPrimitiveId(c.getState_PrimitiveId()); }
+		try { pins = await eda.sch_PrimitiveComponent.getAllPinsByPrimitiveId(primitiveId); }
 		catch { continue; }
 		if (!pins || pins.length === 0) continue;
 		const designator = c.getState_Designator?.() ?? '';
 
 		// Rule 1: floating pins (geometric connectivity).
 		const floating: Array<string> = [];
+		const floatingDetails: Array<CheckPinDetail> = [];
 		for (const p of pins) {
 			const px = p.getState_X();
 			const py = p.getState_Y();
@@ -1371,8 +1411,17 @@ const schematicCheck: Handler = async (payload) => {
 			// Intentionally-NC pins (the X marker) are not "floating" — skip them.
 			try { if (p.getState_NoConnected && p.getState_NoConnected()) continue; }
 			catch { /* treat as not-NC */ }
-			const connected = segs.some(s => pointOnSegment(px, py, s[0], s[1], s[2], s[3]));
-			if (!connected) floating.push(num);
+			const connected = segs.some(s => pointOnSegment(px, py, s[0], s[1], s[2], s[3]))
+				// A pin landing directly on a netflag/netport/netlabel is connected too.
+				|| connectionMarkers.some(m => Math.hypot(px - m.x, py - m.y) <= COINCIDE_TOL);
+			if (!connected) {
+				floating.push(num);
+				const name = (() => {
+					try { return String(p.getState_PinName?.() ?? ''); }
+					catch { return ''; }
+				})();
+				floatingDetails.push({ number: num, name: name || undefined, x: px, y: py });
+			}
 		}
 		if (floating.length > 0) {
 			floatingTotal += floating.length;
@@ -1381,7 +1430,9 @@ const schematicCheck: Handler = async (payload) => {
 				type: 'floating-pin',
 				level: 'warn',
 				designator,
+				primitiveId,
 				pins: floating,
+				pinDetails: floatingDetails,
 				count: floating.length,
 				message: `${floating.length} 个引脚悬空(无导线连接,未打 NC 标识)`,
 			});
@@ -1412,8 +1463,15 @@ const schematicCheck: Handler = async (payload) => {
 
 	// Rule 3: wire-over-pin — a pin sits in a wire's INTERIOR (the wire passes
 	// through it). EasyEDA trims+connects there, an unintended connection.
+	// EXCLUDE intended connections: a pin coincident with a wire endpoint or a
+	// netflag/netport/netlabel anchor is the legitimate terminus of its own stub.
+	// When EasyEDA auto-merges collinear touching stubs into one long wire, an inner
+	// pin lands in that merged wire's interior even though it's connected at its own
+	// stub endpoint/marker — without this guard those merged stubs produce the
+	// wire-over-pin false positives the official DRC does not report.
 	let overPinTotal = 0;
 	for (const p of allPins) {
+		if (coincidesWithAnchor(p.x, p.y)) continue;
 		const hit = segs.some(s => interiorOnSegment(p.x, p.y, s));
 		if (hit) {
 			overPinTotal++;

--- a/internal/app/cmd_sch_check.go
+++ b/internal/app/cmd_sch_check.go
@@ -16,14 +16,23 @@ import (
 // connectivity. This file renders that report and (with --strict) gates on it.
 // Output is by designator + pin number — feed it straight into `sch no-connect`.
 
+type checkPinDetail struct {
+	Number string  `json:"number"`
+	Name   string  `json:"name,omitempty"`
+	X      float64 `json:"x"`
+	Y      float64 `json:"y"`
+}
+
 type checkFinding struct {
-	Type       string   `json:"type"`
-	Level      string   `json:"level"`
-	Designator string   `json:"designator,omitempty"`
-	Pins       []string `json:"pins,omitempty"`
-	Count      int      `json:"count,omitempty"`
-	Message    string   `json:"message,omitempty"`
-	At         *struct {
+	Type        string           `json:"type"`
+	Level       string           `json:"level"`
+	Designator  string           `json:"designator,omitempty"`
+	PrimitiveId string           `json:"primitiveId,omitempty"`
+	Pins        []string         `json:"pins,omitempty"`
+	PinDetails  []checkPinDetail `json:"pinDetails,omitempty"`
+	Count       int              `json:"count,omitempty"`
+	Message     string           `json:"message,omitempty"`
+	At          *struct {
 		X float64 `json:"x"`
 		Y float64 `json:"y"`
 	} `json:"at,omitempty"`
@@ -123,8 +132,13 @@ func renderCheckReport(rep checkReport, w io.Writer) {
 			msg = f.Type
 		}
 		line := fmt.Sprintf("  %-5s  %-14s  ", tag, f.Type)
-		if f.Designator != "" {
+		// Prefer the human designator; fall back to the primitiveId so a finding on
+		// a component with an empty designator is still identifiable.
+		switch {
+		case f.Designator != "":
 			line += f.Designator + "  "
+		case f.PrimitiveId != "":
+			line += f.PrimitiveId + "  "
 		}
 		line += msg
 		if len(f.Pins) > 0 {
@@ -134,6 +148,15 @@ func renderCheckReport(rep checkReport, w io.Writer) {
 			line += fmt.Sprintf("  @(%.2f,%.2f)", f.At.X, f.At.Y)
 		}
 		fmt.Fprintln(w, line)
+		// Per-pin breakdown (floating-pin): pin number/name + coords so the report is
+		// actionable without a second lookup.
+		for _, pd := range f.PinDetails {
+			label := pd.Number
+			if pd.Name != "" {
+				label += " (" + pd.Name + ")"
+			}
+			fmt.Fprintf(w, "          pin %s  @(%.2f,%.2f)\n", label, pd.X, pd.Y)
+		}
 	}
 
 	if rep.Passed {

--- a/skills/easyeda-schematic/SKILL.md
+++ b/skills/easyeda-schematic/SKILL.md
@@ -153,6 +153,7 @@ easyeda doc switch <P2|PCB1|uuid> --project <名字>   # 切换:按页名/PCB名
 - `schematic.select`
 - `schematic.snapshot` — 截图。**产物保存在 CLI 运行目录下的隐藏目录 `<cwd>/.easyeda/artifacts/`,文件名带本地时间戳**(`<YYYYMMDD-HHMMSS>-<kind>-<短id>.png`,便于排序/查找);响应里的 `artifacts[].path` 是绝对路径。netlist/BOM 等其他产物同此规则。
 - `schematic.drc.check` — 用 `easyeda sch drc` 跑，**逐条**打印 `LEVEL <rule> <message> @(x,y)`(`--json` 给结构化)。返回含 `summary{fatal,error,warn,…}` 与 `fatal` 计数;**退出码仅在 `fatal>0` 时非零**(warning 不阻塞),据此判 S5 门「0 fatal」。
+- `schematic.check` — 用 `easyeda sch check` 跑的**重建式逐条设计检查**(官方 DRC 只给聚合 count,这里从图元几何重建):**floating-pin**(引脚悬空)、**wire-crossing**(导线交叉)、**wire-over-pin**(导线穿过引脚)。`floating-pin` 现在带 `primitiveId` 与 `pinDetails[]`(每个悬空脚的 `number`/`name`/`x`/`y`),文本报告逐脚打印脚名+坐标、designator 为空时回退打印 `primitiveId`,可直接喂给 `sch no-connect`。`wire-over-pin` 会**排除落在导线端点或 netflag/netport/netlabel 锚点上的引脚**——那是 `sch connect` 短 stub 的合法终点(EasyEDA 把共线相邻 stub 自动合并成一条长导线时,内部引脚会落进合并后导线的内部,但官方 DRC 视为合法,故不再误报)。`--json`、`--strict`(有 finding 即非零退出)、`--all-pages`。
 - `schematic.save`
 - `schematic.export.netlist`
 - `schematic.export.bom`


### PR DESCRIPTION
Fixes #15

## 问题
官方 DRC 干净时,`sch check` 仍对 `sch connect` 生成的短 stub/netport 走线大量误报 `wire-over-pin`;`floating-pin` 的 `--json` 输出缺少组件/位号/引脚/坐标,无法直接定位。

## 改动
**连接器 `extension/src/actions.ts` (`schematicCheck`)**
- 预扫描收集 netflag/netport/netlabel 锚点坐标 + 所有导线端点。
- **Rule 3 wire-over-pin**:落在导线端点或网络标记锚点上的引脚视为合法终点而排除——EasyEDA 把共线相邻 stub 自动合并成一条长导线时,内部引脚会落进合并导线内部,但那是它自己 stub 的预期连接,官方 DRC 视为合法,不再误报。
- **floating-pin 富化**:finding 增加 `primitiveId`;新增 `pinDetails[]`(每个悬空脚的 `number`/`name`/`x`/`y`);落在网络标记锚点上的引脚也不再算悬空。

**Go `internal/app/cmd_sch_check.go`**
- `checkFinding` 增加 `PrimitiveId` 与 `PinDetails []checkPinDetail`。
- 文本报告逐脚打印脚名+坐标;designator 为空时回退打印 `primitiveId`。

**文档**:`extension/CHANGELOG.md`(Unreleased)、`skills/easyeda-schematic/SKILL.md` 同步说明。

## 测试
- `go build ./...` + `go test ./internal/...` 全绿。
- 连接器 `npm run typecheck` 通过,`npm test` 7/7 通过。

## 尚未完成的运行时验证(需人工)
本改动改了连接器,需 `make eext` 重建并卸载旧的→重新导入 `.eext`、**完全退出并重启 EasyEDA**,再对 `motobox2026`/`docs/test-case-esp32-blink.md` 实测重跑(官方 DRC 干净 vs `sch check` 不再误报、`--json` 带 pinDetails)。该步骤依赖本地 EasyEDA Pro 桌面环境,worktree 内无法执行。