### PR TITLE
feat: add module-aware sch autolayout placement planner

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -156,6 +156,24 @@ Workspace → Project → **Board** → schematic + PCB. Map to `eda.dmt_Board.*
 
 ### Tooling layer
 
+- **Go-side CLI planners (pure geometry over real bboxes)** — deterministic,
+  unit-testable analysis/placement that runs in the daemon's Go process on a
+  single `schematic.components.list` pull, no per-step screenshots:
+  - **`easyeda sch layout-lint`** — pairwise bbox overlap (ERROR) + tight spacing
+    (WARN); non-zero exit gates a workflow.
+  - **`easyeda sch autoconnect`** — pin-aware connect planner: score every
+    (direction × offset) candidate against real geometry, pick the lowest cost,
+    delegate the mutation to `connect_pin` (issue #24).
+  - **`easyeda sch autolayout`** — module-aware **placement** planner (issue #25):
+    reads a `--spec` (page, sheet, modules with zone/core/parts, rules),
+    partitions the canvas into named zones (`left-top`/`center`/`right`/…), places
+    each module's core IC near its zone center, fans peripherals around it with
+    collision retry, and preserves each core pin's fanout channel + the A4
+    title-block keep-out. Same pure-scorer style as autoconnect: identical spec +
+    input → identical coordinates that pass `layout-lint`. `--dry-run` plans
+    without mutating; `--apply` moves parts via `schematic.component.modify` then
+    self-checks overlaps. v1 only **moves already-placed parts** (does not create
+    missing ones).
 - **`skills/easyeda-schematic/scripts`** — a data-only schematic checker (no screenshots): one
   `getAll` + `wire.getAll` pull returns the full layout, then a geometry/union-find
   pass finds connectivity and orientation problems with exact coordinates (13

--- a/internal/app/cmd_sch.go
+++ b/internal/app/cmd_sch.go
@@ -840,6 +840,14 @@ Exits non-zero when any overlap is found, so it can gate a workflow.`,
 	// (cmd_sch_autoconnect.go); orchestration in cmd_sch_autoconnect_run.go.
 	sch.AddCommand(newAutoconnectCmd(cfg, &window, stdout, stderr))
 
+	// ── autolayout ──────────────────────────────────────────────────────────
+	// Module-aware deterministic placement planner: partition the canvas into
+	// named zones, place each module's core IC + peripherals with collision
+	// retry, preserve pin-fanout channels + the title-block keep-out, and emit
+	// lint-clean coordinates. Pure planner in cmd_sch_autolayout.go; I/O +
+	// --apply in cmd_sch_autolayout_run.go. See issue #25.
+	sch.AddCommand(newAutolayoutCmd(cfg, &window, stdout, stderr))
+
 	// ── netlist ───────────────────────────────────────────────────────────
 	// schematic.export.netlist
 	{

--- a/internal/app/cmd_sch_autolayout.go
+++ b/internal/app/cmd_sch_autolayout.go
@@ -1,0 +1,471 @@
+package app
+
+import (
+	"fmt"
+	"math"
+	"sort"
+)
+
+// ── sch autolayout: module-aware deterministic placement planner ─────────────
+//
+// `sch layout-lint` already gives the place→verify→adjust loop a quantified
+// overlap input, and `sch autoconnect` (issue #24) showed how to turn a layout
+// judgment call into a PURE deterministic geometry decision over real bboxes.
+// `sch autolayout` is the larger sibling (issue #25): it solves MODULE-LEVEL
+// placement — not electrical routing — by reading a spec (page, sheet, modules
+// with zone/core/parts, rules), partitioning the usable canvas into named zones,
+// placing each module's core IC near its zone center, fanning peripherals around
+// the core while preserving pin-fanout channels and the A4 title-block keep-out,
+// and retrying candidate positions on collision.
+//
+// The planner core here (planAutolayout + the geometry helpers) is PURE and
+// deterministic: same modules + parts + sheet + rules always yields identical
+// coordinates, so it is unit-testable with no connector. The I/O side (pull real
+// geometry, --apply via schematic.component.modify) lives in
+// cmd_sch_autolayout_run.go. It reuses layoutBBox / boxesOverlap / rectGap /
+// titleBlockKeepout / analyzeLayout rather than re-deriving them.
+
+// ── tunable rules ───────────────────────────────────────────────────────────
+
+// autolayoutRules are the planner knobs. Mirrors the `rules` block of the spec
+// JSON. Gaps are in schematic units (the same space the pin/bbox coordinates
+// live in).
+type autolayoutRules struct {
+	AvoidTitleBlock   bool    // hard keep-out: never land a part in the title block
+	PreservePinFanout bool    // keep peripherals out of a core pin's lead-out lane
+	ModuleGap         float64 // nominal inter-module breathing room (informational/zone sizing)
+	RouteChannelGap   float64 // length of a preserved pin-fanout channel
+	PreferVertical    bool    // try above/below before left/right for dense peripherals
+	PartGap           float64 // minimum edge-to-edge gap between two parts
+}
+
+// defaultAutolayoutRules matches the spec defaults documented in issue #25.
+func defaultAutolayoutRules() autolayoutRules {
+	return autolayoutRules{
+		AvoidTitleBlock:   true,
+		PreservePinFanout: true,
+		ModuleGap:         80,
+		RouteChannelGap:   40,
+		PreferVertical:    true,
+		PartGap:           20,
+	}
+}
+
+// alMaxRing bounds how far out the candidate search spirals before a part is
+// declared unplaceable. 12 rings × 8 directions = 96 candidates per part.
+const alMaxRing = 12
+
+// ── scene inputs ────────────────────────────────────────────────────────────
+
+// alPinPt is one core pin coordinate (for fanout-lane derivation).
+type alPinPt struct{ X, Y float64 }
+
+// alPart is one placed device the planner can MOVE (v1 does not create parts).
+// AnchorX/Y is the component's stored x/y (what schematic.component.modify sets);
+// BBox is the rendered extent. Moving translates anchor and bbox by the same
+// vector, so the planner reasons in bbox-center space and converts back to an
+// anchor at the end (makePlacement).
+type alPart struct {
+	Designator  string
+	PrimitiveID string
+	AnchorX     float64
+	AnchorY     float64
+	Rotation    float64
+	BBox        layoutBBox
+	HasBBox     bool
+	Pins        []alPinPt
+}
+
+// alModuleSpec is one module to place: a named zone, a core IC, and the parts
+// (including the core) that belong to it.
+type alModuleSpec struct {
+	Name  string
+	Zone  string
+	Core  string
+	Parts []string
+}
+
+// ── result shape (issue #25) ────────────────────────────────────────────────
+
+type alPlacement struct {
+	Designator  string  `json:"designator"`
+	X           float64 `json:"x"`
+	Y           float64 `json:"y"`
+	Rotation    float64 `json:"rotation"`
+	Module      string  `json:"module"`
+	PrimitiveID string  `json:"primitiveId,omitempty"`
+	Retries     int     `json:"retries,omitempty"`
+}
+
+type alWarning struct {
+	Module  string `json:"module"`
+	Message string `json:"message"`
+}
+
+type alValidation struct {
+	PartOverlaps      int `json:"partOverlaps"`
+	TitleBlockHits    int `json:"titleBlockHits"`
+	FanoutKeepoutHits int `json:"fanoutKeepoutHits"`
+}
+
+type alReport struct {
+	OK                    bool          `json:"ok"`
+	Page                  string        `json:"page,omitempty"`
+	Placements            []alPlacement `json:"placements"`
+	Warnings              []alWarning   `json:"warnings,omitempty"`
+	Errors                []string      `json:"errors,omitempty"`
+	Validation            alValidation  `json:"validation"`
+	TitleBlockProvisional bool          `json:"titleBlockProvisional,omitempty"`
+	Note                  string        `json:"note,omitempty"`
+}
+
+// ── geometry helpers ────────────────────────────────────────────────────────
+
+func bboxSize(b layoutBBox) (w, h float64) { return b.MaxX - b.MinX, b.MaxY - b.MinY }
+
+func bboxCenter(b layoutBBox) (x, y float64) { return (b.MinX + b.MaxX) / 2, (b.MinY + b.MaxY) / 2 }
+
+// recenterBox returns b's same width/height translated so its center is (cx,cy).
+func recenterBox(b layoutBBox, cx, cy float64) layoutBBox {
+	w, h := bboxSize(b)
+	return layoutBBox{MinX: cx - w/2, MinY: cy - h/2, MaxX: cx + w/2, MaxY: cy + h/2}
+}
+
+// boxInside reports whether inner is fully contained in outer.
+func boxInside(inner, outer layoutBBox) bool {
+	return inner.MinX >= outer.MinX && inner.MaxX <= outer.MaxX &&
+		inner.MinY >= outer.MinY && inner.MaxY <= outer.MaxY
+}
+
+// unionBoxes is the fallback usable area when no sheet bbox is exposed: the
+// extent of every placed part, padded out so there is room to spread them.
+func unionBoxes(parts []alPart) layoutBBox {
+	first := true
+	var u layoutBBox
+	for _, p := range parts {
+		if !p.HasBBox {
+			continue
+		}
+		if first {
+			u = p.BBox
+			first = false
+			continue
+		}
+		u.MinX = math.Min(u.MinX, p.BBox.MinX)
+		u.MinY = math.Min(u.MinY, p.BBox.MinY)
+		u.MaxX = math.Max(u.MaxX, p.BBox.MaxX)
+		u.MaxY = math.Max(u.MaxY, p.BBox.MaxY)
+	}
+	if first {
+		return layoutBBox{MinX: 0, MinY: 0, MaxX: 1000, MaxY: 800}
+	}
+	padX := (u.MaxX-u.MinX)*0.25 + 60
+	padY := (u.MaxY-u.MinY)*0.25 + 60
+	return layoutBBox{MinX: u.MinX - padX, MinY: u.MinY - padY, MaxX: u.MaxX + padX, MaxY: u.MaxY + padY}
+}
+
+// zoneRect maps a named zone to its sub-rectangle of the usable area. Columns:
+// left [0,1/3], center [1/3,2/3], right [2/3,1]. Rows (y-DOWN, top = smaller y):
+// top [0,0.5], bottom [0.5,1]. Unknown/empty zone → center, full height.
+func zoneRect(zone string, u layoutBBox) layoutBBox {
+	w := u.MaxX - u.MinX
+	h := u.MaxY - u.MinY
+	colL := [2]float64{0, 1.0 / 3}
+	colC := [2]float64{1.0 / 3, 2.0 / 3}
+	colR := [2]float64{2.0 / 3, 1.0}
+	rowT := [2]float64{0, 0.5}
+	rowB := [2]float64{0.5, 1.0}
+	full := [2]float64{0, 1.0}
+	col, row := colC, full
+	switch zone {
+	case "left-top":
+		col, row = colL, rowT
+	case "left-bottom":
+		col, row = colL, rowB
+	case "left":
+		col, row = colL, full
+	case "center", "":
+		col, row = colC, full
+	case "center-top":
+		col, row = colC, rowT
+	case "center-bottom":
+		col, row = colC, rowB
+	case "right":
+		col, row = colR, full
+	case "right-top":
+		col, row = colR, rowT
+	case "right-bottom":
+		col, row = colR, rowB
+	case "top":
+		col, row = full, rowT
+	case "bottom":
+		col, row = full, rowB
+	}
+	return layoutBBox{
+		MinX: u.MinX + col[0]*w, MaxX: u.MinX + col[1]*w,
+		MinY: u.MinY + row[0]*h, MaxY: u.MinY + row[1]*h,
+	}
+}
+
+// alDir is a unit search direction (y-DOWN: dy=+1 is "below"/down on canvas).
+type alDir struct{ dx, dy float64 }
+
+// Vertical-first / horizontal-first orderings. Cardinals before diagonals so a
+// dense column/row of peripherals stacks cleanly before spilling into corners.
+var (
+	alDirsVertical   = []alDir{{0, 1}, {0, -1}, {1, 0}, {-1, 0}, {1, 1}, {-1, 1}, {1, -1}, {-1, -1}}
+	alDirsHorizontal = []alDir{{1, 0}, {-1, 0}, {0, 1}, {0, -1}, {1, 1}, {-1, 1}, {1, -1}, {-1, -1}}
+)
+
+// candidateCenters enumerates ring positions around (cx,cy) at radius r*step for
+// r=1..maxRing, each ring sweeping the direction order. Deterministic.
+func candidateCenters(cx, cy, step float64, preferVertical bool, maxRing int) []alPinPt {
+	dirs := alDirsHorizontal
+	if preferVertical {
+		dirs = alDirsVertical
+	}
+	out := make([]alPinPt, 0, maxRing*len(dirs))
+	for r := 1; r <= maxRing; r++ {
+		for _, d := range dirs {
+			out = append(out, alPinPt{X: cx + d.dx*step*float64(r), Y: cy + d.dy*step*float64(r)})
+		}
+	}
+	return out
+}
+
+// alOutward is the direction a pin leads AWAY from its owning core's center.
+func alOutward(px, py, cx, cy float64) string {
+	dx, dy := px-cx, py-cy
+	if math.Abs(dx) >= math.Abs(dy) {
+		if dx >= 0 {
+			return "right"
+		}
+		return "left"
+	}
+	if dy >= 0 {
+		return "down"
+	}
+	return "up"
+}
+
+// coreFanoutLanes builds a thin keep-out rectangle extending outward from each
+// core pin by channelLen — the channel a wire needs and a peripheral must not
+// squat in. core.BBox/core.Pins are the ALREADY-PLACED (translated) geometry.
+func coreFanoutLanes(core alPart, channelLen, halfWidth float64) []layoutBBox {
+	cx, cy := bboxCenter(core.BBox)
+	lanes := make([]layoutBBox, 0, len(core.Pins))
+	for _, p := range core.Pins {
+		switch alOutward(p.X, p.Y, cx, cy) {
+		case "up":
+			lanes = append(lanes, layoutBBox{MinX: p.X - halfWidth, MinY: p.Y - channelLen, MaxX: p.X + halfWidth, MaxY: p.Y})
+		case "down":
+			lanes = append(lanes, layoutBBox{MinX: p.X - halfWidth, MinY: p.Y, MaxX: p.X + halfWidth, MaxY: p.Y + channelLen})
+		case "left":
+			lanes = append(lanes, layoutBBox{MinX: p.X - channelLen, MinY: p.Y - halfWidth, MaxX: p.X, MaxY: p.Y + halfWidth})
+		case "right":
+			lanes = append(lanes, layoutBBox{MinX: p.X, MinY: p.Y - halfWidth, MaxX: p.X + channelLen, MaxY: p.Y + halfWidth})
+		}
+	}
+	return lanes
+}
+
+// makePlacement converts a target bbox-CENTER into the part's new ANCHOR
+// coordinate (modify sets the anchor). Moving translates anchor and bbox by the
+// same vector, so newAnchor = oldAnchor + (targetCenter - oldBBoxCenter).
+func makePlacement(p alPart, targetCX, targetCY float64, module string, retries int) alPlacement {
+	ocx, ocy := bboxCenter(p.BBox)
+	dx, dy := targetCX-ocx, targetCY-ocy
+	return alPlacement{
+		Designator:  p.Designator,
+		X:           round2(p.AnchorX + dx),
+		Y:           round2(p.AnchorY + dy),
+		Rotation:    p.Rotation,
+		Module:      module,
+		PrimitiveID: p.PrimitiveID,
+		Retries:     retries,
+	}
+}
+
+// findSlot searches for the first collision-free center for box, starting at
+// (cx,cy) then spiralling outward. Each predicate (nil = skip) vetoes a
+// candidate; the first survivor wins. Returns the placed box, the retry index
+// (0 = landed at the preferred center), and whether a slot was found.
+func findSlot(box layoutBBox, cx, cy, step float64, preferVertical bool, collides, inBounds, hitsTitle, hitsLane func(layoutBBox) bool) (layoutBBox, int, bool) {
+	tryAt := func(tx, ty float64) (layoutBBox, bool) {
+		cand := recenterBox(box, tx, ty)
+		if inBounds != nil && !inBounds(cand) {
+			return cand, false
+		}
+		if hitsTitle != nil && hitsTitle(cand) {
+			return cand, false
+		}
+		if hitsLane != nil && hitsLane(cand) {
+			return cand, false
+		}
+		if collides != nil && collides(cand) {
+			return cand, false
+		}
+		return cand, true
+	}
+	if cand, ok := tryAt(cx, cy); ok {
+		return cand, 0, true
+	}
+	cands := candidateCenters(cx, cy, step, preferVertical, alMaxRing)
+	for i, c := range cands {
+		if cand, ok := tryAt(c.X, c.Y); ok {
+			return cand, i + 1, true
+		}
+	}
+	return box, len(cands), false
+}
+
+// planAutolayout is the PURE deterministic core. Given the modules (in spec
+// order), the placed parts, the sheet bbox (nil → derive usable area + skip the
+// title-block keep-out), and the rules, it returns the full placement report.
+func planAutolayout(modules []alModuleSpec, parts []alPart, sheet *layoutBBox, rules autolayoutRules) alReport {
+	rep := alReport{OK: true}
+
+	byDes := make(map[string]alPart, len(parts))
+	for _, p := range parts {
+		byDes[p.Designator] = p
+	}
+
+	tb, prov := titleBlockKeepout(sheet)
+	rep.TitleBlockProvisional = prov
+	var usable layoutBBox
+	if sheet != nil {
+		usable = *sheet
+	} else {
+		usable = unionBoxes(parts)
+		rep.Note = "no sheet bbox exposed — usable area derived from existing part extents; title-block keep-out NOT enforced"
+	}
+
+	var placed []layoutBBox      // obstacle boxes accumulated across all modules
+	var placedComps []layoutComp // parallel, for the final overlap validation
+	var coreLanes []layoutBBox   // preserved pin-fanout channels from placed cores
+
+	collides := func(cand layoutBBox) bool {
+		for _, o := range placed {
+			if boxesOverlap(cand, o) || rectGap(cand, o) < rules.PartGap {
+				return true
+			}
+		}
+		return false
+	}
+	inBounds := func(cand layoutBBox) bool {
+		if sheet == nil {
+			return true
+		}
+		return boxInside(cand, usable)
+	}
+	hitsTitle := func(cand layoutBBox) bool {
+		return rules.AvoidTitleBlock && tb != nil && boxesOverlap(cand, *tb)
+	}
+	hitsLane := func(cand layoutBBox) bool {
+		if !rules.PreservePinFanout {
+			return false
+		}
+		for _, l := range coreLanes {
+			if boxesOverlap(cand, l) {
+				return true
+			}
+		}
+		return false
+	}
+	register := func(p alPart, box layoutBBox) {
+		placed = append(placed, box)
+		placedComps = append(placedComps, layoutComp{Designator: p.Designator, ID: p.PrimitiveID, BBox: &box})
+	}
+
+	for _, m := range modules {
+		zone := zoneRect(m.Zone, usable)
+		zcx, zcy := bboxCenter(zone)
+
+		// ── core IC: anchor the module near its zone center ─────────────────
+		if m.Core == "" {
+			rep.Errors = append(rep.Errors, fmt.Sprintf("module %q has no core specified", m.Name))
+			rep.OK = false
+			continue
+		}
+		core, ok := byDes[m.Core]
+		if !ok || !core.HasBBox {
+			rep.Errors = append(rep.Errors, fmt.Sprintf("module %q core %q not found among placed parts (v1 moves existing parts only)", m.Name, m.Core))
+			rep.OK = false
+			continue
+		}
+		cw, ch := bboxSize(core.BBox)
+		coreStep := math.Max(cw, ch) + rules.PartGap
+		corePlaced, cRetries, cok := findSlot(core.BBox, zcx, zcy, coreStep, rules.PreferVertical, collides, inBounds, hitsTitle, nil)
+		if !cok {
+			rep.Errors = append(rep.Errors, fmt.Sprintf("module %q: could not place core %q without collision after %d candidate retries", m.Name, m.Core, alMaxRing*len(alDirsVertical)))
+			rep.OK = false
+			continue
+		}
+		ccx, ccy := bboxCenter(corePlaced)
+		rep.Placements = append(rep.Placements, makePlacement(core, ccx, ccy, m.Name, cRetries))
+		register(core, corePlaced)
+
+		// Register this core's fanout lanes (pins translated to the new center)
+		// so later peripherals (this module and beyond) keep them clear.
+		if rules.PreservePinFanout && len(core.Pins) > 0 {
+			ocx, ocy := bboxCenter(core.BBox)
+			dx, dy := ccx-ocx, ccy-ocy
+			moved := alPart{BBox: corePlaced}
+			for _, p := range core.Pins {
+				moved.Pins = append(moved.Pins, alPinPt{X: p.X + dx, Y: p.Y + dy})
+			}
+			coreLanes = append(coreLanes, coreFanoutLanes(moved, rules.RouteChannelGap, rules.PartGap/2)...)
+		}
+
+		// ── peripherals: deterministic order, ring out from the core ────────
+		periphs := make([]string, 0, len(m.Parts))
+		for _, d := range m.Parts {
+			if d != m.Core {
+				periphs = append(periphs, d)
+			}
+		}
+		sort.Strings(periphs)
+		for _, d := range periphs {
+			pt, ok := byDes[d]
+			if !ok || !pt.HasBBox {
+				rep.Warnings = append(rep.Warnings, alWarning{Module: m.Name, Message: fmt.Sprintf("part %q not found among placed parts — skipped (v1 moves existing parts only)", d)})
+				continue
+			}
+			pw, ph := bboxSize(pt.BBox)
+			step := math.Max(cw, ch)/2 + math.Max(pw, ph)/2 + rules.PartGap
+			box, retries, ok2 := findSlot(pt.BBox, ccx, ccy, step, rules.PreferVertical, collides, inBounds, hitsTitle, hitsLane)
+			if !ok2 {
+				// Last resort: relax the fanout-channel preference (still respect
+				// collisions, bounds, and the title block) and warn the human.
+				box, retries, ok2 = findSlot(pt.BBox, ccx, ccy, step, rules.PreferVertical, collides, inBounds, hitsTitle, nil)
+				if ok2 {
+					rep.Warnings = append(rep.Warnings, alWarning{Module: m.Name, Message: fmt.Sprintf("%s placed inside a pin-fanout lane (no clear slot otherwise)", d)})
+					rep.Validation.FanoutKeepoutHits++
+				}
+			}
+			if !ok2 {
+				rep.Errors = append(rep.Errors, fmt.Sprintf("module %q: could not place peripheral %q after candidate retries", m.Name, d))
+				rep.OK = false
+				continue
+			}
+			pcx, pcy := bboxCenter(box)
+			rep.Placements = append(rep.Placements, makePlacement(pt, pcx, pcy, m.Name, retries))
+			register(pt, box)
+		}
+	}
+
+	// ── validation summary ──────────────────────────────────────────────────
+	overlapRep := analyzeLayout(placedComps, 0) // minGap 0 → count true overlaps only
+	rep.Validation.PartOverlaps = len(overlapRep.Overlaps)
+	if rules.AvoidTitleBlock && tb != nil {
+		for _, b := range placed {
+			if boxesOverlap(b, *tb) {
+				rep.Validation.TitleBlockHits++
+			}
+		}
+	}
+	if rep.Validation.PartOverlaps > 0 || rep.Validation.TitleBlockHits > 0 {
+		rep.OK = false
+	}
+	return rep
+}

--- a/internal/app/cmd_sch_autolayout_run.go
+++ b/internal/app/cmd_sch_autolayout_run.go
@@ -1,0 +1,350 @@
+package app
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// ── autolayout orchestration (I/O side; the planner in cmd_sch_autolayout.go is pure) ──
+
+// alSpec is the `--spec` JSON shape (issue #25).
+type alSpec struct {
+	Page    string         `json:"page"`
+	Sheet   string         `json:"sheet"`
+	Modules []alSpecModule `json:"modules"`
+	Rules   *alSpecRules   `json:"rules"`
+}
+
+type alSpecModule struct {
+	Name  string   `json:"name"`
+	Zone  string   `json:"zone"`
+	Core  string   `json:"core"`
+	Parts []string `json:"parts"`
+}
+
+// alSpecRules mirrors the rules block; pointer fields so an omitted key keeps the
+// default instead of zeroing it.
+type alSpecRules struct {
+	AvoidTitleBlock                   *bool    `json:"avoidTitleBlock"`
+	PreservePinFanout                 *bool    `json:"preservePinFanout"`
+	ModuleGap                         *float64 `json:"moduleGap"`
+	RouteChannelGap                   *float64 `json:"routeChannelGap"`
+	PreferVerticalPeripheralPlacement *bool    `json:"preferVerticalPeripheralPlacement"`
+	PartGap                           *float64 `json:"partGap"`
+}
+
+// applyTo overlays the spec's rules onto a base ruleset.
+func (r *alSpecRules) applyTo(base autolayoutRules) autolayoutRules {
+	if r == nil {
+		return base
+	}
+	if r.AvoidTitleBlock != nil {
+		base.AvoidTitleBlock = *r.AvoidTitleBlock
+	}
+	if r.PreservePinFanout != nil {
+		base.PreservePinFanout = *r.PreservePinFanout
+	}
+	if r.ModuleGap != nil {
+		base.ModuleGap = *r.ModuleGap
+	}
+	if r.RouteChannelGap != nil {
+		base.RouteChannelGap = *r.RouteChannelGap
+	}
+	if r.PreferVerticalPeripheralPlacement != nil {
+		base.PreferVertical = *r.PreferVerticalPeripheralPlacement
+	}
+	if r.PartGap != nil {
+		base.PartGap = *r.PartGap
+	}
+	return base
+}
+
+// parseAutolayoutParts extracts the placed parts (anchor + bbox + pins) and the
+// sheet bbox from a components.list result. Non-part primitives other than the
+// sheet are ignored — the planner only moves real parts.
+func parseAutolayoutParts(result map[string]any) ([]alPart, *layoutBBox) {
+	raw, _ := result["components"].([]any)
+	var parts []alPart
+	var sheet *layoutBBox
+	for _, item := range raw {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		ctype := asString(m["componentType"])
+		var box *layoutBBox
+		if bm, ok := m["bbox"].(map[string]any); ok {
+			box = &layoutBBox{
+				MinX: asFloat(bm["minX"]), MinY: asFloat(bm["minY"]),
+				MaxX: asFloat(bm["maxX"]), MaxY: asFloat(bm["maxY"]),
+			}
+		}
+		switch ctype {
+		case "sheet":
+			if box != nil {
+				sheet = box
+			}
+		case "part", "":
+			p := alPart{
+				Designator:  asString(m["designator"]),
+				PrimitiveID: asString(m["primitiveId"]),
+				AnchorX:     asFloat(m["x"]),
+				AnchorY:     asFloat(m["y"]),
+				Rotation:    asFloat(m["rotation"]),
+			}
+			if box != nil {
+				p.BBox = *box
+				p.HasBBox = true
+			}
+			if pins, ok := m["pins"].([]any); ok {
+				for _, pp := range pins {
+					if pm, ok := pp.(map[string]any); ok {
+						p.Pins = append(p.Pins, alPinPt{X: asFloat(pm["x"]), Y: asFloat(pm["y"])})
+					}
+				}
+			}
+			parts = append(parts, p)
+		}
+	}
+	return parts, sheet
+}
+
+// runAutolayout pulls real geometry, plans, optionally applies, and renders.
+func runAutolayout(cfg *appConfig, window string, spec alSpec, rules autolayoutRules, apply, allPages, asJSON bool, stdout, stderr io.Writer) error {
+	res, err := requestAction(cfg, "schematic.components.list", window, map[string]any{
+		"includeBBox": true,
+		"includePins": true,
+		"allPages":    allPages,
+	})
+	if err != nil {
+		return err
+	}
+	parts, sheet := parseAutolayoutParts(res.Result)
+
+	modules := make([]alModuleSpec, 0, len(spec.Modules))
+	for _, m := range spec.Modules {
+		modules = append(modules, alModuleSpec{Name: m.Name, Zone: m.Zone, Core: m.Core, Parts: m.Parts})
+	}
+	rep := planAutolayout(modules, parts, sheet, rules)
+	rep.Page = spec.Page
+
+	if apply {
+		applyAutolayout(cfg, window, &rep, stderr)
+	}
+
+	if asJSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(rep); err != nil {
+			return err
+		}
+	} else {
+		renderAutolayoutReport(rep, apply, stdout)
+	}
+	if !rep.OK {
+		return fmt.Errorf("autolayout: incomplete (%d error(s), %d overlap(s))", len(rep.Errors), rep.Validation.PartOverlaps)
+	}
+	return nil
+}
+
+// applyAutolayout mutates the page (schematic.component.modify per placement),
+// then re-pulls geometry and re-runs the overlap check as a self-gate. It mutates
+// only when the plan itself is clean — a planning error means nothing is moved.
+func applyAutolayout(cfg *appConfig, window string, rep *alReport, stderr io.Writer) {
+	if !rep.OK {
+		rep.Note = strings.TrimSpace(rep.Note + " plan has errors — nothing applied.")
+		return
+	}
+	applied := 0
+	for i := range rep.Placements {
+		pl := &rep.Placements[i]
+		if pl.PrimitiveID == "" {
+			continue
+		}
+		_, aerr := requestAction(cfg, "schematic.component.modify", window, map[string]any{
+			"primitiveId": pl.PrimitiveID,
+			"patch":       map[string]any{"x": pl.X, "y": pl.Y},
+		})
+		if aerr != nil {
+			rep.Errors = append(rep.Errors, fmt.Sprintf("apply %s: %v", pl.Designator, aerr))
+			rep.OK = false
+			break
+		}
+		applied++
+	}
+	rep.Note = strings.TrimSpace(rep.Note + fmt.Sprintf(" applied %d/%d placements.", applied, len(rep.Placements)))
+
+	if !rep.OK {
+		return
+	}
+	// Post-apply self-check: pull the real rendered bboxes and re-run layout-lint.
+	lres, lerr := requestAction(cfg, "schematic.components.list", window, map[string]any{"includeBBox": true})
+	if lerr != nil {
+		fmt.Fprintf(stderr, "autolayout: post-apply layout-lint skipped: %v\n", lerr)
+		return
+	}
+	comps, perr := parseLayoutComps(lres.Result)
+	if perr != nil {
+		fmt.Fprintf(stderr, "autolayout: post-apply layout-lint skipped: %v\n", perr)
+		return
+	}
+	kept, _ := filterLayoutComps(comps, false)
+	lrep := analyzeLayout(kept, 0)
+	rep.Validation.PartOverlaps = len(lrep.Overlaps)
+	if len(lrep.Overlaps) > 0 {
+		rep.OK = false
+	}
+}
+
+// renderAutolayoutReport prints a compact human summary.
+func renderAutolayoutReport(rep alReport, apply bool, w io.Writer) {
+	mode := "plan (dry-run)"
+	if apply {
+		mode = "apply"
+	}
+	fmt.Fprintf(w, "autolayout: %d placement(s), mode=%s", len(rep.Placements), mode)
+	if rep.Page != "" {
+		fmt.Fprintf(w, ", page=%s", rep.Page)
+	}
+	fmt.Fprintln(w)
+	if rep.Note != "" {
+		fmt.Fprintf(w, "  note: %s\n", rep.Note)
+	}
+	if rep.TitleBlockProvisional {
+		fmt.Fprintf(w, "  note: title-block keep-out is provisional (no sheet bbox) — NOT enforced\n")
+	}
+	for _, p := range rep.Placements {
+		retry := ""
+		if p.Retries > 0 {
+			retry = fmt.Sprintf(" (retry %d)", p.Retries)
+		}
+		fmt.Fprintf(w, "  • %-6s [%s] → (%.2f, %.2f) rot=%.0f%s\n", p.Designator, p.Module, p.X, p.Y, p.Rotation, retry)
+	}
+	for _, wn := range rep.Warnings {
+		fmt.Fprintf(w, "  WARN  [%s] %s\n", wn.Module, wn.Message)
+	}
+	for _, e := range rep.Errors {
+		fmt.Fprintf(w, "  ERROR %s\n", e)
+	}
+	v := rep.Validation
+	fmt.Fprintf(w, "  validation: partOverlaps=%d titleBlockHits=%d fanoutKeepoutHits=%d\n", v.PartOverlaps, v.TitleBlockHits, v.FanoutKeepoutHits)
+	if rep.OK {
+		fmt.Fprintf(w, "✓ layout plan OK\n")
+	} else {
+		fmt.Fprintf(w, "✗ layout incomplete\n")
+	}
+}
+
+// newAutolayoutCmd builds the `sch autolayout` subcommand.
+func newAutolayoutCmd(cfg *appConfig, window *string, stdout, stderr io.Writer) *cobra.Command {
+	var (
+		spec                                            string
+		dryRun, apply                                   bool
+		allPages, asJSON                                bool
+		avoidTitleBlock, preserveFanout, preferVertical bool
+		moduleGap, channelGap, partGap                  float64
+	)
+	c := &cobra.Command{
+		Use:   "autolayout",
+		Short: "Module-aware planner: place parts by module zone with deterministic, lint-clean coordinates",
+		Long: `Module-aware schematic placement planner.
+
+autolayout solves MODULE-LEVEL placement (not routing): it reads a --spec (page,
+sheet, modules with zone/core/parts, rules), partitions the usable canvas into
+named zones (left-top / left-bottom / center / right / right-top / right-bottom /
+…), places each module's core IC near its zone center, fans peripherals around
+the core, and retries candidate positions on collision — all while preserving
+each core pin's fanout channel and the A4 title-block keep-out.
+
+The planner is PURE and deterministic: the same spec on the same input always
+yields identical coordinates that pass 'sch layout-lint'. v1 only MOVES parts
+that are already placed (it does not create missing parts).
+
+  --dry-run  return proposed coordinates + warnings, mutate nothing (default)
+  --apply    move parts via schematic.component.modify, then self-check overlaps
+  --json     emit the structured report
+
+Spec shape:
+  {
+    "page": "P1_MCU_USB_STORAGE", "sheet": "A4",
+    "modules": [
+      {"name":"MCU","zone":"center","core":"U1","parts":["U1","C18","R6"]}
+    ],
+    "rules": {"avoidTitleBlock":true,"preservePinFanout":true,
+              "moduleGap":80,"routeChannelGap":40,
+              "preferVerticalPeripheralPlacement":true}
+  }`,
+		Args: cobra.NoArgs,
+		Example: `  easyeda sch autolayout --spec p1-layout.json --dry-run
+  easyeda sch autolayout --spec p1-layout.json --apply
+  easyeda sch autolayout --spec p1-layout.json --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if spec == "" {
+				return fmt.Errorf("--spec is required (a layout spec JSON file)")
+			}
+			if dryRun && apply {
+				return fmt.Errorf("--dry-run and --apply are mutually exclusive")
+			}
+			raw, err := os.ReadFile(spec)
+			if err != nil {
+				return fmt.Errorf("read --spec: %w", err)
+			}
+			var s alSpec
+			if err := json.Unmarshal(raw, &s); err != nil {
+				return fmt.Errorf("invalid --spec json: %w", err)
+			}
+			if len(s.Modules) == 0 {
+				return fmt.Errorf("--spec has no modules")
+			}
+			for _, m := range s.Modules {
+				if m.Name == "" {
+					return fmt.Errorf("every module needs a name")
+				}
+				if len(m.Parts) == 0 {
+					return fmt.Errorf("module %q has no parts", m.Name)
+				}
+			}
+
+			rules := defaultAutolayoutRules()
+			rules = s.Rules.applyTo(rules)
+			// Explicit CLI flags win over the spec's rules block.
+			if cmd.Flags().Changed("avoid-titleblock") {
+				rules.AvoidTitleBlock = avoidTitleBlock
+			}
+			if cmd.Flags().Changed("preserve-pin-fanout") {
+				rules.PreservePinFanout = preserveFanout
+			}
+			if cmd.Flags().Changed("prefer-vertical") {
+				rules.PreferVertical = preferVertical
+			}
+			if cmd.Flags().Changed("module-gap") {
+				rules.ModuleGap = moduleGap
+			}
+			if cmd.Flags().Changed("route-channel-gap") {
+				rules.RouteChannelGap = channelGap
+			}
+			if cmd.Flags().Changed("part-gap") {
+				rules.PartGap = partGap
+			}
+
+			return runAutolayout(cfg, *window, s, rules, apply, allPages, asJSON, stdout, stderr)
+		},
+	}
+	c.Flags().StringVar(&spec, "spec", "", "layout spec JSON file (required)")
+	c.Flags().BoolVar(&dryRun, "dry-run", false, "plan and print proposed coordinates without mutating (default behavior)")
+	c.Flags().BoolVar(&apply, "apply", false, "move parts via schematic.component.modify, then self-check overlaps")
+	c.Flags().BoolVar(&allPages, "all-pages", false, "build the scene from all schematic pages")
+	c.Flags().BoolVar(&asJSON, "json", false, "emit the report as JSON")
+	c.Flags().BoolVar(&avoidTitleBlock, "avoid-titleblock", true, "treat the title block as a hard keep-out")
+	c.Flags().BoolVar(&preserveFanout, "preserve-pin-fanout", true, "keep peripherals out of core pin lead-out lanes")
+	c.Flags().BoolVar(&preferVertical, "prefer-vertical", true, "try vertical peripheral placement before horizontal")
+	c.Flags().Float64Var(&moduleGap, "module-gap", 80, "nominal inter-module breathing room")
+	c.Flags().Float64Var(&channelGap, "route-channel-gap", 40, "length of a preserved pin-fanout channel")
+	c.Flags().Float64Var(&partGap, "part-gap", 20, "minimum edge-to-edge gap between two parts")
+	return c
+}

--- a/internal/app/cmd_sch_autolayout_test.go
+++ b/internal/app/cmd_sch_autolayout_test.go
@@ -1,0 +1,218 @@
+package app
+
+import "testing"
+
+// part is a tiny test helper: a placed part whose anchor sits at its bbox center
+// (anchorOffset 0), so target-center == target-anchor and the asserted
+// coordinates read directly.
+func part(des string, minX, minY, maxX, maxY float64) alPart {
+	b := layoutBBox{MinX: minX, MinY: minY, MaxX: maxX, MaxY: maxY}
+	cx, cy := bboxCenter(b)
+	return alPart{Designator: des, PrimitiveID: "id-" + des, AnchorX: cx, AnchorY: cy, BBox: b, HasBBox: true}
+}
+
+func a4Sheet() *layoutBBox { return &layoutBBox{MinX: 0, MinY: 0, MaxX: 1188, MaxY: 840} }
+
+func rulesAL() autolayoutRules { return defaultAutolayoutRules() }
+
+func placementOf(rep alReport, des string) (alPlacement, bool) {
+	for _, p := range rep.Placements {
+		if p.Designator == des {
+			return p, true
+		}
+	}
+	return alPlacement{}, false
+}
+
+func TestPlanAutolayout_CorePlacedAtZoneCenter(t *testing.T) {
+	parts := []alPart{part("U1", 0, 0, 40, 40)}
+	modules := []alModuleSpec{{Name: "MCU", Zone: "center", Core: "U1", Parts: []string{"U1"}}}
+	rep := planAutolayout(modules, parts, a4Sheet(), rulesAL())
+	if !rep.OK {
+		t.Fatalf("expected OK plan, got errors=%v", rep.Errors)
+	}
+	pl, ok := placementOf(rep, "U1")
+	if !ok {
+		t.Fatal("U1 not placed")
+	}
+	// center zone center: x in [1/3,2/3] of 1188 → mid = 594; y full → 420.
+	zr := zoneRect("center", *a4Sheet())
+	wantX, wantY := bboxCenter(zr)
+	if pl.X != round2(wantX) || pl.Y != round2(wantY) {
+		t.Errorf("core not at zone center: got (%.2f,%.2f) want (%.2f,%.2f)", pl.X, pl.Y, wantX, wantY)
+	}
+}
+
+func TestPlanAutolayout_Deterministic(t *testing.T) {
+	parts := []alPart{
+		part("U1", 0, 0, 40, 40),
+		part("C18", 0, 0, 8, 8),
+		part("C19", 0, 0, 8, 8),
+		part("R6", 0, 0, 6, 12),
+		part("U8", 500, 500, 540, 540),
+		part("C28", 500, 500, 508, 508),
+	}
+	modules := []alModuleSpec{
+		{Name: "MCU", Zone: "center", Core: "U1", Parts: []string{"U1", "C18", "C19", "R6"}},
+		{Name: "SD", Zone: "right", Core: "U8", Parts: []string{"U8", "C28"}},
+	}
+	a := planAutolayout(modules, parts, a4Sheet(), rulesAL())
+	b := planAutolayout(modules, parts, a4Sheet(), rulesAL())
+	if len(a.Placements) != len(b.Placements) {
+		t.Fatalf("placement count differs: %d vs %d", len(a.Placements), len(b.Placements))
+	}
+	for i := range a.Placements {
+		if a.Placements[i] != b.Placements[i] {
+			t.Fatalf("non-deterministic at %d: %+v vs %+v", i, a.Placements[i], b.Placements[i])
+		}
+	}
+}
+
+func TestPlanAutolayout_NoOverlaps(t *testing.T) {
+	parts := []alPart{
+		part("U1", 0, 0, 40, 40),
+		part("C18", 0, 0, 8, 8),
+		part("C19", 0, 0, 8, 8),
+		part("C20", 0, 0, 8, 8),
+		part("R6", 0, 0, 6, 12),
+		part("R7", 0, 0, 6, 12),
+	}
+	modules := []alModuleSpec{{Name: "MCU", Zone: "center", Core: "U1",
+		Parts: []string{"U1", "C18", "C19", "C20", "R6", "R7"}}}
+	rep := planAutolayout(modules, parts, a4Sheet(), rulesAL())
+	if !rep.OK {
+		t.Fatalf("expected OK, got errors=%v", rep.Errors)
+	}
+	if rep.Validation.PartOverlaps != 0 {
+		t.Errorf("expected 0 overlaps, got %d", rep.Validation.PartOverlaps)
+	}
+	if len(rep.Placements) != 6 {
+		t.Errorf("expected 6 placements, got %d", len(rep.Placements))
+	}
+}
+
+func TestPlanAutolayout_MissingCoreErrors(t *testing.T) {
+	parts := []alPart{part("C18", 0, 0, 8, 8)}
+	modules := []alModuleSpec{{Name: "MCU", Zone: "center", Core: "U1", Parts: []string{"U1", "C18"}}}
+	rep := planAutolayout(modules, parts, a4Sheet(), rulesAL())
+	if rep.OK {
+		t.Fatal("expected NOT OK when core is missing")
+	}
+	if len(rep.Errors) == 0 {
+		t.Fatal("expected a clear error for the missing core")
+	}
+}
+
+func TestPlanAutolayout_TitleBlockKeepout(t *testing.T) {
+	// A module pinned to the right-bottom zone (where the A4 title block sits)
+	// must NOT land any part inside the keep-out.
+	parts := []alPart{
+		part("U8", 0, 0, 40, 40),
+		part("C28", 0, 0, 8, 8),
+		part("C29", 0, 0, 8, 8),
+	}
+	modules := []alModuleSpec{{Name: "SD", Zone: "right-bottom", Core: "U8", Parts: []string{"U8", "C28", "C29"}}}
+	rep := planAutolayout(modules, parts, a4Sheet(), rulesAL())
+	if rep.Validation.TitleBlockHits != 0 {
+		t.Errorf("expected 0 title-block hits, got %d", rep.Validation.TitleBlockHits)
+	}
+	if !rep.OK {
+		t.Fatalf("expected OK plan, got errors=%v", rep.Errors)
+	}
+	// Every placed box must be clear of the keep-out.
+	tb, _ := titleBlockKeepout(a4Sheet())
+	for _, p := range rep.Placements {
+		// reconstruct the placed box center from the anchor (offset 0 here)
+		if tb != nil && p.X >= tb.MinX && p.X <= tb.MaxX && p.Y >= tb.MinY && p.Y <= tb.MaxY {
+			t.Errorf("%s landed inside the title-block keep-out at (%.2f,%.2f)", p.Designator, p.X, p.Y)
+		}
+	}
+}
+
+func TestPlanAutolayout_CollisionRetryAcrossModules(t *testing.T) {
+	// Two modules whose zones both reach toward the center: parts must not
+	// overlap even when cores are close. Validation must stay clean.
+	parts := []alPart{
+		part("U1", 0, 0, 60, 60),
+		part("C1", 0, 0, 10, 10),
+		part("C2", 0, 0, 10, 10),
+		part("U2", 0, 0, 60, 60),
+		part("C3", 0, 0, 10, 10),
+		part("C4", 0, 0, 10, 10),
+	}
+	modules := []alModuleSpec{
+		{Name: "A", Zone: "center", Core: "U1", Parts: []string{"U1", "C1", "C2"}},
+		{Name: "B", Zone: "center", Core: "U2", Parts: []string{"U2", "C3", "C4"}},
+	}
+	rep := planAutolayout(modules, parts, a4Sheet(), rulesAL())
+	if !rep.OK {
+		t.Fatalf("expected OK, got errors=%v", rep.Errors)
+	}
+	if rep.Validation.PartOverlaps != 0 {
+		t.Errorf("two same-zone modules still overlap: %d", rep.Validation.PartOverlaps)
+	}
+}
+
+func TestPlanAutolayout_SkipsUnplacedPeripheral(t *testing.T) {
+	// A peripheral named in the spec but not placed is warned + skipped, not a
+	// hard error (v1 only moves existing parts).
+	parts := []alPart{
+		part("U1", 0, 0, 40, 40),
+		part("C18", 0, 0, 8, 8),
+	}
+	modules := []alModuleSpec{{Name: "MCU", Zone: "center", Core: "U1", Parts: []string{"U1", "C18", "C99"}}}
+	rep := planAutolayout(modules, parts, a4Sheet(), rulesAL())
+	if !rep.OK {
+		t.Fatalf("expected OK (missing peripheral is a warning), got errors=%v", rep.Errors)
+	}
+	if len(rep.Warnings) == 0 {
+		t.Error("expected a warning for the unplaced peripheral C99")
+	}
+	if _, ok := placementOf(rep, "C99"); ok {
+		t.Error("C99 should not have been placed")
+	}
+}
+
+func TestPlanAutolayout_ProvisionalWhenNoSheet(t *testing.T) {
+	parts := []alPart{
+		part("U1", 100, 100, 140, 140),
+		part("C1", 100, 100, 108, 108),
+	}
+	modules := []alModuleSpec{{Name: "MCU", Zone: "center", Core: "U1", Parts: []string{"U1", "C1"}}}
+	rep := planAutolayout(modules, parts, nil, rulesAL())
+	if !rep.TitleBlockProvisional {
+		t.Error("expected provisional title block when no sheet bbox")
+	}
+	if !rep.OK {
+		t.Fatalf("expected OK plan, got errors=%v", rep.Errors)
+	}
+}
+
+func TestZoneRect_Partitions(t *testing.T) {
+	u := layoutBBox{MinX: 0, MinY: 0, MaxX: 900, MaxY: 600}
+	lt := zoneRect("left-top", u)
+	if lt.MinX != 0 || lt.MaxX != 300 || lt.MinY != 0 || lt.MaxY != 300 {
+		t.Errorf("left-top wrong: %+v", lt)
+	}
+	rb := zoneRect("right-bottom", u)
+	if rb.MinX != 600 || rb.MaxX != 900 || rb.MinY != 300 || rb.MaxY != 600 {
+		t.Errorf("right-bottom wrong: %+v", rb)
+	}
+	// unknown zone → center, full height
+	ce := zoneRect("nonsense", u)
+	if ce.MinX != 300 || ce.MaxX != 600 || ce.MinY != 0 || ce.MaxY != 600 {
+		t.Errorf("unknown zone should fall back to center/full: %+v", ce)
+	}
+}
+
+func TestMakePlacement_AnchorOffsetPreserved(t *testing.T) {
+	// A part whose anchor is NOT at its bbox center: moving must shift the anchor
+	// by the same delta the bbox center moves.
+	p := alPart{Designator: "U1", AnchorX: 0, AnchorY: 0,
+		BBox: layoutBBox{MinX: 10, MinY: 10, MaxX: 30, MaxY: 30}, HasBBox: true}
+	// bbox center is (20,20); move it to (120, 220) → anchor delta (+100,+200).
+	pl := makePlacement(p, 120, 220, "M", 0)
+	if pl.X != 100 || pl.Y != 200 {
+		t.Errorf("anchor offset not preserved: got (%.2f,%.2f) want (100,200)", pl.X, pl.Y)
+	}
+}

--- a/skills/easyeda-design-flow/SKILL.md
+++ b/skills/easyeda-design-flow/SKILL.md
@@ -48,6 +48,7 @@ S0 预分析 → S1 分页💾 → S2 模块编组 → S3 按组摆放💾 → S
 ### S3 — 按组摆放(芯片 + 外围一起)
 - **做什么**:**逐组**放置——先放该组核心芯片,再把它的外围**就近**放在芯片周围(去耦贴电源脚、晶振贴时钟脚…),放完一组再下一组。
 - **怎么做**:`easyeda sch place` + `sch modify`(设位号);坐标按 S2 的分区。库优先、选型规则见 easyeda-schematic / conventions。
+- **整组分区摆放优先用 `easyeda sch autolayout`**(模块级放置规划器):把 S2 的分区写成 `--spec`(每个 module 给 `zone`/`core`/`parts` 与规则),它按真实 bbox 把核心芯片放到分区中心、外围环绕核心、碰撞自动重试,并保留引脚 fanout 通道 + A4 标题栏 keep-out,**确定性产出可过 layout-lint 的坐标**。先 `--dry-run` 看方案,满意再 `--apply`(经 `component.modify` 落子并自检 overlap)。**v1 只移动「已放置」的器件**,不创建缺件——所以先 `sch place` 把器件放上页,再用 autolayout 排布。手动 `sch place`/`modify` 仍是逐件微调的兜底。
 - **💾 过门条件**:进入 S4 前**必须先过 S5 的 layout-lint**——本组无覆盖、组内外围紧凑、组间不挤。**有 ERROR 先回 S3 调整**(`sch move`/`align`/`distribute`)。过了就 `easyeda sch save`(整板放置每 ~10 件存一次,别等全放完)。
 
 ### S4 — 通道布线(留距离,别压元件)

--- a/skills/easyeda-schematic/SKILL.md
+++ b/skills/easyeda-schematic/SKILL.md
@@ -153,6 +153,60 @@ enforced (so a guessed box can't corrupt scoring). **Prefer `sch autoconnect`
 over hand-picking `sch connect --direction/--offset`** for power/ground/netport
 stubs; `sch connect` stays for when you deliberately override the geometry.
 
+## Module-aware autolayout — place parts by module zone
+
+Where `autoconnect` is pin-level, **`sch autolayout` is module-level placement**:
+it reads a `--spec` (page, sheet, modules with `zone`/`core`/`parts`, rules),
+pulls the real geometry (anchors + bboxes + core pins + sheet bbox), partitions
+the usable canvas into named zones (`left-top` / `left-bottom` / `center` /
+`right` / `right-top` / `right-bottom` / …), places each module's **core IC near
+its zone center**, fans the **peripherals around the core** with collision retry,
+and keeps each core pin's **fanout channel** and the **A4 title-block** clear.
+Same pure-scorer style as autoconnect: identical spec + input → identical
+coordinates that pass `sch layout-lint`.
+
+```bash
+# preview proposed coordinates + warnings, mutate nothing (default)
+easyeda sch autolayout --spec p1-layout.json --dry-run
+
+# move parts via schematic.component.modify, then self-check overlaps
+easyeda sch autolayout --spec p1-layout.json --apply
+
+# structured report
+easyeda sch autolayout --spec p1-layout.json --json
+```
+
+Spec JSON (`--spec`):
+
+```json
+{
+  "page": "P1_MCU_USB_STORAGE", "sheet": "A4",
+  "modules": [
+    {"name":"USB_HUB","zone":"left-top","core":"U10","parts":["J2","U10","X1","C30","R15"]},
+    {"name":"MCU","zone":"center","core":"U1","parts":["U1","C18","C19","R6"]},
+    {"name":"SD_NAND","zone":"right","core":"U8","parts":["U8","C28","R10"]}
+  ],
+  "rules": {"avoidTitleBlock":true,"preservePinFanout":true,
+            "moduleGap":80,"routeChannelGap":40,
+            "preferVerticalPeripheralPlacement":true}
+}
+```
+
+The result reports each `placement` (designator / x / y / rotation / module), any
+`warnings` (e.g. a peripheral forced into a fanout lane, or a spec part not yet
+placed), and a `validation` summary (`partOverlaps` / `titleBlockHits` /
+`fanoutKeepoutHits`). Notes:
+
+- **v1 moves already-placed parts only** — it does NOT create missing parts; a
+  spec part absent from the page is warned + skipped. Place the parts first
+  (library-first), then `autolayout` arranges them.
+- A **missing core** is a hard error for that module (clear diagnostic).
+- When the **sheet bbox isn't exposed**, the title-block keep-out is reported as
+  **provisional** and not geometrically enforced.
+- `autolayout` solves **module placement, not routing** — follow it with
+  `sch autoconnect` (power/ground/netport) + wiring, then `sch layout-lint` /
+  `sch drc` to gate.
+
 ## Actions
 
 Run `easyeda actions` for the current machine-readable action list.


### PR DESCRIPTION
Fixes #25

## What

Implements `easyeda sch autolayout` — a module-aware schematic **placement** planner (the larger second deliverable from #23, built on the autoconnect geometry model from #24).

It reads a `--spec` (page, sheet, modules with `zone`/`core`/`parts`, rules), pulls real geometry (anchors + bboxes + core pins + sheet bbox via `schematic.components.list --include-bbox --include-pins`), partitions the usable canvas into named zones (`left-top`/`left-bottom`/`center`/`right`/`right-top`/`right-bottom`/…), places each module's **core IC near its zone center**, fans **peripherals around the core** with collision retry, and keeps each core pin's **fanout channel** + the **A4 title-block** clear.

## How it fits

- **Pure deterministic core** (`cmd_sch_autolayout.go`: `planAutolayout` + geometry helpers) — same spec + input → identical coordinates; unit-testable with no connector. Same style as `autoconnect`'s scorer.
- **Reuses** `layoutBBox` / `boxesOverlap` / `rectGap` / `titleBlockKeepout` / `analyzeLayout` rather than re-deriving geometry.
- **I/O side** (`cmd_sch_autolayout_run.go`): spec parsing, `--apply` via `schematic.component.modify`, post-apply `layout-lint` self-check.

## CLI

```bash
easyeda sch autolayout --spec p1-layout.json --dry-run   # plan only (default)
easyeda sch autolayout --spec p1-layout.json --apply     # move parts + self-check
easyeda sch autolayout --spec p1-layout.json --json      # structured report
```

## Decisions on the open questions

- **Title-block source**: reuse `titleBlockKeepout` (derived from the sheet bbox); when no sheet bbox is exposed it's reported **provisional** and not enforced.
- **Create vs move**: v1 **moves already-placed parts only**; a spec part absent from the page is warned + skipped (not a hard failure).
- **Failure policy**: **fail-fast** with a clear per-module diagnostic (missing core, or peripheral unplaceable after candidate retries); zones are not auto-expanded.

## Tests

`go test ./...` green. New unit tests cover: zone partitioning, core-at-zone-center, determinism (identical coords across runs), 0 overlaps in validation, title-block keep-out respected, cross-module collision retry, missing-core error, unplaced-peripheral skip, and anchor-offset preservation.

## Docs

Updated `easyeda-schematic` SKILL (new autolayout section), `easyeda-design-flow` SKILL (S3 place-by-group note), and `docs/FEATURES.md` (Go-side CLI planners entry).

## Not verified

Pure-geometry + unit tests only — no live EasyEDA `--apply` run against a connected window in this environment (requires an open project with external interaction enabled). The planner output is deterministic and the apply path delegates to the existing `component.modify` action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)