### PR TITLE
fix: detect stale frames in pcb snapshot like sch snapshot

### DIFF
--- a/extension/src/actions.ts
+++ b/extension/src/actions.ts
@@ -3658,31 +3658,64 @@ const pcbImportAutoroute: Handler = async (payload) => {
 const pcbSnapshot: Handler = async (payload) => {
 	const tabId = optionalString(payload, 'tabId');
 	const fit = optionalBoolean(payload, 'fit') !== false;
+	// Optional sha256 of the PREVIOUS snapshot (caller threads it back in). When
+	// present we can DETECT a stale frame ourselves (issue #31) instead of only
+	// emitting advisory text: if the viewport changed but the image bytes are
+	// byte-identical, the capture is stale — we force a redraw + retry once.
+	const previousSha = optionalString(payload, 'previousSha256');
 	let fitted = false;
 	if (fit) {
 		try { await eda.dmt_EditorControl.zoomToAllPrimitives(); fitted = true; }
 		catch { /* best-effort */ }
 	}
+	// Let any pending viewport change (a preceding `view region`/`view zoom`, or
+	// the zoomToAllPrimitives above) commit + repaint before we read the frame.
 	await waitForCanvasSettle();
-	let blob;
-	try {
-		blob = await eda.dmt_EditorControl.getCurrentRenderedAreaImage(tabId);
+
+	const capture = async (): Promise<Blob> => {
+		let b;
+		try {
+			b = await eda.dmt_EditorControl.getCurrentRenderedAreaImage(tabId);
+		}
+		catch (err) {
+			throw edaError(err, 'Failed to capture PCB snapshot.');
+		}
+		if (!b) {
+			throw new ActionError(ErrorCodes.EDA_CALL_FAILED, 'PCB snapshot returned no image.');
+		}
+		return b;
+	};
+
+	let blob = await capture();
+	let sha256 = await blobSha256(blob);
+	// Built-in stale detection: if the caller told us the prior frame's sha and we
+	// got the exact same bytes back, the canvas almost certainly didn't repaint —
+	// force a redraw (ratline recompute + zoom-to-all nudge) and recapture once.
+	let staleRetry = false;
+	if (previousSha && sha256 && sha256 === previousSha) {
+		staleRetry = true;
+		// Stronger redraw nudge than schematic's re-settle: a ratline recompute +
+		// re-fit reliably forces EasyEDA to repaint the PCB canvas.
+		try { await eda.pcb_Document.startCalculatingRatline(); }
+		catch { /* best-effort redraw nudge */ }
+		try { await eda.dmt_EditorControl.zoomToAllPrimitives(); }
+		catch { /* best-effort redraw nudge */ }
+		await waitForCanvasSettle();
+		blob = await capture();
+		sha256 = await blobSha256(blob);
 	}
-	catch (err) {
-		throw edaError(err, 'Failed to capture PCB snapshot.');
-	}
-	if (!blob) {
-		throw new ActionError(ErrorCodes.EDA_CALL_FAILED, 'PCB snapshot returned no image.');
-	}
-	const sha256 = await blobSha256(blob);
+	const stale = Boolean(previousSha && sha256 && sha256 === previousSha);
+
 	const artifact = await blobToArtifact(blob, 'pcb_snapshot', 'pcb-snapshot.png', 'image/png');
 	return {
 		result: {
 			artifactId: artifact.id,
 			fitted,
 			sha256,
+			stale,
+			staleRetry,
 			capturedAt: new Date().toISOString(),
-			staleHint: 'EasyEDA may not auto-redraw after API edits; judge state by data (pcb list/drc), screenshot for layout only.',
+			staleHint: 'EasyEDA may not auto-redraw after API edits. Thread this sha256 back as previousSha256 on the next snapshot to auto-detect a stale frame; judge state by data (pcb list/drc), screenshot for layout only.',
 		},
 		artifacts: [artifact],
 	};

--- a/internal/app/cmd_pcb.go
+++ b/internal/app/cmd_pcb.go
@@ -1187,17 +1187,24 @@ external router (Freerouting) would route under the antenna. The result reports
 	}
 	{
 		var fit bool
+		var previousSha string
 		c := &cobra.Command{
 			Use:   "snapshot",
 			Short: "Capture the active PCB canvas as a PNG artifact",
 			Args:  cobra.NoArgs,
 			Example: `  easyeda pcb snapshot
-  easyeda pcb snapshot --fit=false`,
+  easyeda pcb snapshot --fit=false
+  easyeda view region --left 500 --right 1550 --top -1500 --bottom -2260 && easyeda pcb snapshot --fit=false --previous-sha256 <sha>`,
 			RunE: func(cmd *cobra.Command, args []string) error {
-				return dispatch(cfg, "pcb.snapshot", window, map[string]any{"fit": fit}, stdout, stderr)
+				payload := map[string]any{"fit": fit}
+				if previousSha != "" {
+					payload["previousSha256"] = previousSha
+				}
+				return dispatch(cfg, "pcb.snapshot", window, payload, stdout, stderr)
 			},
 		}
 		c.Flags().BoolVar(&fit, "fit", true, "zoom-to-fit before capture (nudges a redraw)")
+		c.Flags().StringVar(&previousSha, "previous-sha256", "", "sha256 of the previous snapshot; enables stale-frame detection + auto-retry")
 		pcb.AddCommand(c)
 	}
 	// ── autoroute: one-command Freerouting round-trip ────────────────────────

--- a/internal/protocol/actions.go
+++ b/internal/protocol/actions.go
@@ -754,9 +754,9 @@ func AllActions() []ActionSpec {
 			Domain:      DomainPcb,
 			Phase:       2,
 			NeedsWindow: true,
-			Description: "Capture the active PCB canvas as a PNG artifact (eda.dmt_EditorControl.getCurrentRenderedAreaImage; fit-to-all by default, pass fit=false to keep viewport). The PCB counterpart to schematic.snapshot. WARNING: EasyEDA may return a STALE frame after API edits — judge layout/DRC by data (pcb list / pcb drc), screenshot for a human eyeball only.",
-			Inputs:      []string{"fit optional (default true)", "tabId optional"},
-			Outputs:     []string{"artifact id", "file path", "fitted", "sha256", "capturedAt"},
+			Description: "Capture the active PCB canvas as a PNG artifact (eda.dmt_EditorControl.getCurrentRenderedAreaImage; fit-to-all by default, pass fit=false to keep viewport). The PCB counterpart to schematic.snapshot. Returns a frame sha256 — pass it back via previousSha256 on the next snapshot and the connector detects a byte-identical (stale) frame, forces a redraw (ratline recompute + zoom-to-all) + retries once, and reports stale=true if it is still identical. WARNING: EasyEDA may return a STALE frame after API edits — judge layout/DRC by data (pcb list / pcb drc), screenshot for a human eyeball only.",
+			Inputs:      []string{"fit optional (default true)", "tabId optional", "previousSha256 optional (enables stale-frame detection + auto-retry)"},
+			Outputs:     []string{"artifact id", "file path", "fitted", "sha256", "stale", "staleRetry", "capturedAt"},
 		},
 		// ─── PCB routing: list + rip-up (iterate/clear copper routing) ────
 		{

--- a/skills/easyeda-agent/references/pcb.md
+++ b/skills/easyeda-agent/references/pcb.md
@@ -173,6 +173,16 @@ layer 12, so list/delete via `pcb fill list --layer 12` / `pcb fill delete`.
 > does NOT auto-redraw after API edits and does not render filled copper/cutouts, so a
 > fresh snapshot shows a **stale frame**. Verify slots/fills/pours by **data** (`pcb fill
 > list`, DRC, manufacture export), not screenshot — the snapshot is for component layout only.
+>
+> **Stale-frame detection (issue #31).** `pcb snapshot` now has parity with `sch snapshot`:
+> the result exposes a frame `sha256`, and `--previous-sha256 <sha>` lets the connector
+> detect a byte-identical (stale) frame, force a redraw (ratline recompute + zoom-to-all)
+> and retry once, reporting `stale:true` if it still cannot refresh. **Reliable recording
+> workflow** for user-facing videos/tutorials where the visual artifact is required:
+> 1. `easyeda view region --left … --right … --top … --bottom …`（或 `easyeda view fit`）框住目标视口。
+> 2. `easyeda pcb snapshot --fit=false --previous-sha256 <上一次的 sha256>`。
+> 3. 若结果 `stale:true`，说明画布未刷新 — 告警/失败，不要用该帧。
+> 4. 用 `pcb list` / `pcb drc` / `pcb check` / `pcb layout-lint` 做**权威**正确性校验（截图只作视觉终检）。
 
 > **Routing boundary (load-bearing — see `docs/ecosystem-survey.md` §7):** EasyEDA's
 > interactive 布线 menu (single/multi/differential **routing**, stretch, optimize,


### PR DESCRIPTION
Fixes #31

## 背景
在 EasyEDA Pro 上录制 ESP32 PCB 流程时，改变视口后 `easyeda pcb snapshot` 仍返回字节相同的 PNG（相同 SHA-256）。`pcb snapshot` 缺少 `sch snapshot` 已有的 stale-frame 检测/重试能力，静默返回旧帧，破坏录制/演示校验。

## 改动
- **extension/src/actions.ts `pcbSnapshot`**：新增 `previousSha256` 入参；捕获逻辑抽成 `capture()` 闭包；当帧字节与上一次相同（`sha256 === previousSha`）时，执行更强的重绘 nudge（`startCalculatingRatline()` + `zoomToAllPrimitives()`）+ `waitForCanvasSettle()` 后重拍一次；结果新增 `stale` / `staleRetry` 字段，与 `schematicSnapshot` 对齐。
- **internal/app/cmd_pcb.go**：`pcb snapshot` 新增 `--previous-sha256` flag，非空时透传进 payload（对齐 `cmd_sch.go`）。
- **internal/protocol/actions.go**：`pcb.snapshot` 的 Inputs 补 `previousSha256`，Outputs 补 `stale` / `staleRetry`，Description 同步 stale 检测/重试说明。
- **skills/easyeda-agent/references/pcb.md**：记录可靠录制流程（view region|fit → pcb snapshot --fit=false --previous-sha256 → stale:true 告警 → 用 pcb list/drc/check/layout-lint 权威校验）。

## 测试
- `go build ./...`、`go vet`、`go test ./internal/...` 全部通过。
- 扩展 `npm run typecheck` 与 `npm test`（12 项）全部通过。
- **未测**：需真实 EasyEDA 画布运行时才能验证强制重绘后帧确实刷新（无硬件/画布环境）。逻辑移植自已验证的 `schematicSnapshot`，并额外加了 PCB 专属的 ratline+fit 重绘 nudge。