### PR TITLE
feat(sch): sheet-geometry — normalized sheet/title-block keep-out source

### DIFF
--- a/internal/app/cmd_sch.go
+++ b/internal/app/cmd_sch.go
@@ -834,6 +834,42 @@ Exits non-zero when any overlap is found, so it can gate a workflow.`,
 		sch.AddCommand(c)
 	}
 
+	// ── sheet-geometry ────────────────────────────────────────────────────
+	// Normalized sheet bounds + title-block keep-out (issue #26). The single
+	// source placement/routing planners (autoconnect/autolayout) consume, so A4
+	// coordinates aren't re-hardcoded per tool. Derives the keep-out from the
+	// live sheet bbox + a known-template ratio, with explicit provenance +
+	// warnings (never false precision). Pure core in cmd_sch_sheet.go.
+	{
+		var asJSON bool
+		c := &cobra.Command{
+			Use:   "sheet-geometry",
+			Short: "Report sheet bounds + title-block keep-out geometry (provenance-tagged)",
+			Long: `Report the schematic sheet's bounds and the title-block (图框/明细表) keep-out.
+
+Placement/routing planners must avoid dropping flags or parts on top of the
+title block. EasyEDA Pro exposes no set-paper-size API and no separate bbox for
+the title block, so the geometry is DERIVED:
+
+  • sheet bbox  — live, from the componentType "sheet" primitive
+  • template    — matched best-effort by the sheet's aspect ratio (A-series ≈ √2)
+  • title block — a corner sub-rect from the matched template's normalized ratio
+  • visibility  — schematic.titleblock.get → showTitleBlock (hidden ⇒ no keep-out)
+
+The result tags provenance (known-template-ratio / fallback-ratio / none) and
+emits warnings instead of false precision when geometry can't be determined.
+The keepouts[] format is what sch autoconnect / autolayout consume.`,
+			Args: cobra.NoArgs,
+			Example: `  easyeda sch sheet-geometry
+  easyeda sch sheet-geometry --json`,
+			RunE: func(cmd *cobra.Command, args []string) error {
+				return runSheetGeometry(cfg, window, asJSON, stdout, stderr)
+			},
+		}
+		c.Flags().BoolVar(&asJSON, "json", false, "emit the geometry as JSON")
+		sch.AddCommand(c)
+	}
+
 	// ── autoconnect ───────────────────────────────────────────────────────
 	// Pin-aware deterministic connect planner: pick direction/offset by scoring
 	// real geometry, then delegate to schematic.power.connect_pin. Scorer is pure

--- a/internal/app/cmd_sch_autoconnect_run.go
+++ b/internal/app/cmd_sch_autoconnect_run.go
@@ -159,26 +159,21 @@ func buildScene(result map[string]any) acScene {
 	return scene
 }
 
-// titleBlockKeepout derives the title-block keep-out. EasyEDA's 明细表/图框 sits in
-// the BOTTOM-RIGHT corner (y-DOWN: larger y is lower). When the sheet bbox is
-// known we carve a corner sub-rect from it; when it is NOT exposed we report a
-// provisional fallback and apply NO geometric penalty (returning nil), so a
-// guessed absolute box can't corrupt scoring — the caller still surfaces
-// `titleBlockProvisional` so a human knows the keep-out was not enforced.
+// titleBlockKeepout derives the title-block keep-out for the autoconnect scorer.
+// It delegates to deriveSheetGeometry (the issue #26 single source of the keep-out
+// ratio) so the geometry is computed in exactly one place. When the sheet bbox is
+// NOT exposed it reports a provisional fallback and applies NO geometric penalty
+// (returning nil), so a guessed absolute box can't corrupt scoring — the caller
+// still surfaces `titleBlockProvisional` so a human knows it was not enforced.
 func titleBlockKeepout(sheet *layoutBBox) (*layoutBBox, bool) {
 	if sheet == nil {
 		return nil, true // provisional: not applied
 	}
-	w := sheet.MaxX - sheet.MinX
-	h := sheet.MaxY - sheet.MinY
-	// Bottom-right corner: rightmost ~22% width × bottom ~14% height — the usual
-	// EasyEDA A-series title block footprint.
-	return &layoutBBox{
-		MinX: sheet.MaxX - 0.22*w,
-		MinY: sheet.MaxY - 0.14*h,
-		MaxX: sheet.MaxX,
-		MaxY: sheet.MaxY,
-	}, false
+	g := deriveSheetGeometry(sheet, nil)
+	if g.TitleBlock.BBox == nil {
+		return nil, true // could not derive (e.g. degenerate bbox) → not enforced
+	}
+	return g.TitleBlock.BBox, false
 }
 
 // resolvePinCoord finds a pin's coordinate from a "designator:pinNumberOrName"

--- a/internal/app/cmd_sch_sheet.go
+++ b/internal/app/cmd_sch_sheet.go
@@ -1,0 +1,251 @@
+package app
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+)
+
+// ── sheet-geometry: normalized sheet bounds + title-block keep-out (issue #26) ─
+//
+// Placement/routing planners (sch autoconnect #24, sch autolayout #25) must never
+// drop flags or parts on top of the drawing sheet's 图框/明细表 (title block). They
+// need a single, normalized keep-out rectangle instead of A4 coordinates
+// re-hardcoded per tool. This is that source.
+//
+// EasyEDA Pro exposes no set-paper-size API and NO separate bbox for the title
+// block itself, so the geometry is DERIVED (issue Option D — hybrid):
+//
+//  1. sheet bbox  — live, from schematic.components.list(includeBBox) where
+//     componentType == "sheet" (Option A).
+//  2. template    — best-effort match by the sheet's aspect ratio against the
+//     known A-series ratio (≈√2). The public API exposes no reliable
+//     template-id field (deviceUuid/symbol name are not surfaced), so the
+//     aspect ratio is the detection key (Option C).
+//  3. title block — a corner sub-rect computed by a normalized ratio from the
+//     matched template (Option C/D).
+//  4. visibility  — schematic.titleblock.get → showTitleBlock (Option B); a
+//     hidden title block emits no keep-out.
+//
+// Every result carries provenance ("known-template-ratio" / "fallback-ratio" /
+// "none") plus warnings, so consumers never get false precision. The ratio table
+// here is the single source that sch autoconnect's titleBlockKeepout consumes.
+
+// titleBlockRatio is a corner sub-rectangle of the sheet expressed as fractions
+// of the sheet width/height.
+type titleBlockRatio struct {
+	WidthFrac  float64
+	HeightFrac float64
+}
+
+// sheetTemplate maps a recognizable sheet (by aspect ratio) to its title-block
+// footprint. A-series sheets all share the √2 aspect, so one landscape + one
+// portrait entry covers A4/A3/A2/A1/A0 — the title block is proportionally the
+// same fraction of the page.
+type sheetTemplate struct {
+	Name       string
+	Aspect     float64 // sheet width / height
+	AspectTol  float64 // match tolerance on aspect
+	TitleBlock titleBlockRatio
+}
+
+// defaultTitleBlockRatio is applied when no template matches (fallback). The
+// rightmost ~22% width × bottom ~14% height is the usual EasyEDA A-series
+// title-block footprint — the same numbers sch autoconnect used to hardcode.
+var defaultTitleBlockRatio = titleBlockRatio{WidthFrac: 0.22, HeightFrac: 0.14}
+
+// sheetTemplates is the known sheet → title-block ratio table. Mirrored for
+// humans/skills in skills/easyeda-conventions/references/sheet-templates.json;
+// this Go table is the runtime authority (the CLI is the interface planners use).
+var sheetTemplates = []sheetTemplate{
+	{Name: "a-series-landscape", Aspect: 1.414, AspectTol: 0.06, TitleBlock: defaultTitleBlockRatio},
+	{Name: "a-series-portrait", Aspect: 0.707, AspectTol: 0.04, TitleBlock: titleBlockRatio{WidthFrac: 0.31, HeightFrac: 0.10}},
+}
+
+// Provenance values for titleBlock.source / how the keep-out was derived.
+const (
+	sheetSourceKnownTemplate = "known-template-ratio" // sheet bbox live + aspect matched a template
+	sheetSourceFallback      = "fallback-ratio"       // sheet bbox live, aspect unrecognized → generic ratio
+	sheetSourceNone          = "none"                 // no sheet bbox, or title block hidden → no keep-out
+)
+
+// sheetInfo describes the drawing sheet itself.
+type sheetInfo struct {
+	Template string      `json:"template,omitempty"`
+	BBox     *layoutBBox `json:"bbox"`
+}
+
+// titleBlockInfo describes the derived title-block rectangle and its provenance.
+type titleBlockInfo struct {
+	Visible *bool       `json:"visible,omitempty"`
+	BBox    *layoutBBox `json:"bbox,omitempty"`
+	Source  string      `json:"source"`
+}
+
+// keepout is one named, normalized exclusion rectangle planners must avoid.
+type keepout struct {
+	Name string      `json:"name"`
+	BBox *layoutBBox `json:"bbox"`
+	Hard bool        `json:"hard"`
+}
+
+// sheetGeometry is the full normalized result, shaped to the issue #26 contract.
+type sheetGeometry struct {
+	Sheet      sheetInfo      `json:"sheet"`
+	TitleBlock titleBlockInfo `json:"titleBlock"`
+	Keepouts   []keepout      `json:"keepouts"`
+	Warnings   []string       `json:"warnings"`
+}
+
+// matchSheetTemplate picks the template whose aspect matches w/h within tolerance.
+// Returns matched=false (and a generic template carrying the default ratio) when
+// nothing matches, so the caller can downgrade provenance to fallback.
+func matchSheetTemplate(w, h float64) (sheetTemplate, bool) {
+	aspect := w / h
+	for _, t := range sheetTemplates {
+		if math.Abs(aspect-t.Aspect) <= t.AspectTol {
+			return t, true
+		}
+	}
+	return sheetTemplate{Name: "unknown", TitleBlock: defaultTitleBlockRatio}, false
+}
+
+// deriveSheetGeometry is the pure core: given the live sheet bbox (or nil) and
+// the title block's visibility (or nil when unknown), produce the normalized
+// geometry with provenance + warnings. Kept free of I/O for unit-testing.
+//
+// Coordinate note: EasyEDA's 图框/明细表 sits in the BOTTOM-RIGHT corner of the
+// returned bbox space (larger y is lower), matching sch autoconnect's existing
+// keep-out — so the carved rect is the high-x, high-y corner of the sheet bbox.
+func deriveSheetGeometry(sheet *layoutBBox, showTitleBlock *bool) sheetGeometry {
+	g := sheetGeometry{Keepouts: []keepout{}, Warnings: []string{}}
+	g.TitleBlock.Visible = showTitleBlock
+	g.TitleBlock.Source = sheetSourceNone
+
+	if sheet == nil {
+		g.Warnings = append(g.Warnings,
+			"no sheet primitive found (componentType \"sheet\" with bbox); cannot derive sheet bounds or title-block keep-out")
+		return g
+	}
+	g.Sheet.BBox = sheet
+
+	w := sheet.MaxX - sheet.MinX
+	h := sheet.MaxY - sheet.MinY
+	if w <= 0 || h <= 0 {
+		g.Warnings = append(g.Warnings,
+			"sheet bbox has non-positive dimensions; title-block keep-out not derived")
+		return g
+	}
+
+	tmpl, matched := matchSheetTemplate(w, h)
+	g.Sheet.Template = tmpl.Name
+	if matched {
+		g.TitleBlock.Source = sheetSourceKnownTemplate
+	} else {
+		g.TitleBlock.Source = sheetSourceFallback
+		g.Warnings = append(g.Warnings, fmt.Sprintf(
+			"sheet aspect %.3f did not match a known template; title-block keep-out uses a generic fallback ratio, not template geometry",
+			w/h))
+	}
+
+	// Respect an explicitly-hidden title block: no keep-out to enforce.
+	if showTitleBlock != nil && !*showTitleBlock {
+		g.TitleBlock.Source = sheetSourceNone
+		g.Warnings = append(g.Warnings,
+			"title block is hidden (showTitleBlock=false); no title-block keep-out emitted")
+		return g
+	}
+	if showTitleBlock == nil {
+		g.Warnings = append(g.Warnings,
+			"title-block visibility unknown (showTitleBlock not reported); assuming visible")
+	}
+
+	ratio := tmpl.TitleBlock
+	tb := &layoutBBox{
+		MinX: round2(sheet.MaxX - ratio.WidthFrac*w),
+		MinY: round2(sheet.MaxY - ratio.HeightFrac*h),
+		MaxX: sheet.MaxX,
+		MaxY: sheet.MaxY,
+	}
+	g.TitleBlock.BBox = tb
+	g.Keepouts = append(g.Keepouts, keepout{Name: "titleBlock", BBox: tb, Hard: true})
+	return g
+}
+
+// runSheetGeometry pulls the live sheet bbox + title-block visibility, derives the
+// normalized geometry, and prints it. Read-only: it always exits zero (a missing
+// sheet is reported as a warning, not an error) since it is a query, not a gate.
+func runSheetGeometry(cfg *appConfig, window string, asJSON bool, stdout, stderr io.Writer) error {
+	// 1. Sheet bbox (live) from components.list(includeBBox).
+	res, err := requestAction(cfg, "schematic.components.list", window, map[string]any{"includeBBox": true})
+	if err != nil {
+		return err
+	}
+	comps, perr := parseLayoutComps(res.Result)
+	if perr != nil {
+		return perr
+	}
+	var sheet *layoutBBox
+	for _, c := range comps {
+		if c.ComponentType == "sheet" && c.BBox != nil {
+			sheet = c.BBox
+			break
+		}
+	}
+
+	// 2. Title-block visibility (best effort; non-fatal if unavailable).
+	var showTB *bool
+	if tb, terr := requestAction(cfg, "schematic.titleblock.get", window, nil); terr == nil && tb.Result != nil {
+		if v, ok := tb.Result["showTitleBlock"].(bool); ok {
+			showTB = &v
+		}
+	}
+
+	g := deriveSheetGeometry(sheet, showTB)
+
+	if asJSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(g)
+	}
+	renderSheetGeometry(g, stdout)
+	return nil
+}
+
+// renderSheetGeometry prints a compact human summary.
+func renderSheetGeometry(g sheetGeometry, w io.Writer) {
+	if g.Sheet.BBox == nil {
+		fmt.Fprintln(w, "sheet-geometry: no sheet bbox available")
+	} else {
+		b := g.Sheet.BBox
+		fmt.Fprintf(w, "sheet-geometry: template %q, bbox [%.2f,%.2f → %.2f,%.2f]\n",
+			g.Sheet.Template, b.MinX, b.MinY, b.MaxX, b.MaxY)
+	}
+	vis := "unknown"
+	if g.TitleBlock.Visible != nil {
+		if *g.TitleBlock.Visible {
+			vis = "visible"
+		} else {
+			vis = "hidden"
+		}
+	}
+	if g.TitleBlock.BBox != nil {
+		b := g.TitleBlock.BBox
+		fmt.Fprintf(w, "  titleBlock (%s, source=%s): bbox [%.2f,%.2f → %.2f,%.2f]\n",
+			vis, g.TitleBlock.Source, b.MinX, b.MinY, b.MaxX, b.MaxY)
+	} else {
+		fmt.Fprintf(w, "  titleBlock (%s, source=%s): no keep-out\n", vis, g.TitleBlock.Source)
+	}
+	for _, k := range g.Keepouts {
+		hard := "soft"
+		if k.Hard {
+			hard = "hard"
+		}
+		fmt.Fprintf(w, "  keepout %q (%s): [%.2f,%.2f → %.2f,%.2f]\n",
+			k.Name, hard, k.BBox.MinX, k.BBox.MinY, k.BBox.MaxX, k.BBox.MaxY)
+	}
+	for _, msg := range g.Warnings {
+		fmt.Fprintf(w, "  WARN  %s\n", msg)
+	}
+}

--- a/internal/app/cmd_sch_sheet_test.go
+++ b/internal/app/cmd_sch_sheet_test.go
@@ -1,0 +1,153 @@
+package app
+
+import "testing"
+
+func boolPtr(b bool) *bool { return &b }
+
+func hasWarningContaining(warnings []string, substr string) bool {
+	for _, w := range warnings {
+		if len(w) >= len(substr) && containsStr(w, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsStr(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}
+
+// Known template: an A-series landscape sheet (aspect ≈ √2 ≈ 1.414). The
+// title-block keep-out must be the bottom-right corner, tagged known-template.
+func TestDeriveSheetGeometry_KnownTemplateA4Landscape(t *testing.T) {
+	// 1160 / 820 ≈ 1.4146 → matches a-series-landscape.
+	sheet := bb(0, 0, 1160, 820)
+	g := deriveSheetGeometry(sheet, boolPtr(true))
+
+	if g.Sheet.Template != "a-series-landscape" {
+		t.Fatalf("expected a-series-landscape, got %q", g.Sheet.Template)
+	}
+	if g.TitleBlock.Source != sheetSourceKnownTemplate {
+		t.Fatalf("expected source %q, got %q", sheetSourceKnownTemplate, g.TitleBlock.Source)
+	}
+	if g.TitleBlock.BBox == nil {
+		t.Fatal("expected a title-block bbox")
+	}
+	tb := g.TitleBlock.BBox
+	// 22% width × 14% height, anchored to the high-x/high-y (bottom-right) corner.
+	if tb.MaxX != 1160 || tb.MaxY != 820 {
+		t.Errorf("keep-out must anchor to the bottom-right corner, got max %.2f,%.2f", tb.MaxX, tb.MaxY)
+	}
+	if tb.MinX != round2(1160-0.22*1160) || tb.MinY != round2(820-0.14*820) {
+		t.Errorf("unexpected keep-out min corner: %.2f,%.2f", tb.MinX, tb.MinY)
+	}
+	if len(g.Keepouts) != 1 || g.Keepouts[0].Name != "titleBlock" || !g.Keepouts[0].Hard {
+		t.Fatalf("expected one hard titleBlock keepout, got %+v", g.Keepouts)
+	}
+	if hasWarningContaining(g.Warnings, "fallback") {
+		t.Errorf("known template must not warn about fallback: %v", g.Warnings)
+	}
+}
+
+// Unknown template: a square-ish sheet matches no known aspect → fallback ratio,
+// keep-out still emitted, but provenance downgraded and a warning surfaced.
+func TestDeriveSheetGeometry_UnknownTemplate(t *testing.T) {
+	sheet := bb(0, 0, 1000, 1000) // aspect 1.0 → no match
+	g := deriveSheetGeometry(sheet, boolPtr(true))
+
+	if g.TitleBlock.Source != sheetSourceFallback {
+		t.Fatalf("expected source %q, got %q", sheetSourceFallback, g.TitleBlock.Source)
+	}
+	if g.TitleBlock.BBox == nil {
+		t.Fatal("fallback must still emit a keep-out (generic ratio)")
+	}
+	if len(g.Keepouts) != 1 {
+		t.Fatalf("expected one keepout in fallback, got %d", len(g.Keepouts))
+	}
+	if !hasWarningContaining(g.Warnings, "did not match a known template") {
+		t.Errorf("expected an unrecognized-template warning, got %v", g.Warnings)
+	}
+}
+
+// A hidden title block must emit NO keep-out and say so.
+func TestDeriveSheetGeometry_HiddenTitleBlock(t *testing.T) {
+	sheet := bb(0, 0, 1160, 820)
+	g := deriveSheetGeometry(sheet, boolPtr(false))
+
+	if g.TitleBlock.BBox != nil {
+		t.Errorf("hidden title block must not produce a bbox, got %+v", g.TitleBlock.BBox)
+	}
+	if len(g.Keepouts) != 0 {
+		t.Errorf("hidden title block must emit no keepouts, got %d", len(g.Keepouts))
+	}
+	if g.TitleBlock.Source != sheetSourceNone {
+		t.Errorf("expected source %q, got %q", sheetSourceNone, g.TitleBlock.Source)
+	}
+	if !hasWarningContaining(g.Warnings, "hidden") {
+		t.Errorf("expected a hidden-title-block warning, got %v", g.Warnings)
+	}
+}
+
+// No sheet primitive → no geometry, a warning, no false precision.
+func TestDeriveSheetGeometry_NoSheet(t *testing.T) {
+	g := deriveSheetGeometry(nil, nil)
+
+	if g.Sheet.BBox != nil {
+		t.Errorf("no sheet must yield a nil sheet bbox, got %+v", g.Sheet.BBox)
+	}
+	if g.TitleBlock.BBox != nil || len(g.Keepouts) != 0 {
+		t.Errorf("no sheet must yield no keep-out, got tb=%+v keepouts=%d", g.TitleBlock.BBox, len(g.Keepouts))
+	}
+	if !hasWarningContaining(g.Warnings, "no sheet primitive found") {
+		t.Errorf("expected a no-sheet warning, got %v", g.Warnings)
+	}
+}
+
+// Unknown visibility (showTitleBlock not reported) assumes visible and warns.
+func TestDeriveSheetGeometry_UnknownVisibility(t *testing.T) {
+	sheet := bb(0, 0, 1160, 820)
+	g := deriveSheetGeometry(sheet, nil)
+
+	if g.TitleBlock.BBox == nil {
+		t.Fatal("unknown visibility must assume visible and emit a keep-out")
+	}
+	if !hasWarningContaining(g.Warnings, "visibility unknown") {
+		t.Errorf("expected a visibility-unknown warning, got %v", g.Warnings)
+	}
+}
+
+// Degenerate sheet bbox (non-positive dimensions) → no keep-out, warning.
+func TestDeriveSheetGeometry_DegenerateBBox(t *testing.T) {
+	sheet := bb(100, 100, 100, 100) // zero width/height
+	g := deriveSheetGeometry(sheet, boolPtr(true))
+
+	if g.TitleBlock.BBox != nil || len(g.Keepouts) != 0 {
+		t.Errorf("degenerate bbox must not derive a keep-out, got %+v", g.TitleBlock.BBox)
+	}
+	if !hasWarningContaining(g.Warnings, "non-positive dimensions") {
+		t.Errorf("expected a degenerate-bbox warning, got %v", g.Warnings)
+	}
+}
+
+// The autoconnect keep-out must stay consistent with the shared derivation:
+// same corner rect for a known sheet, provisional when no sheet.
+func TestTitleBlockKeepout_DelegatesToDerive(t *testing.T) {
+	sheet := bb(0, 0, 1160, 820)
+	box, provisional := titleBlockKeepout(sheet)
+	if provisional {
+		t.Fatal("a known sheet must not be provisional")
+	}
+	g := deriveSheetGeometry(sheet, nil)
+	if box == nil || g.TitleBlock.BBox == nil || *box != *g.TitleBlock.BBox {
+		t.Errorf("titleBlockKeepout must match deriveSheetGeometry; got %+v vs %+v", box, g.TitleBlock.BBox)
+	}
+
+	if nilBox, prov := titleBlockKeepout(nil); nilBox != nil || !prov {
+		t.Errorf("no sheet → nil keep-out + provisional, got box=%+v prov=%v", nilBox, prov)
+	}
+}

--- a/skills/easyeda-conventions/references/schematic-layout-conventions.md
+++ b/skills/easyeda-conventions/references/schematic-layout-conventions.md
@@ -292,3 +292,24 @@ LED 也可用 `LED1` 这种语义化命名（兼容 `D1`），EasyEDA 不强制 
 - 多页之间通过 `net_port` (`createNetPort('IN/OUT/BI')`) 在页间建立电气连接，net 名称相同视为同网。
 - `getCurrentRenderedAreaImage` **实测不可靠**：在后台标签 / 某些状态下它返回的是**缓存的旧渲染**——既不跟随 `zoomToSelectedPrimitives` / `zoomToRegion`，也可能不反映刚做的增删（实测：两次不同板面状态下截图逐字节相同、md5 一致）。用它做"改完截图确认"前，务必先确认它真的刷新了（例如截图前后做一处明显改动并比对像素）；否则改用纯数据校验（如 schematic-lint）或直接肉眼看 EasyEDA 界面。
 - 目前两份 reference（§7 motobox、§8 ESP32S3R8N8）覆盖了「贴近 3×3 理想」与「RF MCU 占角 + 横向电源链」两种典型。若再采集到第三种（例如纯模拟前端、或多电源域工控板），应继续补充以避免 agent 过拟合到单一案例。
+
+## 11. 图纸边界与标题栏 keep-out (sheet / title-block keep-out)
+
+放置 / 布线规划器（`sch autoconnect`、`sch autolayout`）**绝不能**把 net flag / net port /
+器件压在图纸的 **图框/明细表（title block）** 上。但 EasyEDA Pro 既没有 set-paper-size API，
+也不单独暴露标题栏的 bbox，所以 keep-out 几何只能**推导**——不要在各工具里散落硬编码 A4 坐标，
+统一走 **`easyeda sch sheet-geometry`**（实现见 `internal/app/cmd_sch_sheet.go`，运行时权威）。
+
+推导链（issue #26，Option D 混合）：
+
+1. **sheet bbox**（实测）：`schematic.components.list --include-bbox` 里 `componentType == "sheet"` 的图元。
+2. **模板识别**：用 sheet bbox 的**长宽比**匹配已知模板（A 系列横/纵向 ≈ √2）。公共 API 不暴露
+   可靠的模板 id（deviceUuid / 符号名都拿不到），所以长宽比是识别键。
+3. **标题栏矩形**：按匹配模板的**归一化比例**在 sheet bbox 的**右下角**（坐标空间中 x、y 都偏大的角）
+   切出子矩形。比例表见 [`sheet-templates.json`](./sheet-templates.json)（Go 表 `sheetTemplates` 为运行时权威，
+   此 JSON 为人/skill 可读镜像，二者须保持同步）。
+4. **可见性**：`schematic.titleblock.get` 的 `showTitleBlock`；隐藏时**不**输出 keep-out。
+
+返回的每条结果都带 **provenance**（`known-template-ratio` / `fallback-ratio` / `none`）与 `warnings`，
+无法确定时只给警告、**绝不输出虚假精度**。规划器消费 `keepouts[]`（`{name, bbox, hard}`）即可，
+不必关心几何怎么算出来的。

--- a/skills/easyeda-conventions/references/sheet-templates.json
+++ b/skills/easyeda-conventions/references/sheet-templates.json
@@ -1,0 +1,42 @@
+{
+  "_doc": [
+    "Sheet -> title-block keep-out RATIO table for the easyeda-agent placement/routing planners.",
+    "EasyEDA Pro exposes NO set-paper-size API and NO separate bbox for the 图框/明细表 (title block),",
+    "so the keep-out is DERIVED: read the live sheet bbox (componentType == 'sheet'), match a template",
+    "by ASPECT RATIO (the API exposes no reliable template id), then carve a corner sub-rect by ratio.",
+    "",
+    "RUNTIME AUTHORITY is the Go table `sheetTemplates` in internal/app/cmd_sch_sheet.go and the CLI",
+    "`easyeda sch sheet-geometry --json`. This JSON is the human/skill-readable mirror — keep the two in",
+    "sync. Planners should CALL the CLI (it tags provenance + warnings), not read these numbers directly.",
+    "",
+    "Coordinate note: the title block sits in the BOTTOM-RIGHT corner of the bbox space returned by",
+    "getPrimitivesBBox (larger y is lower on the page), so the carved rect anchors to the high-x/high-y",
+    "corner of the sheet bbox. widthFrac/heightFrac are fractions of the sheet width/height."
+  ],
+  "defaultTitleBlockRatio": {
+    "widthFrac": 0.22,
+    "heightFrac": 0.14,
+    "corner": "bottom-right",
+    "note": "Applied as a FALLBACK when no template matches; provenance downgrades to 'fallback-ratio' + a warning."
+  },
+  "templates": [
+    {
+      "name": "a-series-landscape",
+      "aspect": 1.414,
+      "aspectTol": 0.06,
+      "titleBlock": { "widthFrac": 0.22, "heightFrac": 0.14, "corner": "bottom-right" },
+      "note": "A0..A4 landscape share the same √2 aspect; EasyEDA's default drawing-symbol_a4 is landscape A-series."
+    },
+    {
+      "name": "a-series-portrait",
+      "aspect": 0.707,
+      "aspectTol": 0.04,
+      "titleBlock": { "widthFrac": 0.31, "heightFrac": 0.10, "corner": "bottom-right" }
+    }
+  ],
+  "provenance": {
+    "known-template-ratio": "sheet bbox is live AND its aspect matched a template here",
+    "fallback-ratio": "sheet bbox is live but aspect matched no template -> defaultTitleBlockRatio",
+    "none": "no sheet bbox available, or the title block is hidden (showTitleBlock=false)"
+  }
+}

--- a/skills/easyeda-schematic/SKILL.md
+++ b/skills/easyeda-schematic/SKILL.md
@@ -147,9 +147,10 @@ Spec JSON (`--spec`): `{"connections":[{"pin":"U1:41","kind":"gnd","net":"GND"},
 "avoidPinFanout":true,"staggerLabels":true,"offsetRange":[18,80],"offsetStep":6,
 "minLabelGap":12}}`. Each result reports the `selected` candidate (direction /
 offset / endPoint / score), the `rejected` alternatives with reasons, and the
-`wirePrimitiveId` / `flagPrimitiveId`. When the sheet bbox isn't exposed, the
-title-block keep-out is reported as **provisional** and not geometrically
-enforced (so a guessed box can't corrupt scoring). **Prefer `sch autoconnect`
+`wirePrimitiveId` / `flagPrimitiveId`. The title-block keep-out comes from the
+shared `sch sheet-geometry` derivation (issue #26) — when the sheet bbox isn't
+exposed it is reported as **provisional** and not geometrically enforced (so a
+guessed box can't corrupt scoring). **Prefer `sch autoconnect`
 over hand-picking `sch connect --direction/--offset`** for power/ground/netport
 stubs; `sch connect` stays for when you deliberately override the geometry.
 
@@ -191,6 +192,7 @@ easyeda doc switch <P2|PCB1|uuid> --project <名字>   # 切换:按页名/PCB名
 
 - `schematic.components.list` — `--include-bbox` 附带每个元件渲染范围 `{minX,minY,maxX,maxY}`(供布局推理);`--include-pins` 附带每脚 `{pinName,pinNumber,x,y,noConnected}`(布线/连通性判断的数据面,布线前读引脚功能名→坐标用它,**不要**再用 `easyeda call schematic.components.list --payload '{"includePins":true}'` 绕过)。两个 flag 可与 `--all-pages` 叠加(输出会显著变大)。
 - **`easyeda sch layout-lint`** — **布局自检**(治覆盖的机械真值)。拉 `components.list --include-bbox`,Go 侧两两几何检查:**bbox 重叠 = ERROR**(命令非零退出,可当门禁)、**间距 < `--min-gap`(默认 2.54mm)= WARN**。`--all-pages`、`--json`。**默认只检真实器件(`componentType == "part"`)**:图框/标题栏(sheet)铺满整页、netflag/netport/netlabel 等非器件原语都会被自动排除,否则它们会与几乎每个器件误报重叠(见 issue #13)。需要把这些也纳入检查时加 `--include-non-parts`;被排除的数量会在报告里以 `skippedNonParts` 透明列出。摆放后跑它判覆盖/间距,比肉眼/截图可靠(截图可能 stale)。是 place→verify→adjust 闭环的输入。
+- **`easyeda sch sheet-geometry`** — **图纸边界 + 标题栏 keep-out**(放置/布线规划器的统一几何源,issue #26)。读 `components.list --include-bbox` 里 `componentType == "sheet"` 的实测 bbox,按**长宽比**匹配已知模板(A 系列横/纵向 ≈ √2),在**右下角**按归一化比例切出标题栏(图框/明细表)子矩形;`schematic.titleblock.get` 的 `showTitleBlock` 隐藏时不输出 keep-out。返回 `{sheet, titleBlock, keepouts[], warnings[]}`,每项带 **provenance**(`known-template-ratio` / `fallback-ratio` / `none`),无法确定时只给 warning、不输出虚假精度。`--json`。规划器消费 `keepouts[]`(`{name,bbox,hard}`)即可,**不要再各处硬编码 A4 坐标**。比例表见 `easyeda-conventions/references/sheet-templates.json`。
 - `schematic.component.place`
 - `schematic.component.modify`
 - `schematic.component.delete` — ⚠️ **只删组件,不删导线/总线/图形**。删完 `schematic.components.list` 只剩 A4 sheet 会让你误以为页面已干净,实际残留导线还在(DRC 仍会报)。要真正清页用 `schematic.page.clear`。


### PR DESCRIPTION
Fixes #26

## 做了什么
新增只读命令 `easyeda sch sheet-geometry [--json]`:为图纸边界 + 标题栏(图框/明细表)keep-out 提供一个**统一、带 provenance 的归一化几何源**,取代散落在各工具里的硬编码 A4 坐标,供 #24(autoconnect)/#25(autolayout)的 `avoidTitleBlock` 与未来任何放置/布线规划器共用。

## 几何推导(issue #26 Option D 混合)
- **sheet bbox**:实测,取 `components.list --include-bbox` 中 `componentType == "sheet"` 的图元
- **模板识别**:按 sheet bbox **长宽比**匹配已知模板(A 系列横/纵向 ≈ √2)。公共 API 不暴露可靠的模板 id(deviceUuid/符号名都拿不到),故长宽比是识别键
- **标题栏**:按匹配模板的归一化比例在**右下角**切子矩形
- **可见性**:`schematic.titleblock.get` 的 `showTitleBlock`(隐藏 ⇒ 不输出 keep-out)

返回 `{sheet, titleBlock, keepouts[], warnings[]}`,每项带 provenance(`known-template-ratio` / `fallback-ratio` / `none`);无法确定时只给 warning,**绝不输出虚假精度**。

## 关键设计决策
- **遵循 `sch layout-lint` 先例**:CLI 组合已有 action(`components.list` + `titleblock.get`),**不新增连接器 handler、不需重新打包/导入 .eext**——也规避了 CLAUDE.md 记载的 connector 重导入坑;且 API 本就不暴露标题栏独立 bbox(issue 风险段确认),比例推导放在 Go 侧最易测。
- **单一比例源**:把 #24 中 autoconnect 硬编码的 `titleBlockKeepout`(22%/14%)重构为委托给本派生函数,消除漂移。
- 比例表 Go 侧 `sheetTemplates` 为运行时权威,镜像到 `easyeda-conventions/references/sheet-templates.json` 供 skill/人阅读。

## 验收对照
- ✅ 标准 A4(横向 A 系列,aspect≈1.414)可用,返回 sheet bbox + 标题栏 keep-out
- ✅ 明确标注 provenance
- ✅ 无法确定时给 warning、无虚假精度(no-sheet / 退化 bbox / 隐藏标题栏 / 未知可见性)
- ✅ `keepouts[]`(`{name,bbox,hard}`)格式可被 layout-lint / 规划器消费
- ✅ 单元 fixtures 覆盖 known + unknown 模板两路(另含隐藏/未知可见性、无 sheet、退化 bbox、autoconnect 委托一致性)

## 测试
`go build ./...` + `go test ./...` 全绿;新增 7 个纯函数单测全部通过。**未做 EasyEDA 实机联调**(无连接窗口环境):模板识别的长宽比阈值与右下角约定沿用 #24 已落地的 `titleBlockKeepout` 经验值,实机标定可作为后续校准(类似 calibrate.js 流程)。