### PR TITLE
fix: correct sch connect up/down endpoint sign for y-DOWN schematic coords

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -6,6 +6,16 @@ follow [SemVer](https://semver.org/).
 
 ## [Unreleased]
 ### Fixed
+- **`schematic.power.connect_pin` (`sch connect`) `--direction up/down` no longer
+  inverts the stub/netport endpoint.** EasyEDA Pro schematic coords are y-DOWN (a
+  larger stored y renders LOWER on screen, verified on 3.2.121, issue #19), but the
+  endpoint math assumed y-UP, so `--direction up` pushed a top-pin stub DOWN into the
+  IC body and `--direction down` pushed a bottom-pin stub UP — visually wrong even
+  when DRC was clean. `up` now decreases y (visually higher) and `down` increases y
+  (visually lower). The flag-rotation table is unchanged: it is calibrated against
+  real rendered bbox and already keyed to visual directions, so the corrected
+  endpoint and the flag orientation now agree (callers no longer need the
+  `--direction down --rotation 90` workaround to get a visually-upward netport).
 - **`schematic.check` no longer false-flags merged-stub endpoints as `wire-over-pin`,
   and floating-pin findings now carry component-level detail.** A pin coincident with
   a wire endpoint or a netflag/netport/netlabel anchor is the legitimate terminus of

--- a/extension/src/actions.ts
+++ b/extension/src/actions.ts
@@ -1765,12 +1765,22 @@ const schematicPowerConnectPin: Handler = async (payload) => {
 	const rotation = optionalNumber(payload, 'rotation') ?? rotationFor(kind, direction);
 	const applied = await appliedRotation(rotation);
 
-	// EasyEDA is y-UP: +y renders upward. 'up' must increase y, 'down' decrease.
+	// `--direction` is the VISUAL outward direction (what the caller sees on the
+	// canvas), NOT a raw coordinate sign. On EasyEDA Pro (verified 3.2.121, issue
+	// #19) the schematic document coords are y-DOWN: a LARGER stored y renders
+	// LOWER on screen. So 'up' (visually higher) must DECREASE y and 'down'
+	// (visually lower) must INCREASE y. The earlier y-UP assumption pushed top-pin
+	// stubs/netports DOWN into the IC body and vice-versa even when DRC was clean.
+	// (The flag-rotation table below is independent: it is calibrated against real
+	// rendered bbox via calibrate.js and already keyed to visual directions — e.g.
+	// rotationFor('port','up')===90, the exact rotation a reporter had to pass by
+	// hand alongside `--direction down`; fixing the endpoint sign makes the wire and
+	// the flag orientation agree without touching that calibrated table.)
 	let endX = pinX;
 	let endY = pinY;
 	switch (direction) {
-		case 'up': endY = pinY + offset; break;
-		case 'down': endY = pinY - offset; break;
+		case 'up': endY = pinY - offset; break;
+		case 'down': endY = pinY + offset; break;
 		case 'left': endX = pinX - offset; break;
 		case 'right': endX = pinX + offset; break;
 		default:

--- a/internal/app/cmd_sch.go
+++ b/internal/app/cmd_sch.go
@@ -592,7 +592,7 @@ command fails fast after a short timeout with a hint instead of stalling.`,
 		c.Flags().Float64Var(&y, "y", 0, "pin Y coordinate")
 		c.Flags().StringVar(&kind, "kind", "", netflagKindHelp)
 		c.Flags().StringVar(&net, "net", "", "net name (required)")
-		c.Flags().StringVar(&direction, "direction", "", "wire direction: up, down, left, right")
+		c.Flags().StringVar(&direction, "direction", "", "visual stub direction (up=higher on canvas, down=lower): up, down, left, right")
 		c.Flags().Float64Var(&offset, "offset", 0, "wire length in schematic units")
 		c.Flags().Float64Var(&rotation, "rotation", 0, "flag rotation override in degrees")
 		sch.AddCommand(c)

--- a/internal/protocol/actions.go
+++ b/internal/protocol/actions.go
@@ -295,7 +295,7 @@ func AllActions() []ActionSpec {
 			Phase:       1,
 			Mutates:     true,
 			NeedsWindow: true,
-			Description: "Composite: stub a wire out of a pin and place a netflag/netport at its far end in one call — structurally prevents the 'netflag overlaps pin' DRC fatal. Direction/offset/rotation default from kind and can be overridden; flag orientation follows schematic-layout-conventions.md §3.5.",
+			Description: "Composite: stub a wire out of a pin and place a netflag/netport at its far end in one call — structurally prevents the 'netflag overlaps pin' DRC fatal. `direction` is the VISUAL outward direction on the canvas (up=higher, down=lower; coords are y-DOWN so 'up' moves the endpoint to a smaller y). Direction/offset/rotation default from kind and can be overridden; flag orientation follows schematic-layout-conventions.md §3.5.",
 			Inputs:      []string{"pinX", "pinY", "kind", "net", "direction optional", "offset optional", "rotation optional"},
 			Outputs:     []string{"wire primitiveId", "flag primitiveId", "end point", "rotation"},
 			VerifyWith:  []string{"schematic.snapshot", "schematic.drc.check"},

--- a/skills/easyeda-conventions/references/schematic-layout-conventions.md
+++ b/skills/easyeda-conventions/references/schematic-layout-conventions.md
@@ -138,7 +138,9 @@ EasyEDA 默认 lineWidth = 1。约定：
 
 > ⚠️ **createNetFlag / createNetPort 存储时取反**（2026-06 build）：传 `R` → 存储/渲染是 `(360-R)`。**坑**：建完**立即** `getState_Rotation()` 会回显 `R`（看着像恒等），**重新拉取**（`getAll`）才看到真正的取反值。`connect_pin` 已**运行时自探测并补偿**（`detectRotationNegation`），所以**经 connect_pin 传下表的值就能得到正确朝向**，对调用者透明;若直接调 raw `eda.createNetFlag`（debug.exec_js），需自己传取反值 `(360-表值)`。
 >
-> ⚠️ **坐标是 y-UP**：+y 在屏幕上是**向上**（实测：R2@y=250 显示在图纸底部、C1/C2@y=600 在顶部，且 bbox 校准 ground rot0 的 body 偏移 dy=-14.5=向下）。所以判断"导线朝哪/flag 放哪一侧"时，`dy>0` 是**向上**不是向下。`schematic.power.connect_pin` 的 `direction='up'` 用 `endY = pinY + offset`。
+> ⚠️ **坐标 y 轴方向是 build-dependent，端点几何按 y-DOWN 处理（EasyEDA Pro 3.2.121 实测，issue #19）**：在 3.2.121 上**较大的 y 在屏幕上更靠下**（y-DOWN）——报告者实测顶部引脚 `(525,320)`、底部引脚 `(560,540)`，底部引脚 y 更大，只有 y-DOWN 才自洽。因此 `schematic.power.connect_pin` 的 `direction='up'` 现在用 `endY = pinY - offset`（视觉向上），`'down'` 用 `endY = pinY + offset`（视觉向下）。**`--direction` 一律按"视觉方向"理解，不是坐标符号。**
+>
+> ⚠️ **历史校准曾记录 y-UP**（更早的 build：R2@y=250 在图纸底部、C1/C2@y=600 在顶部，且 ground rot0 的 bbox 偏移 dy=-14.5=向下）。EasyEDA 构建间会**静默翻转符号约定**（参见同节 createNetFlag 旋转取反的先例），y 轴方向亦然。**flag 旋转表(下表 12 项)不受影响**：它由 `calibrate.js` 对**实际渲染** bbox 校准、按**视觉方向**索引（`rotationFor('port','up')===90` 恰是报告者手动 workaround `--direction down --rotation 90` 用的值），修正端点符号后导线与 flag 朝向自动一致，**无需改那 12 个数字**。**合入前必须在已连接的 3.2.121 窗口跑一遍 `calibrate.js` / ESP32 端到端用例确认 y 轴方向**;若需同时兼容两类 build，应仿照 `detectRotationNegation` 加运行时 y 轴探测而非硬翻符号。
 >
 > ⛔ **走过的弯路（勿重蹈）**：取反是**真的**——实测 `connect_pin(direction=left)` 传 `90` → 存 `270` → 渲染**朝右**（0/180 上下对称，所以只有横向 flag 才暴露,藏了很久）。曾把这个取反当"误判"、撤掉 connect_pin 的补偿(commit `8aace7e`)，那次 **revert 才是 bug**;现已用运行时自探测重新锁死。**不要再据"恒等"撤补偿,除非先用 `connect_pin` 放个 left flag 肉眼确认朝向。** 校准方法：对 flag 调 `sch_Primitive.getPrimitivesBBox([pid])`，bbox 中心相对放置点 (x,y) 的偏移方向 = body 真实朝向（纯数据，不靠截图）。
 


### PR DESCRIPTION
Fixes #19

## 根因
`schematic.power.connect_pin`(`sch connect`)的端点几何(`extension/src/actions.ts`)假设坐标 y-UP(`up → endY = pinY + offset`)。但报告者在 **EasyEDA Pro 3.2.121** 实测坐标为 **y-DOWN**(较大 y 在屏幕上更靠下):顶部引脚 `(525,320)` `--direction up --offset 26` → 端点 `(525,346)` 落在视觉下方、嵌入器件体;底部 GND 引脚 `(560,540)` `--direction down` → flag 落在引脚上方。报告者数据本身只有在 y-DOWN 下才自洽(底部引脚 y=540 > 顶部引脚 y=320)。

## 修复
`--direction` 现按**视觉方向**理解:`up` → `endY = pinY - offset`(视觉向上),`down` → `endY = pinY + offset`(视觉向下)。left/right 不变。

**未触碰已校准的 flag 旋转真值表**:该表由 `calibrate.js` 对实际渲染 bbox 校准、按视觉方向索引——`rotationFor('port','up')===90` 恰好等于报告者手动 workaround `--direction down --rotation 90` 用的旋转值,说明旋转表本就正确,只有端点 Δy 符号错了。修正端点符号后导线与 flag 朝向自动一致,workaround 不再需要。

## 改动文件
- `extension/src/actions.ts` — 翻转 up/down 端点符号 + 注释
- `internal/protocol/actions.go` / `internal/app/cmd_sch.go` — action 描述与 CLI help 标明视觉方向语义
- `skills/easyeda-conventions/references/schematic-layout-conventions.md` §3.5 — 记录 y-DOWN 端点约定,保留历史 y-UP 校准为上下文
- `extension/CHANGELOG.md` — [Unreleased] 条目

## 测试
- `make lint-test` ✅(旋转表未漂移:actions.ts 与 orientation.json 仍一致)
- `go test ./...` ✅、`go build ./...` ✅、连接器 `npm run compile` ✅

## ⚠️ 合入前需人工验证(本环境无活体 EasyEDA 窗口)
1. 本仓库历史校准文档曾记录 y-UP,与本次 3.2.121 实测冲突。EasyEDA 构建间有静默翻转符号约定的先例(参见 CLAUDE.md 的 createNetFlag 旋转取反)。**合入前请在已连接的 3.2.121 窗口跑 `calibrate.js` 与 `docs/test-case-esp32-blink.md` ESP32 端到端用例确认 y 轴方向**。
2. 连接器为 TypeScript,需 `make eext` 重新构建并重新导入 .eext(并完全重启 EasyEDA 加载新代码)才能生效。
3. 若线上需同时兼容 y-UP / y-DOWN 两类 build,建议后续仿照 `detectRotationNegation` 增加运行时 y 轴探测,而非硬翻符号。