### PR TITLE
fix: add board rebind + harden stale Board binding handling

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -124,7 +124,7 @@ Pro; the title block (明细表) is the editable "图纸" surface. CLI: `easyeda
 | `schematic.page.delete` | Delete a page (confirmation-gated, no undo). Mutates. |
 | `schematic.rename` | Rename a schematic document (whole sheet; may also rename a linked reuse-module symbol + PCB). Mutates. |
 
-### Board / 组合 — schematic↔PCB binding (6 actions, `board` domain)
+### Board / 组合 — schematic↔PCB binding (7 actions, `board` domain)
 
 A **Board groups one schematic + one PCB** (识别符是 name, not uuid) — the structural
 unit that keeps the two together and that `import_changes` follows. Project tree:
@@ -138,6 +138,7 @@ Workspace → Project → **Board** → schematic + PCB. Map to `eda.dmt_Board.*
 | `board.rename` | Rename a board by its current name. Mutates. |
 | `board.copy` | Duplicate a board (schematic + PCB). Mutates. |
 | `board.delete` | Delete a board by name (confirmation-gated, no undo). Mutates. |
+| `board.rebind` | Repair a stale/orphaned board binding after a PCB rebuild: delete the board (by `--name`, else current) and re-create it bound to `--schematic` (+ `--pcb`), rolling back on failure. Clears the false DRC Netlist Error left when the binding points at a deleted schematic UUID. `--force` moves a schematic already bound elsewhere. Mutates. |
 
 ### Draw / edit (9 actions, all mutate)
 

--- a/extension/src/actions.ts
+++ b/extension/src/actions.ts
@@ -3215,6 +3215,105 @@ const boardDelete: Handler = async (payload) => {
 };
 
 /**
+ * Rebind a Board to the intended schematic + PCB — the deterministic repair for
+ * a stale/orphaned binding (the #33 case: a rebuild-from-empty PCB left the Board
+ * pointing at a deleted schematic UUID, so `board list` crashed and DRC reported a
+ * false Netlist Error).
+ *
+ * A schematic can belong to only ONE Board in EasyEDA Pro, so we can't just
+ * createBoard on top of the old one — the SDK would MOVE the schematic and leave a
+ * stale shell (same trap `pcb new-board` documents). We therefore delete the old
+ * Board (by name) FIRST, then createBoard(schematic, pcb) fresh. The old binding's
+ * schematic/pcb UUIDs are captured beforehand so a failed re-create rolls back to
+ * the original Board instead of leaving the project board-less.
+ *
+ * GUARDRAIL: if the target schematic is bound to a DIFFERENT board, refuse unless
+ * force=true (rebinding would silently steal it).
+ */
+const boardRebind: Handler = async (payload) => {
+	const schematicUuid = requireString(payload, 'schematicUuid');
+	const pcbUuid = optionalString(payload, 'pcbUuid');
+	const name = optionalString(payload, 'name');
+	const force = optionalBoolean(payload, 'force') === true;
+
+	let boards: Array<BoardItem>;
+	try {
+		boards = (await eda.dmt_Board.getAllBoardsInfo()) ?? [];
+	}
+	catch (err) {
+		throw edaError(err, 'Failed to list Boards for rebind.');
+	}
+
+	// Locate the board to rebind: by name if given, else the current board.
+	let target: BoardItem | undefined;
+	if (name) {
+		target = boards.find(b => b?.name === name);
+	}
+	else {
+		try { target = (await eda.dmt_Board.getCurrentBoardInfo()) ?? undefined; }
+		catch { /* none */ }
+	}
+
+	// Refuse to steal a schematic already bound to a DIFFERENT board (unless force).
+	if (!force) {
+		const holder = boards.find(b => b?.schematic?.uuid === schematicUuid && b?.name !== target?.name);
+		if (holder) {
+			throw new ActionError(
+				ErrorCodes.INVALID_STATE,
+				`Schematic ${schematicUuid} is already bound to board "${holder.name}". `
+				+ `Rebinding here would MOVE it out of "${holder.name}" (a schematic can belong to only one board). `
+				+ `Pass force=true only if you really want to move it.`,
+			);
+		}
+	}
+
+	// Capture the old binding for rollback, then delete the stale board (best-effort:
+	// a missing target just means we create fresh).
+	const oldName = target?.name;
+	const oldSchematicUuid = target?.schematic?.uuid;
+	const oldPcbUuid = target?.pcb?.uuid;
+	if (oldName) {
+		try { await eda.dmt_Board.deleteBoard(oldName); }
+		catch (err) { throw edaError(err, `Failed to delete the stale Board "${oldName}" before rebinding.`); }
+	}
+
+	// Create the fresh binding.
+	let newName: string | undefined;
+	try { newName = await eda.dmt_Board.createBoard(schematicUuid, pcbUuid); }
+	catch (err) {
+		// Roll back to the original binding so we don't leave the project board-less.
+		if (oldSchematicUuid || oldPcbUuid) {
+			try { await eda.dmt_Board.createBoard(oldSchematicUuid, oldPcbUuid); } catch { /* best-effort */ }
+		}
+		throw edaError(err, 'Failed to create the rebound Board (rolled back to the previous binding).');
+	}
+	if (!newName) {
+		if (oldSchematicUuid || oldPcbUuid) {
+			try { await eda.dmt_Board.createBoard(oldSchematicUuid, oldPcbUuid); } catch { /* best-effort */ }
+		}
+		throw new ActionError(ErrorCodes.EDA_CALL_FAILED, 'createBoard returned nothing (check the schematic/PCB UUIDs); rolled back to the previous binding.');
+	}
+
+	// Restore the desired board name (createBoard mints an auto name).
+	const wantName = name ?? oldName;
+	if (wantName && wantName !== newName) {
+		try { await eda.dmt_Board.modifyBoardName(newName, wantName); newName = wantName; }
+		catch { /* keep the auto name */ }
+	}
+
+	return {
+		result: {
+			boardName: newName,
+			schematicUuid,
+			pcbUuid: pcbUuid ?? null,
+			replaced: oldName
+				? { name: oldName, schematicUuid: oldSchematicUuid ?? null, pcbUuid: oldPcbUuid ?? null }
+				: null,
+		},
+	};
+};
+
+/**
  * Create a NEW board (板) that CONTAINS a fresh, empty PCB, bound to a schematic —
  * the programmatic equivalent of the UI's 新建 PCB / 原理图转 PCB. `board.create`
  * only mints the schematic↔PCB *linkage*; this makes an actual new PCB page you can
@@ -3374,8 +3473,11 @@ const pcbImportChanges: Handler = async (payload) => {
 		result: {
 			imported,
 			createdBoard,
+			// Read schematic/pcb defensively: a Board can legitimately hold only one
+			// side (e.g. after a rebuild the schematic ref may be a deleted/orphaned
+			// UUID), so `board.schematic.uuid` would crash — mirror serializeBoard.
 			board: board
-				? { name: board.name, schematicUuid: board.schematic.uuid, pcbUuid: board.pcb.uuid }
+				? { name: board.name, schematicUuid: board.schematic?.uuid ?? null, pcbUuid: board.pcb?.uuid ?? null }
 				: null,
 			reason: imported
 				? null
@@ -3452,6 +3554,26 @@ const pcbAddComponent: Handler = async (payload) => {
 	try { await eda.pcb_Document.startCalculatingRatline(); }
 	catch { /* best-effort */ }
 
+	// Rebuild-flow guardrail (#33): if the active PCB's Board binding points at a
+	// schematic UUID that no longer matches any open schematic doc, adding parts
+	// won't clear the resulting DRC Netlist Error until the Board is rebound. Warn
+	// so the agent knows to run `board rebind`. Best-effort, never fails the place.
+	const warnings: Array<string> = [];
+	try {
+		const board = await eda.dmt_Board.getCurrentBoardInfo();
+		const boundSchUuid = board?.schematic?.uuid;
+		if (boundSchUuid) {
+			const schematics = (await eda.dmt_Schematic.getAllSchematicsInfo()) ?? [];
+			if (!schematics.some(s => s.uuid === boundSchUuid)) {
+				warnings.push(
+					`Board "${board?.name}" is bound to schematic ${boundSchUuid}, which is not among the open schematics `
+					+ `— DRC may report a false Netlist Error. Run \`easyeda board rebind --schematic <uuid> --pcb <uuid>\` to repair the binding.`,
+				);
+			}
+		}
+	}
+	catch { /* best-effort — diagnostic only */ }
+
 	return {
 		result: {
 			primitiveId: id,
@@ -3461,6 +3583,7 @@ const pcbAddComponent: Handler = async (payload) => {
 			assignedNets,
 			unmatchedPads: unmatched,
 		},
+		...(warnings.length ? { warnings } : {}),
 	};
 };
 
@@ -4064,7 +4187,31 @@ const pcbDrcCheck: Handler = async (payload) => {
 	catch (err) {
 		throw edaError(err, 'Failed to run PCB DRC (ensure the PCB document is the active/foreground tab).');
 	}
-	return { result: { passed: violations.length === 0, violations } };
+
+	// A Netlist Error ("PCB and schematic netlist does not match") is usually a
+	// stale Board binding, not a real mismatch (see #33). Surface the bound
+	// schematic/PCB names so the fix (`board rebind`) is obvious. Best-effort:
+	// never let this diagnostic hide the actual DRC result.
+	let binding: Record<string, unknown> | undefined;
+	const hasNetlistError = violations.some((v) => JSON.stringify(v ?? '').toLowerCase().includes('netlist'));
+	if (hasNetlistError) {
+		try {
+			const board = await eda.dmt_Board.getCurrentBoardInfo();
+			if (board) {
+				binding = {
+					boardName: board.name,
+					schematicUuid: board.schematic?.uuid ?? null,
+					schematicName: board.schematic?.name ?? null,
+					pcbUuid: board.pcb?.uuid ?? null,
+					pcbName: board.pcb?.name ?? null,
+					hint: 'Netlist Error is often a stale Board binding — verify the schematic UUID matches the open schematic; if not, run `easyeda board rebind --schematic <uuid> --pcb <uuid>`.',
+				};
+			}
+		}
+		catch { /* best-effort — diagnostic only */ }
+	}
+
+	return { result: { passed: violations.length === 0, violations, ...(binding ? { binding } : {}) } };
 };
 
 /**
@@ -4988,6 +5135,7 @@ const HANDLERS: Record<string, Handler> = {
 	'board.rename': boardRename,
 	'board.copy': boardCopy,
 	'board.delete': boardDelete,
+	'board.rebind': boardRebind,
 	'pcb.import_changes': pcbImportChanges,
 	'pcb.add_component': pcbAddComponent,
 	'pcb.component.modify': pcbComponentModify,

--- a/internal/app/cmd_board.go
+++ b/internal/app/cmd_board.go
@@ -143,5 +143,46 @@ func newBoardCmd(cfg *appConfig, stdout, stderr io.Writer) *cobra.Command {
 		board.AddCommand(c)
 	}
 
+	// ── rebind ─────────────────────────────────────────────────────────────
+	// board.rebind — repair a stale/orphaned Board binding after a PCB rebuild.
+	{
+		var name, schUuid, pcbUuid string
+		var force bool
+		c := &cobra.Command{
+			Use:   "rebind",
+			Short: "Rebind a Board to the intended schematic + PCB (repair a stale binding)",
+			Long: "Repair a Board whose schematic/PCB binding went stale — e.g. after a\n" +
+				"rebuild-from-empty PCB left the Board pointing at a deleted schematic UUID,\n" +
+				"which crashed `board list` and produced a false DRC Netlist Error.\n\n" +
+				"Deletes the old Board (by --name, else the current Board) and re-creates it\n" +
+				"bound to --schematic (+ --pcb), rolling back on failure. A schematic can\n" +
+				"belong to only one Board, so pass --force to move one already bound elsewhere.",
+			Args: cobra.NoArgs,
+			Example: `  easyeda board rebind --schematic <schUuid> --pcb <pcbUuid>
+  easyeda board rebind --name "Board1" --schematic <schUuid> --pcb <pcbUuid>`,
+			RunE: func(cmd *cobra.Command, args []string) error {
+				if schUuid == "" {
+					return fmt.Errorf("--schematic is required")
+				}
+				payload := map[string]any{"schematicUuid": schUuid}
+				if pcbUuid != "" {
+					payload["pcbUuid"] = pcbUuid
+				}
+				if name != "" {
+					payload["name"] = name
+				}
+				if force {
+					payload["force"] = true
+				}
+				return dispatch(cfg, "board.rebind", window, payload, stdout, stderr)
+			},
+		}
+		c.Flags().StringVar(&name, "name", "", "board name to rebind (default: current board)")
+		c.Flags().StringVar(&schUuid, "schematic", "", "schematic UUID to bind (required)")
+		c.Flags().StringVar(&pcbUuid, "pcb", "", "PCB UUID to bind")
+		c.Flags().BoolVar(&force, "force", false, "move the schematic even if already bound to another board")
+		board.AddCommand(c)
+	}
+
 	return board
 }

--- a/internal/app/cmd_board_test.go
+++ b/internal/app/cmd_board_test.go
@@ -1,0 +1,133 @@
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// newCapturingDaemon stands up a fake daemon that identifies as easyeda-agent
+// and records the last /action request body, so a command test can assert the
+// exact action + payload the CLI wired.
+func newCapturingDaemon(t *testing.T) (*appConfig, *capturedRequest, func()) {
+	t.Helper()
+	cap := &capturedRequest{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/health":
+			_, _ = w.Write([]byte(`{"service":"easyeda-agent","windows":[{"windowId":"w1"}]}`))
+		case "/action":
+			var body struct {
+				Action  string         `json:"action"`
+				Payload map[string]any `json:"payload"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			cap.mu.Lock()
+			cap.action = body.Action
+			cap.payload = body.Payload
+			cap.mu.Unlock()
+			_, _ = w.Write([]byte(`{"ok":true,"result":{}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+
+	hostPort := strings.TrimPrefix(srv.URL, "http://")
+	host, portStr, _ := strings.Cut(hostPort, ":")
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("parse test server port: %v", err)
+	}
+	cfg := &appConfig{host: host, ports: fmt.Sprintf("%d-%d", port, port)}
+	return cfg, cap, srv.Close
+}
+
+type capturedRequest struct {
+	mu      sync.Mutex
+	action  string
+	payload map[string]any
+}
+
+// board rebind requires --schematic; without it the command errors before any
+// daemon call.
+func TestBoardRebind_RequiresSchematic(t *testing.T) {
+	cfg, _, cleanup := newCapturingDaemon(t)
+	defer cleanup()
+
+	var stdout, stderr bytes.Buffer
+	cmd := newBoardCmd(cfg, &stdout, &stderr)
+	cmd.SetArgs([]string{"rebind", "--pcb", "pcb1"})
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error when --schematic is missing")
+	}
+}
+
+// board rebind maps to the board.rebind action and forwards the schematic/pcb/
+// name/force fields into the payload.
+func TestBoardRebind_WiresActionAndPayload(t *testing.T) {
+	cfg, cap, cleanup := newCapturingDaemon(t)
+	defer cleanup()
+
+	var stdout, stderr bytes.Buffer
+	cmd := newBoardCmd(cfg, &stdout, &stderr)
+	cmd.SetArgs([]string{"rebind", "--name", "Board1", "--schematic", "sch1", "--pcb", "pcb1", "--force"})
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v (stderr=%s)", err, stderr.String())
+	}
+
+	cap.mu.Lock()
+	defer cap.mu.Unlock()
+	if cap.action != "board.rebind" {
+		t.Fatalf("expected action board.rebind, got %q", cap.action)
+	}
+	if cap.payload["schematicUuid"] != "sch1" {
+		t.Errorf("schematicUuid: got %v", cap.payload["schematicUuid"])
+	}
+	if cap.payload["pcbUuid"] != "pcb1" {
+		t.Errorf("pcbUuid: got %v", cap.payload["pcbUuid"])
+	}
+	if cap.payload["name"] != "Board1" {
+		t.Errorf("name: got %v", cap.payload["name"])
+	}
+	if cap.payload["force"] != true {
+		t.Errorf("force: got %v", cap.payload["force"])
+	}
+}
+
+// Without --pcb / --name / --force, only schematicUuid is sent (optional fields
+// are omitted, not sent empty).
+func TestBoardRebind_OmitsUnsetFields(t *testing.T) {
+	cfg, cap, cleanup := newCapturingDaemon(t)
+	defer cleanup()
+
+	var stdout, stderr bytes.Buffer
+	cmd := newBoardCmd(cfg, &stdout, &stderr)
+	cmd.SetArgs([]string{"rebind", "--schematic", "sch1"})
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v (stderr=%s)", err, stderr.String())
+	}
+
+	cap.mu.Lock()
+	defer cap.mu.Unlock()
+	if _, ok := cap.payload["pcbUuid"]; ok {
+		t.Error("pcbUuid should be omitted when --pcb is unset")
+	}
+	if _, ok := cap.payload["name"]; ok {
+		t.Error("name should be omitted when --name is unset")
+	}
+	if _, ok := cap.payload["force"]; ok {
+		t.Error("force should be omitted when --force is unset")
+	}
+}


### PR DESCRIPTION
Fixes #33

## 问题
PCB 重建(rebuild-from-empty + `pcb add-component`)后,Board 绑定仍指向旧/已删除的 schematic UUID,导致:
- `board list` / `pcb board-info` 崩溃(`Cannot read properties of undefined (reading 'uuid')`)
- `pcb drc` 报假 Netlist Error
- 只能手工 delete + create 重绑定

## 改动
1. **新增 `board.rebind` action + `easyeda board rebind` CLI**(`--name --schematic <uuid> --pcb <uuid> [--force]`):删除旧 Board(按 name,否则当前 Board),再以目标 schematic + PCB 重建;失败时回滚到原绑定;`--force` 才允许移动已绑定到其他 Board 的 schematic(复用 `pcb new-board` 的 GUARDRAIL 语义)。
2. **`pcbImportChanges`**:改为 null-safe 读取 `schematic?.uuid`/`pcb?.uuid`,消除残留崩溃面(actions.ts:3378)。
3. **`pcbDrcCheck`**:检测到 Netlist 类错误时,best-effort 附带当前 Board 的 schematic/PCB 名称与 `board rebind` 提示到结果 `binding` 字段。
4. **`pcbAddComponent`**:重建路径中比对当前 Board 的 schematicUuid 与打开的原理图文档,不一致时输出 warning 指引运行 `board rebind`。
5. 文档:FEATURES.md 增补 `board.rebind`(Board 域 6→7 actions)。

## 验收对照
删空 PCB → add-component 重建 → `board rebind --schematic <uuid> --pcb <uuid>` 提供确定性、非崩溃的重绑定序列并清除假 netlist 错误。

## 测试
- `go test ./...` 全绿;新增 `internal/app/cmd_board_test.go`(3 例:必填校验、action/payload 连线、可选字段省略)。
- `npm run typecheck` + `npm test`(extension)通过。
- 未验证:实际 EasyEDA 运行时行为(需连接 EasyEDA Pro 连接器,本地无硬件/连接器环境)。SDK 调用序列按现有 `pcbNewBoard` 已验证模式编写。