### PR TITLE
feat(sch): pin-aware autoconnect planner (direction/offset auto-pick)

### DIFF
--- a/internal/app/cmd_sch.go
+++ b/internal/app/cmd_sch.go
@@ -834,6 +834,12 @@ Exits non-zero when any overlap is found, so it can gate a workflow.`,
 		sch.AddCommand(c)
 	}
 
+	// ── autoconnect ───────────────────────────────────────────────────────
+	// Pin-aware deterministic connect planner: pick direction/offset by scoring
+	// real geometry, then delegate to schematic.power.connect_pin. Scorer is pure
+	// (cmd_sch_autoconnect.go); orchestration in cmd_sch_autoconnect_run.go.
+	sch.AddCommand(newAutoconnectCmd(cfg, &window, stdout, stderr))
+
 	// ── netlist ───────────────────────────────────────────────────────────
 	// schematic.export.netlist
 	{

--- a/internal/app/cmd_sch_autoconnect.go
+++ b/internal/app/cmd_sch_autoconnect.go
@@ -1,0 +1,387 @@
+package app
+
+import (
+	"math"
+	"sort"
+)
+
+// ── sch autoconnect: pin-aware deterministic connect planner ────────────────
+//
+// `schematic.power.connect_pin` already solves the low-level safety problem
+// (pin → short wire → flag/netport, so a netflag never sits on a bare pin and
+// trips DRC). But it still makes the CALLER pick `direction` and `offset`, which
+// turns layout quality into AI/manual judgment.
+//
+// `sch autoconnect` removes that judgment: it pulls the real rendered geometry
+// (part bboxes, pin coordinates, existing flag/port/label bboxes), enumerates
+// every (direction × offset) candidate, scores each with a PURE deterministic
+// cost function, picks the lowest-cost one, and delegates the actual mutation to
+// the existing `connect_pin` primitive. Mirrors `analyzeLayout` in
+// cmd_sch_layout.go — pure geometry in Go, unit-testable, no side effects in the
+// scorer. See issue #24.
+
+// ── tunable rules ───────────────────────────────────────────────────────────
+
+// autoconnectRules are the planner knobs. Mirrors the `rules` block of the spec
+// JSON. Offsets/gaps are in schematic units (the same space connect_pin's
+// `offset` and the pin/bbox coordinates live in).
+type autoconnectRules struct {
+	AvoidTitleBlock bool    `json:"avoidTitleBlock"`
+	AvoidPinFanout  bool    `json:"avoidPinFanout"`
+	StaggerLabels   bool    `json:"staggerLabels"`
+	OffsetMin       float64 `json:"offsetMin"`
+	OffsetMax       float64 `json:"offsetMax"`
+	OffsetStep      float64 `json:"offsetStep"`
+	MinLabelGap     float64 `json:"minLabelGap"`
+}
+
+// defaultAutoconnectRules matches the spec defaults documented in issue #24.
+func defaultAutoconnectRules() autoconnectRules {
+	return autoconnectRules{
+		AvoidTitleBlock: true,
+		AvoidPinFanout:  true,
+		StaggerLabels:   true,
+		OffsetMin:       18,
+		OffsetMax:       80,
+		OffsetStep:      6,
+		MinLabelGap:     12,
+	}
+}
+
+// ── scene geometry ──────────────────────────────────────────────────────────
+
+// acPin is a pin in the scene: its coordinate plus the owning part's identity
+// and bbox (for outward-side reasoning). Pins with no owner bbox still
+// participate in crossing checks.
+type acPin struct {
+	X, Y       float64
+	Designator string
+	PinNumber  string
+	PinName    string
+	OwnerBBox  *layoutBBox
+}
+
+// acScene is the full geometric context one autoconnect run reasons against.
+// Flags grows as connections are placed so later labels stagger off earlier ones.
+type acScene struct {
+	Parts                 []layoutBBox // real part bboxes (componentType "part")
+	Pins                  []acPin      // every pin across all parts
+	Flags                 []layoutBBox // existing netflag/netport/netlabel bboxes
+	TitleBlock            *layoutBBox  // derived keep-out (nil if not applied)
+	TitleBlockProvisional bool         // true when no sheet bbox was found (keep-out NOT geometrically applied)
+}
+
+// ── candidate + scoring ─────────────────────────────────────────────────────
+
+type acPoint struct {
+	X float64 `json:"x"`
+	Y float64 `json:"y"`
+}
+
+// acReason is one signed cost contribution (penalty > 0, bonus < 0).
+type acReason struct {
+	Cost float64 `json:"cost"`
+	Desc string  `json:"desc"`
+}
+
+// acCandidate is one scored (direction, offset) option.
+type acCandidate struct {
+	Direction string     `json:"direction"`
+	Offset    float64    `json:"offset"`
+	EndPoint  acPoint    `json:"endPoint"`
+	Score     float64    `json:"score"`
+	Reasons   []acReason `json:"reasons,omitempty"`
+}
+
+// Cost-table constants (issue #24). Kept as named constants so the scorer reads
+// like the table and the unit tests can assert exact figures.
+const (
+	costPartOverlap   = 10000 // endpoint/label bbox overlaps a real part bbox
+	costTitleBlock    = 10000 // endpoint/label bbox enters the title-block keep-out
+	costPinCross      = 5000  // stub crosses a non-target pin
+	costFlagCollision = 1000  // endpoint/label collides with an existing flag/port/label
+	costThroughPart   = 500   // stub passes through another component bbox
+	costFanoutChannel = 100   // too close to a preserved pin-fanout channel
+	costOffsetPerUnit = 0.1   // +offset * 0.1 — prefer shorter stubs
+	bonusOutwardSide  = -20   // direction matches the pin's outward side
+	bonusKindDefault  = -10   // direction matches the kind default (GND down / power up / port outward)
+	acLabelHalfExtent = 4.0   // nominal half-size of a placed flag/label marker box (schematic units)
+	acCoordEps        = 0.01  // coordinate-equality tolerance
+	acOverlapEps      = 1e-6  // positive-length threshold for interval/area overlap
+)
+
+// endpointFor computes where connect_pin will land the stub end for a given
+// direction/offset. MUST match the connector's switch (extension/src/actions.ts,
+// schematicPowerConnectPin): y-DOWN coords — 'up' decreases y, 'down' increases
+// y — so the planned geometry equals the geometry connect_pin actually creates.
+func endpointFor(pinX, pinY, offset float64, dir string) (x, y float64) {
+	switch dir {
+	case "up":
+		return pinX, pinY - offset
+	case "down":
+		return pinX, pinY + offset
+	case "left":
+		return pinX - offset, pinY
+	case "right":
+		return pinX + offset, pinY
+	}
+	return pinX, pinY
+}
+
+// kindDefaultDirection mirrors the connector's defaultDirection(kind): power up,
+// grounds down, in-ports left, out/bi-ports right. Input is the CANONICAL kind.
+func kindDefaultDirection(canonicalKind string) string {
+	switch canonicalKind {
+	case "power":
+		return "up"
+	case "net_port_in":
+		return "left"
+	case "net_port_out", "net_port_bi":
+		return "right"
+	default: // ground / analog_ground / protective_ground / protect_ground / unknown
+		return "down"
+	}
+}
+
+// outwardDirection is the direction that moves the endpoint AWAY from the owning
+// part's bbox center — the natural side to route a pin's flag. Empty when the
+// owner bbox is unknown.
+func outwardDirection(pin acPin) string {
+	if pin.OwnerBBox == nil {
+		return ""
+	}
+	cx := (pin.OwnerBBox.MinX + pin.OwnerBBox.MaxX) / 2
+	cy := (pin.OwnerBBox.MinY + pin.OwnerBBox.MaxY) / 2
+	dx := pin.X - cx
+	dy := pin.Y - cy
+	if math.Abs(dx) >= math.Abs(dy) {
+		if dx >= 0 {
+			return "right"
+		}
+		return "left"
+	}
+	// y-DOWN: a pin BELOW center (larger y) routes outward as 'down' (y+offset).
+	if dy >= 0 {
+		return "down"
+	}
+	return "up"
+}
+
+// labelBox is the nominal extent of the flag/label that will sit at the endpoint.
+func labelBox(x, y float64) layoutBBox {
+	return layoutBBox{
+		MinX: x - acLabelHalfExtent, MinY: y - acLabelHalfExtent,
+		MaxX: x + acLabelHalfExtent, MaxY: y + acLabelHalfExtent,
+	}
+}
+
+// segHitsRect reports whether an axis-aligned segment from (x0,y0) to (x1,y1)
+// passes through the INTERIOR of rect (positive-length overlap). A segment that
+// merely runs along an edge (e.g. a stub leaving a pin on the part boundary)
+// does not count — that's what lets an outward stub avoid flagging its own owner.
+func segHitsRect(x0, y0, x1, y1 float64, rect layoutBBox) bool {
+	if x0 == x1 { // vertical stub
+		if !(rect.MinX < x0 && x0 < rect.MaxX) {
+			return false
+		}
+		lo, hi := math.Min(y0, y1), math.Max(y0, y1)
+		return math.Min(hi, rect.MaxY)-math.Max(lo, rect.MinY) > acOverlapEps
+	}
+	// horizontal stub
+	if !(rect.MinY < y0 && y0 < rect.MaxY) {
+		return false
+	}
+	lo, hi := math.Min(x0, x1), math.Max(x0, x1)
+	return math.Min(hi, rect.MaxX)-math.Max(lo, rect.MinX) > acOverlapEps
+}
+
+// pinOnSegment reports whether point (px,py) lies strictly between the endpoints
+// of an axis-aligned segment (i.e. the stub crosses that pin).
+func pinOnSegment(x0, y0, x1, y1, px, py float64) bool {
+	if x0 == x1 { // vertical
+		if math.Abs(px-x0) > acCoordEps {
+			return false
+		}
+		lo, hi := math.Min(y0, y1), math.Max(y0, y1)
+		return py > lo+acCoordEps && py < hi-acCoordEps
+	}
+	// horizontal
+	if math.Abs(py-y0) > acCoordEps {
+		return false
+	}
+	lo, hi := math.Min(x0, x1), math.Max(x0, x1)
+	return px > lo+acCoordEps && px < hi-acCoordEps
+}
+
+// pointSegDist is the distance from (px,py) to an axis-aligned segment.
+func pointSegDist(x0, y0, x1, y1, px, py float64) float64 {
+	if x0 == x1 { // vertical
+		lo, hi := math.Min(y0, y1), math.Max(y0, y1)
+		cy := math.Max(lo, math.Min(hi, py))
+		return math.Hypot(px-x0, py-cy)
+	}
+	lo, hi := math.Min(x0, x1), math.Max(x0, x1)
+	cx := math.Max(lo, math.Min(hi, px))
+	return math.Hypot(px-cx, py-y0)
+}
+
+// boxesOverlap is true when two bboxes share positive area.
+func boxesOverlap(a, b layoutBBox) bool {
+	ox := math.Min(a.MaxX, b.MaxX) - math.Max(a.MinX, b.MinX)
+	oy := math.Min(a.MaxY, b.MaxY) - math.Max(a.MinY, b.MinY)
+	return ox > acOverlapEps && oy > acOverlapEps
+}
+
+// scoreCandidate is the PURE deterministic core: given a pin, a direction, an
+// offset, the canonical kind, the scene, and the rules, return the scored
+// candidate with its signed cost breakdown. No I/O, no mutation — the whole
+// reason this is unit-testable.
+func scoreCandidate(pin acPin, dir string, offset float64, canonicalKind string, scene acScene, rules autoconnectRules) acCandidate {
+	endX, endY := endpointFor(pin.X, pin.Y, offset, dir)
+	lbl := labelBox(endX, endY)
+	var reasons []acReason
+
+	// +10000 endpoint/label overlaps a real part bbox.
+	for _, p := range scene.Parts {
+		if boxesOverlap(lbl, p) {
+			reasons = append(reasons, acReason{costPartOverlap, "label overlaps a part bbox"})
+			break
+		}
+	}
+
+	// +10000 endpoint/label enters the title-block keep-out (only when applied).
+	if rules.AvoidTitleBlock && scene.TitleBlock != nil && boxesOverlap(lbl, *scene.TitleBlock) {
+		reasons = append(reasons, acReason{costTitleBlock, "label enters title-block keep-out"})
+	}
+
+	// +5000 stub crosses a non-target pin.
+	for _, op := range scene.Pins {
+		if math.Abs(op.X-pin.X) < acCoordEps && math.Abs(op.Y-pin.Y) < acCoordEps {
+			continue // the target pin itself
+		}
+		if pinOnSegment(pin.X, pin.Y, endX, endY, op.X, op.Y) {
+			reasons = append(reasons, acReason{costPinCross, "stub crosses a non-target pin"})
+			break
+		}
+	}
+
+	// +1000 endpoint/label collides with an existing flag/port/label.
+	for _, f := range scene.Flags {
+		if boxesOverlap(lbl, f) {
+			reasons = append(reasons, acReason{costFlagCollision, "label collides with an existing flag/port/label"})
+			break
+		}
+	}
+
+	// +500 stub passes through another component bbox.
+	for _, p := range scene.Parts {
+		if segHitsRect(pin.X, pin.Y, endX, endY, p) {
+			reasons = append(reasons, acReason{costThroughPart, "stub passes through a component bbox"})
+			break
+		}
+	}
+
+	// +100 too close to a preserved fanout channel (a nearby non-target pin the
+	// stub runs alongside without crossing).
+	if rules.AvoidPinFanout {
+		for _, op := range scene.Pins {
+			if math.Abs(op.X-pin.X) < acCoordEps && math.Abs(op.Y-pin.Y) < acCoordEps {
+				continue
+			}
+			if pinOnSegment(pin.X, pin.Y, endX, endY, op.X, op.Y) {
+				continue // already counted as a crossing
+			}
+			if d := pointSegDist(pin.X, pin.Y, endX, endY, op.X, op.Y); d > acCoordEps && d < rules.MinLabelGap {
+				reasons = append(reasons, acReason{costFanoutChannel, "stub runs close to a pin fanout channel"})
+				break
+			}
+		}
+	}
+
+	// +offset * 0.1 — prefer shorter stubs.
+	reasons = append(reasons, acReason{round2(offset * costOffsetPerUnit), "offset cost"})
+
+	// -20 direction matches the pin's outward side.
+	if outwardDirection(pin) == dir {
+		reasons = append(reasons, acReason{bonusOutwardSide, "matches pin outward side"})
+	}
+	// -10 direction matches the kind default.
+	if kindDefaultDirection(canonicalKind) == dir {
+		reasons = append(reasons, acReason{bonusKindDefault, "matches kind default direction"})
+	}
+
+	var score float64
+	for _, r := range reasons {
+		score += r.Cost
+	}
+	return acCandidate{
+		Direction: dir,
+		Offset:    offset,
+		EndPoint:  acPoint{X: round2(endX), Y: round2(endY)},
+		Score:     round2(score),
+		Reasons:   reasons,
+	}
+}
+
+// candidateOffsets enumerates offsets from OffsetMin to OffsetMax stepping by
+// OffsetStep (inclusive of OffsetMax). Deterministic, ascending.
+func candidateOffsets(rules autoconnectRules) []float64 {
+	min, max, step := rules.OffsetMin, rules.OffsetMax, rules.OffsetStep
+	if step <= 0 {
+		step = 6
+	}
+	if max < min {
+		max = min
+	}
+	var out []float64
+	for o := min; o <= max+acOverlapEps; o += step {
+		out = append(out, round2(o))
+	}
+	if len(out) == 0 {
+		out = []float64{min}
+	}
+	return out
+}
+
+var acDirections = []string{"up", "down", "left", "right"}
+
+// planConnection enumerates every (direction × offset) candidate, scores them,
+// and returns them sorted best-first. Deterministic tie-break: score asc, then
+// direction lexical (down<left<right<up), then offset asc — so the same scene +
+// spec always yields the same selection (acceptance: "deterministic result").
+func planConnection(pin acPin, canonicalKind string, scene acScene, rules autoconnectRules) []acCandidate {
+	offsets := candidateOffsets(rules)
+	all := make([]acCandidate, 0, len(acDirections)*len(offsets))
+	for _, dir := range acDirections {
+		for _, off := range offsets {
+			all = append(all, scoreCandidate(pin, dir, off, canonicalKind, scene, rules))
+		}
+	}
+	sort.SliceStable(all, func(i, j int) bool {
+		if all[i].Score != all[j].Score {
+			return all[i].Score < all[j].Score
+		}
+		if all[i].Direction != all[j].Direction {
+			return all[i].Direction < all[j].Direction
+		}
+		return all[i].Offset < all[j].Offset
+	})
+	return all
+}
+
+// dominantReason picks the most expensive penalty for a rejected candidate's
+// human summary; falls back to a generic note when nothing was penalized.
+func dominantReason(c acCandidate) string {
+	best := ""
+	var bestCost float64
+	for _, r := range c.Reasons {
+		if r.Cost > bestCost {
+			bestCost = r.Cost
+			best = r.Desc
+		}
+	}
+	if best == "" {
+		return "higher total cost (longer offset / non-default direction)"
+	}
+	return best
+}

--- a/internal/app/cmd_sch_autoconnect_run.go
+++ b/internal/app/cmd_sch_autoconnect_run.go
@@ -1,0 +1,473 @@
+package app
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// ── autoconnect orchestration (I/O side; the scorer in cmd_sch_autoconnect.go is pure) ──
+
+// acSpec is the batch `--spec` JSON shape (issue #24).
+type acSpec struct {
+	Connections []acSpecConn `json:"connections"`
+	Rules       *acSpecRules `json:"rules"`
+}
+
+type acSpecConn struct {
+	Pin  string   `json:"pin"`
+	X    *float64 `json:"x"`
+	Y    *float64 `json:"y"`
+	Kind string   `json:"kind"`
+	Net  string   `json:"net"`
+}
+
+// acSpecRules mirrors the rules block; pointer fields so an omitted key keeps the
+// default instead of zeroing it.
+type acSpecRules struct {
+	AvoidTitleBlock *bool     `json:"avoidTitleBlock"`
+	AvoidPinFanout  *bool     `json:"avoidPinFanout"`
+	StaggerLabels   *bool     `json:"staggerLabels"`
+	OffsetRange     []float64 `json:"offsetRange"`
+	OffsetStep      *float64  `json:"offsetStep"`
+	MinLabelGap     *float64  `json:"minLabelGap"`
+}
+
+// applyTo overlays the spec's rules onto a base ruleset.
+func (r *acSpecRules) applyTo(base autoconnectRules) autoconnectRules {
+	if r == nil {
+		return base
+	}
+	if r.AvoidTitleBlock != nil {
+		base.AvoidTitleBlock = *r.AvoidTitleBlock
+	}
+	if r.AvoidPinFanout != nil {
+		base.AvoidPinFanout = *r.AvoidPinFanout
+	}
+	if r.StaggerLabels != nil {
+		base.StaggerLabels = *r.StaggerLabels
+	}
+	if len(r.OffsetRange) == 2 {
+		base.OffsetMin, base.OffsetMax = r.OffsetRange[0], r.OffsetRange[1]
+	}
+	if r.OffsetStep != nil {
+		base.OffsetStep = *r.OffsetStep
+	}
+	if r.MinLabelGap != nil {
+		base.MinLabelGap = *r.MinLabelGap
+	}
+	return base
+}
+
+// acConnSpec is the normalized form of one connection to plan, after merging CLI
+// flags / spec entries.
+type acConnSpec struct {
+	PinRef string   // "U1:41" (for reporting / coordinate resolution); empty when explicit coords given
+	X, Y   *float64 // explicit coordinate override
+	Kind   string   // raw CLI/spec kind ("gnd", "power", "netport", …)
+	Net    string
+}
+
+// acConnResult is the per-connection output (issue #24 result shape).
+type acConnResult struct {
+	Pin             string       `json:"pin,omitempty"`
+	Net             string       `json:"net"`
+	Kind            string       `json:"kind"`
+	PinX            float64      `json:"pinX"`
+	PinY            float64      `json:"pinY"`
+	Selected        *acCandidate `json:"selected,omitempty"`
+	Rejected        []acRejected `json:"rejected,omitempty"`
+	WirePrimitiveID string       `json:"wirePrimitiveId,omitempty"`
+	FlagPrimitiveID string       `json:"flagPrimitiveId,omitempty"`
+	DryRun          bool         `json:"dryRun,omitempty"`
+	Error           string       `json:"error,omitempty"`
+}
+
+type acRejected struct {
+	Direction string  `json:"direction"`
+	Offset    float64 `json:"offset"`
+	Score     float64 `json:"score"`
+	Reason    string  `json:"reason"`
+}
+
+// acReport is the whole autoconnect run.
+type acReport struct {
+	OK                    bool           `json:"ok"`
+	Connections           []acConnResult `json:"connections"`
+	TitleBlockProvisional bool           `json:"titleBlockProvisional,omitempty"`
+	Note                  string         `json:"note,omitempty"`
+}
+
+// buildScene pulls real geometry from schematic.components.list and assembles the
+// scoring scene: part bboxes, every pin (tagged with owner), existing flag/port/
+// label bboxes, and a title-block keep-out derived from the sheet bbox (or a
+// reported provisional fallback when no sheet bbox is exposed).
+func buildScene(result map[string]any) acScene {
+	scene := acScene{}
+	raw, _ := result["components"].([]any)
+	var sheet *layoutBBox
+	for _, item := range raw {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		ctype := asString(m["componentType"])
+		var box *layoutBBox
+		if bm, ok := m["bbox"].(map[string]any); ok {
+			box = &layoutBBox{
+				MinX: asFloat(bm["minX"]), MinY: asFloat(bm["minY"]),
+				MaxX: asFloat(bm["maxX"]), MaxY: asFloat(bm["maxY"]),
+			}
+		}
+		switch ctype {
+		case "part", "":
+			if box != nil {
+				scene.Parts = append(scene.Parts, *box)
+			}
+			designator := asString(m["designator"])
+			if pins, ok := m["pins"].([]any); ok {
+				for _, pp := range pins {
+					pm, ok := pp.(map[string]any)
+					if !ok {
+						continue
+					}
+					scene.Pins = append(scene.Pins, acPin{
+						X:          asFloat(pm["x"]),
+						Y:          asFloat(pm["y"]),
+						Designator: designator,
+						PinNumber:  asString(pm["pinNumber"]),
+						PinName:    asString(pm["pinName"]),
+						OwnerBBox:  box,
+					})
+				}
+			}
+		case "netflag", "netport", "netlabel":
+			if box != nil {
+				scene.Flags = append(scene.Flags, *box)
+			}
+		case "sheet":
+			if box != nil {
+				sheet = box
+			}
+		}
+	}
+	scene.TitleBlock, scene.TitleBlockProvisional = titleBlockKeepout(sheet)
+	return scene
+}
+
+// titleBlockKeepout derives the title-block keep-out. EasyEDA's 明细表/图框 sits in
+// the BOTTOM-RIGHT corner (y-DOWN: larger y is lower). When the sheet bbox is
+// known we carve a corner sub-rect from it; when it is NOT exposed we report a
+// provisional fallback and apply NO geometric penalty (returning nil), so a
+// guessed absolute box can't corrupt scoring — the caller still surfaces
+// `titleBlockProvisional` so a human knows the keep-out was not enforced.
+func titleBlockKeepout(sheet *layoutBBox) (*layoutBBox, bool) {
+	if sheet == nil {
+		return nil, true // provisional: not applied
+	}
+	w := sheet.MaxX - sheet.MinX
+	h := sheet.MaxY - sheet.MinY
+	// Bottom-right corner: rightmost ~22% width × bottom ~14% height — the usual
+	// EasyEDA A-series title block footprint.
+	return &layoutBBox{
+		MinX: sheet.MaxX - 0.22*w,
+		MinY: sheet.MaxY - 0.14*h,
+		MaxX: sheet.MaxX,
+		MaxY: sheet.MaxY,
+	}, false
+}
+
+// resolvePinCoord finds a pin's coordinate from a "designator:pinNumberOrName"
+// reference against the scene's pins.
+func resolvePinCoord(scene acScene, ref string) (acPin, error) {
+	parts := strings.SplitN(ref, ":", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return acPin{}, fmt.Errorf("invalid --pin %q; expected DESIGNATOR:PIN, e.g. U1:41 or U1:3V3", ref)
+	}
+	desig, token := parts[0], parts[1]
+	var matches []acPin
+	for _, p := range scene.Pins {
+		if p.Designator == desig && (p.PinNumber == token || p.PinName == token) {
+			matches = append(matches, p)
+		}
+	}
+	switch len(matches) {
+	case 1:
+		return matches[0], nil
+	case 0:
+		return acPin{}, fmt.Errorf("no pin %q found (component %q not placed, or pin number/name mismatch — check `easyeda sch list --include-pins`)", ref, desig)
+	default:
+		return acPin{}, fmt.Errorf("pin reference %q is ambiguous (%d matches); use the pin NUMBER instead of name", ref, len(matches))
+	}
+}
+
+// runAutoconnect is the command core: build the scene once, then plan → (dispatch)
+// each connection sequentially, staggering later labels off earlier placements.
+func runAutoconnect(cfg *appConfig, window string, conns []acConnSpec, rules autoconnectRules, allPages, dryRun, asJSON bool, stdout, stderr io.Writer) error {
+	res, err := requestAction(cfg, "schematic.components.list", window, map[string]any{
+		"includeBBox": true,
+		"includePins": true,
+		"allPages":    allPages,
+	})
+	if err != nil {
+		return err
+	}
+	scene := buildScene(res.Result)
+
+	report := acReport{OK: true, TitleBlockProvisional: scene.TitleBlockProvisional}
+	if scene.TitleBlockProvisional && rules.AvoidTitleBlock {
+		report.Note = "no sheet bbox exposed — title-block keep-out is provisional and was NOT geometrically enforced"
+	}
+
+	for _, c := range conns {
+		cr := acConnResult{Net: c.Net, Kind: c.Kind, DryRun: dryRun}
+
+		canonicalKind, kerr := resolveNetflagKind(c.Kind)
+		if kerr != nil {
+			cr.Error = kerr.Error()
+			report.OK = false
+			report.Connections = append(report.Connections, cr)
+			continue
+		}
+
+		// Resolve pin coordinate: explicit --x/--y wins; else designator:pin.
+		var pin acPin
+		if c.X != nil && c.Y != nil {
+			pin = acPin{X: *c.X, Y: *c.Y}
+		} else if c.PinRef != "" {
+			cr.Pin = c.PinRef
+			p, perr := resolvePinCoord(scene, c.PinRef)
+			if perr != nil {
+				cr.Error = perr.Error()
+				report.OK = false
+				report.Connections = append(report.Connections, cr)
+				continue
+			}
+			pin = p
+		} else {
+			cr.Error = "no pin coordinate: pass --pin DESIGNATOR:PIN or both --x and --y"
+			report.OK = false
+			report.Connections = append(report.Connections, cr)
+			continue
+		}
+		cr.PinX, cr.PinY = pin.X, pin.Y
+
+		all := planConnection(pin, canonicalKind, scene, rules)
+		selected := all[0]
+		cr.Selected = &selected
+		cr.Rejected = summarizeRejected(all, selected)
+
+		if !dryRun {
+			payload := map[string]any{
+				"pinX":      pin.X,
+				"pinY":      pin.Y,
+				"kind":      canonicalKind,
+				"net":       c.Net,
+				"direction": selected.Direction,
+				"offset":    selected.Offset,
+			}
+			cres, cerr := requestAction(cfg, "schematic.power.connect_pin", window, payload)
+			if cerr != nil {
+				cr.Error = cerr.Error()
+				report.OK = false
+				report.Connections = append(report.Connections, cr)
+				continue
+			}
+			cr.WirePrimitiveID = asString(cres.Result["wirePrimitiveId"])
+			cr.FlagPrimitiveID = asString(cres.Result["flagPrimitiveId"])
+		}
+
+		// Stagger: register the just-placed label so later connections in this
+		// batch avoid stacking on it (clustered-pin staggering).
+		if rules.StaggerLabels {
+			scene.Flags = append(scene.Flags, labelBox(selected.EndPoint.X, selected.EndPoint.Y))
+		}
+
+		report.Connections = append(report.Connections, cr)
+	}
+
+	if asJSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(report); err != nil {
+			return err
+		}
+	} else {
+		renderAutoconnectReport(report, dryRun, stdout)
+	}
+	if !report.OK {
+		return fmt.Errorf("autoconnect: %d connection(s) failed", countFailed(report))
+	}
+	return nil
+}
+
+// summarizeRejected returns the best-scoring candidate of each direction OTHER
+// than the selected one, with its dominant reason — compact but representative.
+func summarizeRejected(all []acCandidate, selected acCandidate) []acRejected {
+	seen := map[string]bool{selected.Direction: true}
+	var out []acRejected
+	for _, c := range all {
+		if seen[c.Direction] {
+			continue
+		}
+		seen[c.Direction] = true
+		out = append(out, acRejected{
+			Direction: c.Direction,
+			Offset:    c.Offset,
+			Score:     c.Score,
+			Reason:    dominantReason(c),
+		})
+	}
+	return out
+}
+
+func countFailed(r acReport) int {
+	n := 0
+	for _, c := range r.Connections {
+		if c.Error != "" {
+			n++
+		}
+	}
+	return n
+}
+
+func renderAutoconnectReport(r acReport, dryRun bool, w io.Writer) {
+	mode := "connect"
+	if dryRun {
+		mode = "plan (dry-run)"
+	}
+	fmt.Fprintf(w, "autoconnect: %d connection(s), mode=%s\n", len(r.Connections), mode)
+	if r.Note != "" {
+		fmt.Fprintf(w, "  note: %s\n", r.Note)
+	}
+	for _, c := range r.Connections {
+		id := c.Pin
+		if id == "" {
+			id = fmt.Sprintf("(%.2f,%.2f)", c.PinX, c.PinY)
+		}
+		if c.Error != "" {
+			fmt.Fprintf(w, "  ✗ %s → %s [%s]: %s\n", id, c.Net, c.Kind, c.Error)
+			continue
+		}
+		s := c.Selected
+		fmt.Fprintf(w, "  ✓ %s → %s [%s]: %s offset=%.0f end=(%.2f,%.2f) score=%.2f\n",
+			id, c.Net, c.Kind, s.Direction, s.Offset, s.EndPoint.X, s.EndPoint.Y, s.Score)
+		if !dryRun {
+			fmt.Fprintf(w, "      wire=%s flag=%s\n", c.WirePrimitiveID, c.FlagPrimitiveID)
+		}
+		for _, rj := range c.Rejected {
+			fmt.Fprintf(w, "      rejected %-5s offset=%.0f score=%.2f — %s\n", rj.Direction, rj.Offset, rj.Score, rj.Reason)
+		}
+	}
+}
+
+// newAutoconnectCmd builds the `sch autoconnect` subcommand.
+func newAutoconnectCmd(cfg *appConfig, window *string, stdout, stderr io.Writer) *cobra.Command {
+	var (
+		pin, kind, net, spec         string
+		x, y                         float64
+		avoidTitleBlock, avoidFanout bool
+		offsetMin, offsetMax, step   float64
+		allPages, dryRun, asJSON     bool
+	)
+	c := &cobra.Command{
+		Use:   "autoconnect",
+		Short: "Pin-aware planner: auto-pick direction/offset and connect a pin (or batch) to a flag/netport",
+		Long: `Pin-aware autoconnect planner.
+
+connect_pin already guarantees the structural safety (pin → short wire →
+flag/netport, so a netflag never sits on a bare pin and trips DRC). autoconnect
+removes the remaining judgment call — which direction and offset — by turning it
+into a deterministic geometry decision:
+
+  1. Resolve the pin coordinate (DESIGNATOR:PIN, or explicit --x/--y).
+  2. Enumerate every direction (up/down/left/right) × offset candidate.
+  3. Score each against real geometry: part bboxes, pin coordinates, existing
+     flag/port/label bboxes, and the title-block keep-out.
+  4. Pick the lowest-cost candidate (deterministic tie-break) and delegate the
+     actual mutation to connect_pin.
+
+The scorer is pure and deterministic: the same schematic state + spec always
+yields the same selection. Use --dry-run to see the plan (and rejected options)
+without mutating.`,
+		Args: cobra.NoArgs,
+		Example: `  easyeda sch autoconnect --pin U1:41 --kind gnd --net GND
+  easyeda sch autoconnect --x 720 --y 670 --kind gnd --net GND
+  easyeda sch autoconnect --pin U1:3V3 --kind power --net +3V3 --dry-run
+  easyeda sch autoconnect --spec p1-connect.json --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rules := defaultAutoconnectRules()
+			if cmd.Flags().Changed("avoid-titleblock") {
+				rules.AvoidTitleBlock = avoidTitleBlock
+			}
+			if cmd.Flags().Changed("avoid-pin-fanout") {
+				rules.AvoidPinFanout = avoidFanout
+			}
+			if cmd.Flags().Changed("offset-min") {
+				rules.OffsetMin = offsetMin
+			}
+			if cmd.Flags().Changed("offset-max") {
+				rules.OffsetMax = offsetMax
+			}
+			if cmd.Flags().Changed("offset-step") {
+				rules.OffsetStep = step
+			}
+
+			var conns []acConnSpec
+			if spec != "" {
+				raw, err := os.ReadFile(spec)
+				if err != nil {
+					return fmt.Errorf("read --spec: %w", err)
+				}
+				var s acSpec
+				if err := json.Unmarshal(raw, &s); err != nil {
+					return fmt.Errorf("invalid --spec json: %w", err)
+				}
+				if len(s.Connections) == 0 {
+					return fmt.Errorf("--spec has no connections")
+				}
+				rules = s.Rules.applyTo(rules)
+				for _, sc := range s.Connections {
+					if sc.Kind == "" || sc.Net == "" {
+						return fmt.Errorf("each spec connection needs kind and net (got pin=%q)", sc.Pin)
+					}
+					conns = append(conns, acConnSpec{PinRef: sc.Pin, X: sc.X, Y: sc.Y, Kind: sc.Kind, Net: sc.Net})
+				}
+			} else {
+				if kind == "" || net == "" {
+					return fmt.Errorf("--kind and --net are required (or use --spec)")
+				}
+				cs := acConnSpec{Kind: kind, Net: net}
+				if pin != "" {
+					cs.PinRef = pin
+				} else if cmd.Flags().Changed("x") && cmd.Flags().Changed("y") {
+					cs.X, cs.Y = &x, &y
+				} else {
+					return fmt.Errorf("pass --pin DESIGNATOR:PIN or both --x and --y")
+				}
+				conns = append(conns, cs)
+			}
+
+			return runAutoconnect(cfg, *window, conns, rules, allPages, dryRun, asJSON, stdout, stderr)
+		},
+	}
+	c.Flags().StringVar(&pin, "pin", "", "pin reference DESIGNATOR:PIN (number or name), e.g. U1:41 or U1:3V3")
+	c.Flags().Float64Var(&x, "x", 0, "explicit pin X coordinate (use with --y instead of --pin)")
+	c.Flags().Float64Var(&y, "y", 0, "explicit pin Y coordinate (use with --x instead of --pin)")
+	c.Flags().StringVar(&kind, "kind", "", netflagKindHelp)
+	c.Flags().StringVar(&net, "net", "", "net name")
+	c.Flags().StringVar(&spec, "spec", "", "batch spec JSON file ({connections:[...], rules:{...}})")
+	c.Flags().BoolVar(&avoidTitleBlock, "avoid-titleblock", true, "penalize candidates whose label enters the title-block keep-out")
+	c.Flags().BoolVar(&avoidFanout, "avoid-pin-fanout", true, "penalize candidates that run close to a pin fanout channel")
+	c.Flags().Float64Var(&offsetMin, "offset-min", 18, "minimum stub offset to consider")
+	c.Flags().Float64Var(&offsetMax, "offset-max", 80, "maximum stub offset to consider")
+	c.Flags().Float64Var(&step, "offset-step", 6, "offset increment")
+	c.Flags().BoolVar(&allPages, "all-pages", false, "build the scene from all schematic pages")
+	c.Flags().BoolVar(&dryRun, "dry-run", false, "plan and print the selection without mutating")
+	c.Flags().BoolVar(&asJSON, "json", false, "emit the report as JSON")
+	return c
+}

--- a/internal/app/cmd_sch_autoconnect_test.go
+++ b/internal/app/cmd_sch_autoconnect_test.go
@@ -1,0 +1,208 @@
+package app
+
+import "testing"
+
+// clearScene is an empty world: no parts, pins, flags, or title block. A pin in
+// open space — every penalty is zero, so only offset cost + direction bonuses
+// drive selection.
+func clearScene() acScene { return acScene{} }
+
+func rulesFor() autoconnectRules { return defaultAutoconnectRules() }
+
+func TestEndpointFor_MatchesConnectorYDown(t *testing.T) {
+	cases := []struct {
+		dir   string
+		wantX float64
+		wantY float64
+	}{
+		{"up", 100, 70},    // y decreases
+		{"down", 100, 130}, // y increases
+		{"left", 70, 100},  // x decreases
+		{"right", 130, 100},
+	}
+	for _, c := range cases {
+		x, y := endpointFor(100, 100, 30, c.dir)
+		if x != c.wantX || y != c.wantY {
+			t.Errorf("dir %s: got (%.0f,%.0f), want (%.0f,%.0f)", c.dir, x, y, c.wantX, c.wantY)
+		}
+	}
+}
+
+func TestPlanConnection_GroundPrefersDownShortest(t *testing.T) {
+	// A pin below its owner center → outward = down; kind gnd default = down.
+	// Both bonuses stack on 'down', and the shortest offset wins ties.
+	pin := acPin{X: 100, Y: 200, OwnerBBox: bb(80, 150, 120, 190)}
+	all := planConnection(pin, "ground", clearScene(), rulesFor())
+	sel := all[0]
+	if sel.Direction != "down" {
+		t.Fatalf("expected down (outward + kind default), got %s", sel.Direction)
+	}
+	if sel.Offset != 18 {
+		t.Errorf("expected shortest offset 18, got %.0f", sel.Offset)
+	}
+	// down should score below any up candidate (up gets neither bonus here).
+	for _, c := range all {
+		if c.Direction == "up" && c.Offset == sel.Offset && c.Score <= sel.Score {
+			t.Errorf("up should cost more than down at equal offset: down=%.2f up=%.2f", sel.Score, c.Score)
+		}
+	}
+}
+
+func TestScoreCandidate_PartOverlapDominates(t *testing.T) {
+	// A part bbox sits right where the 'down' endpoint would land → +10000.
+	pin := acPin{X: 100, Y: 100}
+	scene := acScene{Parts: []layoutBBox{bb(90, 115, 110, 135).deref()}}
+	c := scoreCandidate(pin, "down", 24, "ground", scene, rulesFor())
+	if c.Score < costPartOverlap {
+		t.Fatalf("expected part-overlap penalty (>=%d), got %.2f", costPartOverlap, c.Score)
+	}
+}
+
+func TestScoreCandidate_StubCrossesPin(t *testing.T) {
+	pin := acPin{X: 100, Y: 100}
+	// Another pin sits on the downward stub path (x=100, between y=100 and 130).
+	scene := acScene{Pins: []acPin{{X: 100, Y: 115, Designator: "U2", PinNumber: "1"}}}
+	c := scoreCandidate(pin, "down", 30, "ground", scene, rulesFor())
+	hasCross := false
+	for _, r := range c.Reasons {
+		if r.Cost == costPinCross {
+			hasCross = true
+		}
+	}
+	if !hasCross {
+		t.Fatalf("expected a pin-cross penalty, reasons=%+v", c.Reasons)
+	}
+}
+
+func TestPlanConnection_AvoidsOverlappingDirection(t *testing.T) {
+	// A wall of parts blocks 'down'; 'up' is clear. Planner must not pick down.
+	pin := acPin{X: 100, Y: 100}
+	scene := acScene{Parts: []layoutBBox{bb(80, 110, 120, 200).deref()}}
+	all := planConnection(pin, "ground", scene, rulesFor())
+	if all[0].Direction == "down" {
+		t.Fatalf("planner chose blocked direction down; scene=%+v score=%.2f", scene, all[0].Score)
+	}
+}
+
+func TestPlanConnection_Deterministic(t *testing.T) {
+	pin := acPin{X: 100, Y: 100, OwnerBBox: bb(80, 80, 120, 95)}
+	a := planConnection(pin, "power", clearScene(), rulesFor())
+	b := planConnection(pin, "power", clearScene(), rulesFor())
+	if len(a) != len(b) {
+		t.Fatalf("candidate count differs: %d vs %d", len(a), len(b))
+	}
+	for i := range a {
+		if a[i].Direction != b[i].Direction || a[i].Offset != b[i].Offset || a[i].Score != b[i].Score {
+			t.Fatalf("non-deterministic at %d: %+v vs %+v", i, a[i], b[i])
+		}
+	}
+}
+
+func TestPlanConnection_TieBreakStable(t *testing.T) {
+	// No geometry, no owner bbox, kind with default 'down' → 'down' wins its
+	// bonus, but among the OTHER three directions (all equal score per offset)
+	// the lexical tie-break must order down<left<right<up. Confirm offsets too:
+	// shortest first within a direction.
+	pin := acPin{X: 0, Y: 0}
+	all := planConnection(pin, "ground", clearScene(), rulesFor())
+	if all[0].Direction != "down" || all[0].Offset != 18 {
+		t.Fatalf("expected down@18 first, got %s@%.0f", all[0].Direction, all[0].Offset)
+	}
+	// Every 'down' candidate (cheapest direction) should precede the first
+	// non-down candidate.
+	firstNonDown := -1
+	for i, c := range all {
+		if c.Direction != "down" {
+			firstNonDown = i
+			break
+		}
+	}
+	for i := 0; i < firstNonDown; i++ {
+		if all[i].Direction != "down" {
+			t.Fatalf("down block broken at %d: %s", i, all[i].Direction)
+		}
+	}
+}
+
+func TestCandidateOffsets_InclusiveRange(t *testing.T) {
+	got := candidateOffsets(autoconnectRules{OffsetMin: 18, OffsetMax: 80, OffsetStep: 6})
+	if got[0] != 18 {
+		t.Errorf("first offset want 18, got %.0f", got[0])
+	}
+	last := got[len(got)-1]
+	if last > 80 || last < 74 {
+		t.Errorf("last offset should approach 80, got %.0f", last)
+	}
+}
+
+func TestResolvePinCoord(t *testing.T) {
+	scene := acScene{Pins: []acPin{
+		{X: 10, Y: 20, Designator: "U1", PinNumber: "41", PinName: "GND"},
+		{X: 30, Y: 40, Designator: "U1", PinNumber: "3", PinName: "3V3"},
+	}}
+	// by number
+	p, err := resolvePinCoord(scene, "U1:41")
+	if err != nil || p.X != 10 || p.Y != 20 {
+		t.Fatalf("U1:41 → %+v err=%v", p, err)
+	}
+	// by name
+	p, err = resolvePinCoord(scene, "U1:3V3")
+	if err != nil || p.X != 30 {
+		t.Fatalf("U1:3V3 → %+v err=%v", p, err)
+	}
+	// not found
+	if _, err := resolvePinCoord(scene, "U9:1"); err == nil {
+		t.Error("expected error for missing pin")
+	}
+	// malformed
+	if _, err := resolvePinCoord(scene, "U1"); err == nil {
+		t.Error("expected error for malformed ref")
+	}
+}
+
+func TestBuildScene_ClassifiesPrimitives(t *testing.T) {
+	result := map[string]any{"components": []any{
+		map[string]any{
+			"componentType": "part", "designator": "U1",
+			"bbox": map[string]any{"minX": 0.0, "minY": 0.0, "maxX": 10.0, "maxY": 10.0},
+			"pins": []any{
+				map[string]any{"pinNumber": "1", "pinName": "VCC", "x": 0.0, "y": 5.0},
+			},
+		},
+		map[string]any{
+			"componentType": "netflag",
+			"bbox":          map[string]any{"minX": 50.0, "minY": 50.0, "maxX": 54.0, "maxY": 54.0},
+		},
+		map[string]any{
+			"componentType": "sheet",
+			"bbox":          map[string]any{"minX": -100.0, "minY": -100.0, "maxX": 400.0, "maxY": 300.0},
+		},
+	}}
+	scene := buildScene(result)
+	if len(scene.Parts) != 1 {
+		t.Errorf("expected 1 part bbox, got %d", len(scene.Parts))
+	}
+	if len(scene.Pins) != 1 || scene.Pins[0].Designator != "U1" || scene.Pins[0].OwnerBBox == nil {
+		t.Errorf("pin not attached to owner: %+v", scene.Pins)
+	}
+	if len(scene.Flags) != 1 {
+		t.Errorf("expected 1 flag bbox, got %d", len(scene.Flags))
+	}
+	if scene.TitleBlock == nil || scene.TitleBlockProvisional {
+		t.Errorf("title block keep-out should be derived from sheet, got tb=%+v prov=%v", scene.TitleBlock, scene.TitleBlockProvisional)
+	}
+}
+
+func TestBuildScene_ProvisionalWhenNoSheet(t *testing.T) {
+	result := map[string]any{"components": []any{
+		map[string]any{"componentType": "part", "designator": "R1",
+			"bbox": map[string]any{"minX": 0.0, "minY": 0.0, "maxX": 5.0, "maxY": 5.0}},
+	}}
+	scene := buildScene(result)
+	if scene.TitleBlock != nil || !scene.TitleBlockProvisional {
+		t.Errorf("no sheet → provisional & no enforced keep-out, got tb=%+v prov=%v", scene.TitleBlock, scene.TitleBlockProvisional)
+	}
+}
+
+// deref is a tiny test helper: turn the *layoutBBox from bb() into a value.
+func (p *layoutBBox) deref() layoutBBox { return *p }

--- a/skills/easyeda-design-flow/SKILL.md
+++ b/skills/easyeda-design-flow/SKILL.md
@@ -53,6 +53,7 @@ S0 预分析 → S1 分页💾 → S2 模块编组 → S3 按组摆放💾 → S
 ### S4 — 通道布线(留距离,别压元件)
 - **做什么**:在组**摆放并通过 layout-lint 之后**再布线——信号走元件间的**空通道**,不要让导线压在元件或外围上。
 - **怎么做**:布线/flag/去耦规则见 conventions 的 `auto-layout-sop.md`(信号=本地正交线、flag 仅电源地、绝不穿引脚)。
+- **电源/地/netport stub 用 `easyeda sch autoconnect`**(别再手猜 `connect --direction/--offset`):它按真实 bbox/引脚/已有 flag 几何打分,确定性选 direction+offset 再委托 `connect_pin` 落地,批量 `--spec` 还会自动错开标签。先 `--dry-run` 看计划,满意再落地。
 - **💾 过门后**:`easyeda sch save` 存盘,再进入 S5。
 
 ### S5 — 校验门(机械真值,不是肉眼)

--- a/skills/easyeda-schematic/SKILL.md
+++ b/skills/easyeda-schematic/SKILL.md
@@ -114,6 +114,45 @@ above doesn't scale. Pipeline (proven on box-v2/110 parts):
 > (long calls die to the heartbeat); heavy-retry + incremental `sch save` per chunk;
 > re-pull fresh pids each chunk.
 
+## Pin-aware autoconnect — let the planner pick direction/offset
+
+`connect_pin` (`sch connect`) keeps the connection **safe** (pin → short wire →
+flag/netport, never a netflag on a bare pin), but it still makes YOU pick
+`--direction` and `--offset`, so layout quality depends on judgment. **`sch
+autoconnect` removes that judgment**: it pulls the real geometry (part bboxes,
+pin coords, existing flag/port/label bboxes, title-block keep-out), scores every
+`up/down/left/right × offset` candidate with a deterministic cost function (part
+overlap / title-block / pin-crossing / flag-collision / through-part penalties,
+shortest-offset + outward-side + kind-default bonuses), picks the lowest-cost
+one, and delegates the mutation to `connect_pin`. Same schematic state + spec →
+same selection (deterministic).
+
+```bash
+# single pin by designator:pin (number OR name)
+easyeda sch autoconnect --pin U1:41 --kind gnd --net GND
+easyeda sch autoconnect --pin U1:3V3 --kind power --net +3V3
+
+# explicit coordinates (compat with existing flows)
+easyeda sch autoconnect --x 720 --y 670 --kind gnd --net GND
+
+# preview the plan + rejected options WITHOUT mutating
+easyeda sch autoconnect --pin U1:41 --kind gnd --net GND --dry-run --json
+
+# batch spec — clustered pins auto-stagger so labels don't stack
+easyeda sch autoconnect --spec p1-connect.json
+```
+
+Spec JSON (`--spec`): `{"connections":[{"pin":"U1:41","kind":"gnd","net":"GND"},
+{"pin":"U1:3V3","kind":"power","net":"+3V3"}], "rules":{"avoidTitleBlock":true,
+"avoidPinFanout":true,"staggerLabels":true,"offsetRange":[18,80],"offsetStep":6,
+"minLabelGap":12}}`. Each result reports the `selected` candidate (direction /
+offset / endPoint / score), the `rejected` alternatives with reasons, and the
+`wirePrimitiveId` / `flagPrimitiveId`. When the sheet bbox isn't exposed, the
+title-block keep-out is reported as **provisional** and not geometrically
+enforced (so a guessed box can't corrupt scoring). **Prefer `sch autoconnect`
+over hand-picking `sch connect --direction/--offset`** for power/ground/netport
+stubs; `sch connect` stays for when you deliberately override the geometry.
+
 ## Actions
 
 Run `easyeda actions` for the current machine-readable action list.


### PR DESCRIPTION
Fixes #24

## 做了什么

新增 `easyeda sch autoconnect` —— 一个**确定性几何规划层**,自动为引脚的 flag/netport stub 选最佳 `direction` + `offset`,再委托既有 `schematic.power.connect_pin` 落地。把过去让调用方手猜 `--direction/--offset`(布局质量依赖 AI/人工判断)变成纯几何决策。

架构上完全契合现有模式:纯 Go scorer 仿照 `cmd_sch_layout.go::analyzeLayout`(拉真实 bbox → 纯 pairwise 几何 → 确定性输出),复用 `schematic.components.list(includeBBox,includePins)` 数据面,最终 dispatch 到已验证的 `connect_pin` —— **不新增连接器 action、无新依赖**。

## 主要改动

- **纯 scorer**(`cmd_sch_autoconnect.go`):枚举 `up/down/left/right × offset` 候选,按 issue 成本表打分(器件重叠/标题栏/穿引脚/flag 碰撞/穿器件 体罚 + 最短 offset/外向侧/kind 默认 加分),确定性 tie-break(分数 → direction 字典序 → offset)。无 I/O,纯函数可单测。端点映射与连接器 y-DOWN 公式严格一致。
- **编排**(`cmd_sch_autoconnect_run.go`):构建场景(part bbox / 全部引脚带 owner / 已有 netflag·netport·netlabel bbox / 由 sheet bbox 推导的标题栏 keep-out)→ 解析 `DESIGNATOR:PIN`(编号或名称)或 `--x/--y` → plan → `connect_pin`,批量时逐项把已落标签注册回场景以**自动错开**。无 sheet bbox 时标题栏 keep-out 报为 **provisional 且不几何强制**(避免猜测框污染评分)。
- **三种入口**:单 pin(`--pin` / `--x --y`)、批量 `--spec` JSON;`--dry-run` 只规划不落地;`--json` 输出含 selected + rejected 原因 + wire/flag id。
- **Skill 文档**(首要准则):`easyeda-schematic/SKILL.md` 新增 autoconnect 用法小节;`easyeda-design-flow` S4 通道布线步骤指向 autoconnect。

## 验收对照

- ✅ `sch connect` 行为不变(保留作手动覆盖)。
- ✅ `--pin` 与 `--x/--y` 单 pin 均可。
- ✅ 批量 `--spec` 逐连接返回结果。
- ✅ scorer 候选选择单测覆盖(端点映射/各体罚/确定性/tie-break/offset 范围/pin 解析/场景分类)。
- ✅ 相同状态+spec 确定性输出(`TestPlanConnection_Deterministic`)。
- ✅ Skill 文档已更新示例。

## 测试

- `go build ./...` / `go vet ./internal/app/` / `go test ./...` 全绿。
- ⚠️ **未做的**:CLAUDE.md 的固定端到端用例(ESP32 点灯板)与 testing SOP 需要**已连接的 EasyEDA 窗口**(`允许外部交互`),本无头环境无法连真实 daemon,故 `autoconnect` 对真实工程的活体落地(以及 `sch check` 回归 fixture 的 `wireCrossings==0`)留待有 EasyEDA 窗口的同学跑一遍。纯几何规划核心(本 PR 的新逻辑)已被单测充分覆盖,活体 mutation 仅委托给已验证的 `connect_pin`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)