### PR TITLE
fix: reliably capture local region in view region + snapshot --no-fit

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -24,6 +24,20 @@ follow [SemVer](https://semver.org/).
   - Live behavioral verification on a connected board is still pending.
 
 ### Fixed
+- **`view region` + `schematic.snapshot --no-fit` now reliably captures the
+  requested local region (issue #20).** Three coordinated fixes: (1) the snapshot
+  handler now waits for the canvas to repaint (two `requestAnimationFrame`s with a
+  timeout fallback) BEFORE reading the frame, so a preceding `view region` viewport
+  has actually landed — previously `--no-fit` grabbed the pre-region frame because
+  EasyEDA does not synchronously repaint after `eda.*` view calls (the `--fit` path
+  only "worked" by accident, since `zoomToAllPrimitives` nudged a redraw). (2)
+  Built-in stale-frame detection: the snapshot result now exposes the frame
+  `sha256`; thread it back via `sch snapshot --previous-sha256 <sha>` and the
+  connector detects a byte-identical (stale) frame, retries once after another
+  redraw, and reports `stale`/`staleRetry`. (3) `view.region` now normalizes the
+  rectangle (sorts each axis to min/max) and rejects a zero-area box, so a
+  reversed/degenerate bound no longer renders as a tiny sliver in a blank frame;
+  `view region` CLI help documents the y-DOWN schematic axis semantics and units.
 - **`schematic.power.connect_pin` (`sch connect`) `--direction up/down` no longer
   inverts the stub/netport endpoint.** EasyEDA Pro schematic coords are y-DOWN (a
   larger stored y renders LOWER on screen, verified on 3.2.121, issue #19), but the

--- a/extension/src/actions.ts
+++ b/extension/src/actions.ts
@@ -16,6 +16,7 @@ import {
 	asPayload,
 	blobToBase64,
 	newArtifactId,
+	normalizeRegion,
 	normalizeWirePoints,
 	optionalBoolean,
 	optionalNumber,
@@ -1004,6 +1005,54 @@ async function countLivePagePrimitives(): Promise<number | null> {
 	}
 }
 
+/**
+ * Wait for the canvas to settle (commit any pending viewport change + redraw)
+ * before we read a frame. EasyEDA does NOT synchronously repaint after an
+ * `eda.*` view call, so `getCurrentRenderedAreaImage` issued back-to-back can
+ * return the PREVIOUS frame (issue #20: `view region` followed immediately by
+ * `snapshot --no-fit` captures the stale, pre-region viewport). The `--fit`
+ * path only "worked" because `zoomToAllPrimitives` happened to nudge a redraw;
+ * `--no-fit` had no such nudge. Two animation frames straddle a paint, and the
+ * timeout is the fallback for runtimes where rAF never fires (e.g. a
+ * backgrounded tab). Best-effort: never throws.
+ */
+async function waitForCanvasSettle(): Promise<void> {
+	const raf: typeof requestAnimationFrame | undefined
+		= typeof requestAnimationFrame === 'function' ? requestAnimationFrame : undefined;
+	await new Promise<void>((resolve) => {
+		let done = false;
+		const settle = () => {
+			if (done) return;
+			done = true;
+			resolve();
+		};
+		// Fallback so we never hang if rAF is throttled/unavailable.
+		setTimeout(settle, 120);
+		if (raf) {
+			raf(() => raf(settle));
+		}
+	});
+}
+
+/**
+ * Hex SHA-256 of an image blob, used to tell whether two captures are the
+ * byte-identical STALE frame (issue #2/#20). Best-effort: returns null when
+ * SubtleCrypto is unavailable rather than blocking the capture.
+ */
+async function blobSha256(blob: Blob): Promise<string | null> {
+	try {
+		if (typeof crypto === 'undefined' || !crypto.subtle) return null;
+		const buf = await blob.arrayBuffer();
+		const digest = await crypto.subtle.digest('SHA-256', buf);
+		return Array.from(new Uint8Array(digest))
+			.map(b => b.toString(16).padStart(2, '0'))
+			.join('');
+	}
+	catch {
+		return null;
+	}
+}
+
 const schematicSnapshot: Handler = async (payload) => {
 	const tabId = optionalString(payload, 'tabId');
 	// Auto fit-to-all before capturing (适应全部) is ON by default so the whole
@@ -1012,6 +1061,11 @@ const schematicSnapshot: Handler = async (payload) => {
 	// not block the capture. Bonus: changing the viewport also nudges EasyEDA to
 	// redraw, which mitigates the stale-frame problem documented below.
 	const fit = optionalBoolean(payload, 'fit') !== false;
+	// Optional sha256 of the PREVIOUS snapshot (caller threads it back in). When
+	// present we can DETECT a stale frame ourselves (issue #20) instead of only
+	// emitting advisory text: if the canvas state changed but the image bytes are
+	// byte-identical, the capture is stale — we retry once after another settle.
+	const previousSha = optionalString(payload, 'previousSha256');
 	let fitted = false;
 	if (fit) {
 		try {
@@ -1022,30 +1076,58 @@ const schematicSnapshot: Handler = async (payload) => {
 			/* best-effort — fall through and capture at the current viewport */
 		}
 	}
-	let blob;
-	try {
-		blob = await eda.dmt_EditorControl.getCurrentRenderedAreaImage(tabId);
+
+	// Let any pending viewport change (a preceding `view region`/`view zoom`, or
+	// the zoomToAllPrimitives above) commit + repaint before we read the frame.
+	// Without this the --no-fit path captures the PRE-region viewport (issue #20).
+	await waitForCanvasSettle();
+
+	const capture = async (): Promise<Blob> => {
+		let b;
+		try {
+			b = await eda.dmt_EditorControl.getCurrentRenderedAreaImage(tabId);
+		}
+		catch (err) {
+			throw edaError(err, 'Failed to capture snapshot.');
+		}
+		if (!b) {
+			throw new ActionError(ErrorCodes.EDA_CALL_FAILED, 'Snapshot returned no image.');
+		}
+		return b;
+	};
+
+	let blob = await capture();
+	let sha256 = await blobSha256(blob);
+	// Built-in stale detection: if the caller told us the prior frame's sha and we
+	// got the exact same bytes back, the canvas almost certainly didn't repaint —
+	// give it one more settle + recapture before reporting.
+	let staleRetry = false;
+	if (previousSha && sha256 && sha256 === previousSha) {
+		staleRetry = true;
+		await waitForCanvasSettle();
+		blob = await capture();
+		sha256 = await blobSha256(blob);
 	}
-	catch (err) {
-		throw edaError(err, 'Failed to capture snapshot.');
-	}
-	if (!blob) {
-		throw new ActionError(ErrorCodes.EDA_CALL_FAILED, 'Snapshot returned no image.');
-	}
+	const stale = Boolean(previousSha && sha256 && sha256 === previousSha);
+
 	const artifact = await blobToArtifact(blob, 'schematic_snapshot', 'snapshot.png', 'image/png');
-	// Anti-stale metadata (issue #2): EasyEDA does NOT auto-redraw after eda.*
+	// Anti-stale metadata (issue #2/#20): EasyEDA does NOT auto-redraw after eda.*
 	// edits, so getCurrentRenderedAreaImage can return a byte-identical STALE
-	// frame. The caller compares `primitiveCount` across two snapshots — if it
-	// changed while the image sha did not, the frame is stale; judge STATE by
-	// data, not by the picture.
+	// frame. We now (a) settle the canvas before capturing, (b) expose the frame
+	// `sha256` so the caller can thread it back as `previousSha256` to let us
+	// detect+retry a stale frame, and (c) still surface `primitiveCount` for the
+	// data-over-picture judgement.
 	const primitiveCount = await countLivePagePrimitives();
 	return {
 		result: {
 			artifactId: artifact.id,
 			primitiveCount,
 			fitted,
+			sha256,
+			stale,
+			staleRetry,
 			capturedAt: new Date().toISOString(),
-			stale: 'EasyEDA may not auto-redraw after API edits; compare primitiveCount across snapshots to detect a stale frame. Judge state by data, screenshot for layout only.',
+			staleHint: 'EasyEDA may not auto-redraw after API edits. Thread this sha256 back as previousSha256 on the next snapshot to auto-detect a stale frame; judge state by data, screenshot for layout only.',
 		},
 		artifacts: [artifact],
 	};
@@ -2998,12 +3080,16 @@ const viewRegion: Handler = async (payload) => {
 	const right = requireNumber(payload, 'right');
 	const top = requireNumber(payload, 'top');
 	const bottom = requireNumber(payload, 'bottom');
+	// Order the bounds (and reject a zero-area box) before handing them to
+	// zoomToRegion — a reversed/degenerate rectangle otherwise renders as a tiny
+	// sliver in a mostly-blank frame (issue #20).
+	const region = normalizeRegion(left, right, top, bottom);
 	try {
-		const ok = await eda.dmt_EditorControl.zoomToRegion(left, right, top, bottom);
+		const ok = await eda.dmt_EditorControl.zoomToRegion(region.left, region.right, region.top, region.bottom);
 		if (!ok) {
 			throw new ActionError(ErrorCodes.EDA_CALL_FAILED, 'Canvas does not support region zoom (or no focused canvas).');
 		}
-		return { result: { ok } };
+		return { result: { ok, region } };
 	}
 	catch (err) {
 		if (err instanceof ActionError) throw err;

--- a/extension/src/util.test.ts
+++ b/extension/src/util.test.ts
@@ -8,7 +8,7 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
 import { ActionError } from './protocol';
-import { normalizeWirePoints } from './util';
+import { normalizeRegion, normalizeWirePoints } from './util';
 
 test('normalizeWirePoints: flat input is returned unchanged', () => {
 	assert.deepEqual(normalizeWirePoints([195, 350, 215, 350]), [195, 350, 215, 350]);
@@ -44,4 +44,27 @@ test('normalizeWirePoints: malformed nested entry throws', () => {
 test('normalizeWirePoints: non-finite coordinates throw', () => {
 	assert.throws(() => normalizeWirePoints([1, 2, NaN, 4]), ActionError);
 	assert.throws(() => normalizeWirePoints([[1, 2], [Infinity, 4]]), ActionError);
+});
+
+test('normalizeRegion: already-ordered box is returned unchanged', () => {
+	assert.deepEqual(normalizeRegion(400, 730, 300, 520), { left: 400, right: 730, top: 300, bottom: 520 });
+});
+
+test('normalizeRegion: reversed X / Y bounds are sorted to min/max', () => {
+	assert.deepEqual(normalizeRegion(730, 400, 520, 300), { left: 400, right: 730, top: 300, bottom: 520 });
+	assert.deepEqual(normalizeRegion(400, 730, 520, 300), { left: 400, right: 730, top: 300, bottom: 520 });
+});
+
+test('normalizeRegion: negative coordinates are supported', () => {
+	assert.deepEqual(normalizeRegion(-100, -500, 50, -50), { left: -500, right: -100, top: -50, bottom: 50 });
+});
+
+test('normalizeRegion: zero-area box (collapsed axis) throws', () => {
+	assert.throws(() => normalizeRegion(400, 400, 300, 520), ActionError); // x span 0
+	assert.throws(() => normalizeRegion(400, 730, 300, 300), ActionError); // y span 0
+});
+
+test('normalizeRegion: non-finite bound throws', () => {
+	assert.throws(() => normalizeRegion(NaN, 730, 300, 520), ActionError);
+	assert.throws(() => normalizeRegion(400, Infinity, 300, 520), ActionError);
 });

--- a/extension/src/util.ts
+++ b/extension/src/util.ts
@@ -211,3 +211,59 @@ export function normalizeWirePoints(points: unknown): number[] {
 
 	return flat as number[];
 }
+
+/** A canvas rectangle with X/Y bounds already normalized to min/max order. */
+export interface NormalizedRegion {
+	left: number;
+	right: number;
+	top: number;
+	bottom: number;
+}
+
+/**
+ * Normalize a `view region` rectangle so `zoomToRegion` always receives a
+ * sane, non-degenerate box.
+ *
+ * `eda.dmt_EditorControl.zoomToRegion(left, right, top, bottom)` expects two X
+ * bounds and two Y bounds, but it does NOT defensively order them — passing a
+ * reversed pair (e.g. `right < left`, or `top`/`bottom` in the wrong order for
+ * the y-DOWN schematic coords, issue #19/#20) yields a zero/negative-area box
+ * that the canvas resolves to a tiny sliver in a mostly-blank frame. We sort
+ * each axis here so the rectangle is the same regardless of which corner the
+ * caller passed first, and reject a fully degenerate (zero-area) request up
+ * front instead of letting it render as blank.
+ *
+ * @param left - first X bound
+ * @param right - second X bound
+ * @param top - first Y bound
+ * @param bottom - second Y bound
+ * @returns the rectangle with `left<=right` and `top<=bottom`
+ * @throws ActionError when any bound is non-finite or the box has zero area
+ */
+export function normalizeRegion(
+	left: number,
+	right: number,
+	top: number,
+	bottom: number,
+): NormalizedRegion {
+	for (const [name, value] of [['left', left], ['right', right], ['top', top], ['bottom', bottom]] as const) {
+		if (typeof value !== 'number' || !Number.isFinite(value)) {
+			throw new ActionError(
+				ErrorCodes.MISSING_PAYLOAD_FIELD,
+				`Invalid region: "${name}" must be a finite number.`,
+			);
+		}
+	}
+	const minX = Math.min(left, right);
+	const maxX = Math.max(left, right);
+	const minY = Math.min(top, bottom);
+	const maxY = Math.max(top, bottom);
+	if (minX === maxX || minY === maxY) {
+		throw new ActionError(
+			ErrorCodes.MISSING_PAYLOAD_FIELD,
+			`Invalid region: zero-area box (x span ${maxX - minX}, y span ${maxY - minY}). `
+			+ 'left/right and top/bottom must each be two distinct bounds.',
+		);
+	}
+	return { left: minX, right: maxX, top: minY, bottom: maxY };
+}

--- a/internal/app/cmd_sch.go
+++ b/internal/app/cmd_sch.go
@@ -667,6 +667,7 @@ command fails fast after a short timeout with a hint instead of stalling.`,
 	// schematic.snapshot
 	{
 		var noFit bool
+		var previousSha string
 		c := &cobra.Command{
 			Use:   "snapshot",
 			Short: "Capture the current schematic view as an image artifact",
@@ -679,12 +680,16 @@ current viewport.
 For a PARTIAL / zoomed-in shot, frame the area first with "easyeda view region
 --left --right --top --bottom" (or "view zoom --x --y --scale"), then capture
 with --no-fit so the snapshot keeps that viewport instead of zooming back out.
+The snapshot now waits for the canvas to repaint before grabbing the frame, so
+"view region && sch snapshot --no-fit" reliably captures the requested region
+(issue #20).
 
-WARNING: EasyEDA does NOT auto-redraw after API edits, so the captured frame can
-be STALE (byte-identical to the previous one even though the page changed). The
-result includes primitiveCount + capturedAt — compare primitiveCount across two
-snapshots to detect a stale frame, and judge STATE by data (sch list/getAll), not
-by the screenshot. (The auto-fit also nudges a redraw, which helps.)`,
+STALE FRAMES: EasyEDA does NOT auto-redraw after API edits, so a capture can be
+byte-identical to a previous one even though the page changed. The result now
+includes a frame "sha256" — pass it back via --previous-sha256 on the next
+snapshot and the connector will detect a byte-identical (stale) frame, retry
+once after another redraw, and report stale=true if it is still identical. Also
+compare primitiveCount and judge STATE by data (sch list/getAll), not the pixels.`,
 			Args: cobra.NoArgs,
 			Example: `  easyeda sch snapshot           # auto fit-to-all, then capture
   easyeda sch snapshot --no-fit  # keep the current viewport (partial shot)
@@ -693,11 +698,15 @@ by the screenshot. (The auto-fit also nudges a redraw, which helps.)`,
 				// Auto-fit is built into the schematic.snapshot action (default on);
 				// the CLI just forwards the opt-out so a single round-trip both fits
 				// and captures.
-				return dispatch(cfg, "schematic.snapshot", window,
-					map[string]any{"fit": !noFit}, stdout, stderr)
+				payload := map[string]any{"fit": !noFit}
+				if previousSha != "" {
+					payload["previousSha256"] = previousSha
+				}
+				return dispatch(cfg, "schematic.snapshot", window, payload, stdout, stderr)
 			},
 		}
 		c.Flags().BoolVar(&noFit, "no-fit", false, "do NOT zoom to fit before capturing (keep current viewport)")
+		c.Flags().StringVar(&previousSha, "previous-sha256", "", "sha256 of the previous snapshot; enables stale-frame detection + auto-retry")
 		sch.AddCommand(c)
 	}
 

--- a/internal/app/cmd_view.go
+++ b/internal/app/cmd_view.go
@@ -78,8 +78,23 @@ func newViewCmd(cfg *appConfig, stdout, stderr io.Writer) *cobra.Command {
 	{
 		var left, right, top, bottom float64
 		c := &cobra.Command{
-			Use:     "region",
-			Short:   "Zoom to a rectangular region (canvas units: sch 0.01inch, PCB mil)",
+			Use:   "region",
+			Short: "Zoom to a rectangular region (canvas units: sch 0.01inch, PCB mil)",
+			Long: `Zoom to a rectangular region of the canvas.
+
+--left/--right are the two X bounds, --top/--bottom the two Y bounds. Order does
+NOT matter: the connector sorts each axis to a min/max box, so a reversed pair
+still frames the same rectangle. A zero-area box (a bound repeated, e.g.
+--left == --right) is rejected.
+
+Units are canvas units: schematic 0.01inch, PCB mil. NOTE the schematic canvas
+is y-DOWN — a LARGER stored y renders LOWER on screen (verified on Pro 3.2.121,
+issue #19). The flag names are just "two Y bounds"; you do not need to guess
+which is visually higher.
+
+For a partial / zoomed-in screenshot, frame the area here first, then capture
+with "easyeda sch snapshot --no-fit" so the snapshot keeps this viewport. The
+snapshot waits for the canvas to repaint before grabbing the frame (issue #20).`,
 			Args:    cobra.NoArgs,
 			Example: `  easyeda view region --left 0 --right 1000 --top 1000 --bottom 0`,
 			RunE: func(cmd *cobra.Command, args []string) error {
@@ -94,7 +109,7 @@ func newViewCmd(cfg *appConfig, stdout, stderr io.Writer) *cobra.Command {
 		}
 		c.Flags().Float64Var(&left, "left", 0, "first X bound")
 		c.Flags().Float64Var(&right, "right", 0, "second X bound")
-		c.Flags().Float64Var(&top, "top", 0, "first Y bound")
+		c.Flags().Float64Var(&top, "top", 0, "first Y bound (canvas is y-DOWN: larger y renders lower)")
 		c.Flags().Float64Var(&bottom, "bottom", 0, "second Y bound")
 		view.AddCommand(c)
 	}


### PR DESCRIPTION
Fixes #20

## 问题
`view region` + `sch snapshot --no-fit` 无法稳定框住请求的局部区域：常常截到上一次的视口（pre-region 帧），或返回字节相同的 stale 图；反向/退化的区域参数会渲染成大片空白中的极小图形。根因是 EasyEDA 在 `eda.*` 视图调用后不会同步重绘，而 `--no-fit` 路径又缺少 `zoomToAllPrimitives` 顺带触发的重绘 nudge。

## 改动
1. **抓图前等待画布重绘落定**（`schematicSnapshot`）：用两次 `requestAnimationFrame`(带 120ms 超时兜底) 等待前序 `view region` 视口真正生效后再读帧，不再依赖 `--fit` 的副作用。
2. **内建 stale 检测 + 重试**：快照结果新增帧 `sha256`；调用方可通过 `sch snapshot --previous-sha256 <sha>` 回传，连接器检测到字节相同帧时自动再落定+重抓一次，并在结果中给出 `stale`/`staleRetry`。
3. **区域归一化与校验**（`viewRegion` + 新 `normalizeRegion`）：对 left/right、top/bottom 各轴排序为 min/max，零面积框直接报错；`view region` CLI 帮助补充 y-DOWN 轴语义与单位(sch 0.01inch / PCB mil)。

## 测试
- 连接器单测：新增 `normalizeRegion` 6 组用例(有序/反向/负坐标/零面积/非有限)，`npm test` 12 通过。
- `npm run typecheck` 通过，`npm run compile` 产物正常。
- Go：`go build ./...` 与 `go test ./internal/app/...` 通过。
- **未验证**：缺少连接 EasyEDA Pro 3.2.121 + motobox2026 工程的实机环境，无法实跑 region→snapshot 的真实重绘时序；重绘落定与 stale 检测逻辑需在实机上按 `docs/test-case-esp32-blink.md` MCU 区域回归确认。