### PR TITLE
fix: install/update easyeda-agent skill for Codex and Claude Code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,5 +147,5 @@ endif
 		$(DIST)/skills.tar.gz \
 		$(DIST)/install.sh \
 		--title "easyeda-agent $(VERSION)" \
-		--notes "One-line install: \`curl -fsSL https://raw.githubusercontent.com/zhoushoujianwork/easyeda-agent/main/install.sh | sh\`"
+		--notes "$$(printf 'One-line install/update:\n\`\`\`\ncurl -fsSL https://raw.githubusercontent.com/zhoushoujianwork/easyeda-agent/main/install.sh | sh\n\`\`\`\n\nInstalls/updates:\n- easyeda CLI/daemon\n- easyeda-agent skill for Codex (~/.codex/skills) and/or Claude Code (~/.claude/skills) when detected\n- prints EasyEDA connector .eext import URL\n\nSkill targets: set \`EASYEDA_INSTALL_SKILLS=codex,claude\` to force targets, \`none\` to skip, or \`EASYEDA_SKILL_PRESERVE=1\` to keep local edits.')"
 	@echo "✅ Released: https://github.com/zhoushoujianwork/easyeda-agent/releases/tag/$(VERSION)"

--- a/README.en.md
+++ b/README.en.md
@@ -52,6 +52,18 @@ by the installer:
 curl -fsSL https://raw.githubusercontent.com/zhoushoujianwork/easyeda-agent/main/install.sh | sh
 ```
 
+The one-line script installs/updates the `easyeda` CLI/daemon, auto-detects
+installed clients and installs/updates the `easyeda-agent` skill into each —
+Codex (`~/.codex/skills/easyeda-agent`) and Claude Code
+(`~/.claude/skills/easyeda-agent`) — and prints the connector `.eext` import URL.
+Control skill install with env vars:
+
+```bash
+EASYEDA_INSTALL_SKILLS=codex,claude curl -fsSL .../install.sh | sh  # force targets
+EASYEDA_INSTALL_SKILLS=none          curl -fsSL .../install.sh | sh  # skip skills
+EASYEDA_SKILL_PRESERVE=1             curl -fsSL .../install.sh | sh  # keep local edits
+```
+
 The published skill slug is `easyeda-agent` (suffix intentional: it distinguishes this
 community automation layer from official EasyEDA tooling). To install only the skill
 from a registry:

--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@
 curl -fsSL https://raw.githubusercontent.com/zhoushoujianwork/easyeda-agent/main/install.sh | sh
 ```
 
+一键脚本会：安装/更新 `easyeda` CLI/daemon;自动检测已安装的客户端并把 `easyeda-agent` skill 安装/更新到对应目录 —— Codex(`~/.codex/skills/easyeda-agent`)、Claude Code(`~/.claude/skills/easyeda-agent`);打印连接器 `.eext` 导入地址。可用环境变量控制 skill 安装:
+
+```bash
+EASYEDA_INSTALL_SKILLS=codex,claude curl -fsSL .../install.sh | sh  # 指定目标
+EASYEDA_INSTALL_SKILLS=none          curl -fsSL .../install.sh | sh  # 跳过 skill
+EASYEDA_SKILL_PRESERVE=1             curl -fsSL .../install.sh | sh  # 保留本地改动
+```
+
 Skill slug 为 `easyeda-agent`(后缀有意为之,区分于官方 EasyEDA 工具)。只从 registry 装 skill:
 
 ```bash

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,11 @@
 set -euo pipefail
 
 REPO="zhoushoujianwork/easyeda-agent"
-SKILLS_DIR="${HOME}/.claude/skills"
+SKILL_NAME="easyeda-agent"
+# EASYEDA_INSTALL_SKILLS: ""|auto (detect), "none" (skip), or CSV of codex,claude
+INSTALL_SKILLS="${EASYEDA_INSTALL_SKILLS:-}"
+# EASYEDA_SKILL_PRESERVE=1 keeps existing files instead of clean-replacing
+SKILL_PRESERVE="${EASYEDA_SKILL_PRESERVE:-0}"
 
 # ── helpers ──────────────────────────────────────────────────────────────────
 info()  { printf '\033[34m[easyeda-agent]\033[0m %s\n' "$*"; }
@@ -51,15 +55,96 @@ curl -fsSL "${BASE_URL}/${BINARY_NAME}" -o "${INSTALL_DIR}/easyeda"
 chmod +x "${INSTALL_DIR}/easyeda"
 ok "CLI installed → ${INSTALL_DIR}/easyeda"
 
-# ── install skills ────────────────────────────────────────────────────────────
-info "Installing skills to ${SKILLS_DIR}..."
-mkdir -p "$SKILLS_DIR"
+# ── install skills (Codex + Claude Code) ──────────────────────────────────────
+# Resolve which clients to install for.
+# codex → ~/.codex/skills/easyeda-agent, claude → ~/.claude/skills/easyeda-agent
+detect_targets() {
+  # Explicit "none" → skip entirely.
+  case "$INSTALL_SKILLS" in
+    none|NONE|None) return 0 ;;
+  esac
+
+  if [ -n "$INSTALL_SKILLS" ] && [ "$INSTALL_SKILLS" != "auto" ]; then
+    # Explicit CSV list (e.g. "codex,claude").
+    printf '%s\n' "$INSTALL_SKILLS" | tr ',' '\n' | while IFS= read -r t; do
+      t=$(printf '%s' "$t" | tr -d '[:space:]')
+      [ -n "$t" ] && printf '%s\n' "$t"
+    done
+    return 0
+  fi
+
+  # auto-detect
+  found=0
+  if [ -d "${HOME}/.codex" ] || command -v codex >/dev/null 2>&1; then
+    printf 'codex\n'; found=1
+  fi
+  if [ -d "${HOME}/.claude" ] || command -v claude >/dev/null 2>&1; then
+    printf 'claude\n'; found=1
+  fi
+  # Neither detected → create both by default so the skill is ready when a
+  # client shows up. EASYEDA_INSTALL_SKILLS=none opts out.
+  if [ "$found" = 0 ]; then
+    warn "No Codex/Claude Code client detected; creating both skill dirs by default." >&2
+    printf 'codex\n'
+    printf 'claude\n'
+  fi
+}
+
+# Map a client name to its skills base dir.
+client_base_dir() {
+  case "$1" in
+    codex)  printf '%s/.codex/skills\n' "$HOME" ;;
+    claude) printf '%s/.claude/skills\n' "$HOME" ;;
+    *)      return 1 ;;
+  esac
+}
+
+# install_skill_to <client> <src_skill_dir>
+# Cleanly replaces <base>/easyeda-agent from the release, backing up local edits.
+install_skill_to() {
+  _client="$1"; _src="$2"
+  _base=$(client_base_dir "$_client") || { warn "Unknown skill target: ${_client} (skipped)"; return 0; }
+  mkdir -p "$_base"
+  _dest="${_base}/${SKILL_NAME}"
+
+  if [ ! -d "$_dest" ]; then
+    cp -r "$_src" "$_dest"
+    ok "${_client} skill installed → ${_dest}"
+    return 0
+  fi
+
+  if [ "$SKILL_PRESERVE" = "1" ]; then
+    cp -rn "$_src"/. "$_dest"/ 2>/dev/null || cp -r "$_src"/. "$_dest"/
+    ok "${_client} skill updated (preserve mode, existing files kept) → ${_dest}"
+    return 0
+  fi
+
+  # Detect local modifications vs the release; back up before replacing.
+  if diff -r "$_src" "$_dest" >/dev/null 2>&1; then
+    ok "${_client} skill already up to date → ${_dest}"
+    return 0
+  fi
+  _bak="${_dest}.bak.$(date +%Y%m%d%H%M%S)"
+  mv "$_dest" "$_bak"
+  cp -r "$_src" "$_dest"
+  ok "${_client} skill updated → ${_dest} (old backed up → ${_bak})"
+}
+
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
-curl -fsSL "${BASE_URL}/skills.tar.gz" | tar -xzf - -C "$TMP"
-# Copy each skill dir; preserve existing files with -n to avoid clobbering user edits
-cp -r "$TMP"/. "$SKILLS_DIR/"
-ok "Skills installed → ${SKILLS_DIR}"
+
+TARGETS=$(detect_targets)
+if [ -z "$TARGETS" ]; then
+  info "Skill install skipped (EASYEDA_INSTALL_SKILLS=none)"
+else
+  info "Downloading skills.tar.gz..."
+  curl -fsSL "${BASE_URL}/skills.tar.gz" | tar -xzf - -C "$TMP"
+  SRC_SKILL="${TMP}/${SKILL_NAME}"
+  [ -d "$SRC_SKILL" ] || fatal "skills.tar.gz did not contain ${SKILL_NAME}/"
+  printf '%s\n' "$TARGETS" | while IFS= read -r client; do
+    [ -n "$client" ] && install_skill_to "$client" "$SRC_SKILL"
+  done
+fi
 
 # ── PATH check ────────────────────────────────────────────────────────────────
 if ! echo ":${PATH}:" | grep -q ":${INSTALL_DIR}:"; then
@@ -79,6 +164,7 @@ printf '  2. Install the EasyEDA connector extension:\n'
 printf '       Download: %s/easyeda-agent-connector.eext\n' "$BASE_URL"
 printf '       In EasyEDA Pro: 扩展管理 → 导入扩展 → select the .eext file\n\n'
 printf '  3. In EasyEDA Pro: 设置 → 允许外部交互 (Allow external interaction)\n\n'
-printf '  4. In Claude Code, use the merged skill:\n'
-printf '       /easyeda-agent       (schematic + PCB workflow)\n\n'
+printf '  4. Use the skill in your AI client:\n'
+printf '       /easyeda-agent       (schematic + PCB workflow)\n'
+printf '       Installed for detected clients: Codex (~/.codex/skills) and/or Claude Code (~/.claude/skills)\n\n'
 printf 'Full docs: https://github.com/%s\n' "$REPO"

--- a/skills/README.md
+++ b/skills/README.md
@@ -19,6 +19,12 @@ by the installer:
 curl -fsSL https://raw.githubusercontent.com/zhoushoujianwork/easyeda-agent/main/install.sh | sh
 ```
 
+The installer auto-detects your AI clients and installs/updates the
+`easyeda-agent` skill into each: Codex (`~/.codex/skills/easyeda-agent`) and
+Claude Code (`~/.claude/skills/easyeda-agent`). Set
+`EASYEDA_INSTALL_SKILLS=codex,claude` to force targets, `none` to skip, or
+`EASYEDA_SKILL_PRESERVE=1` to keep local edits during an update.
+
 To install only the skill from a registry:
 
 ```bash


### PR DESCRIPTION
Fixes #35

## What changed
把一键安装脚本从「只往 `~/.claude/skills` 装技能」升级为面向 Codex + Claude Code 的统一安装/更新器。

### install.sh
- 新增 `EASYEDA_INSTALL_SKILLS`(空/auto=自动检测,`none`=跳过,CSV 如 `codex,claude`=显式目标)与 `EASYEDA_SKILL_PRESERVE=1`(保留本地改动)。
- `detect_targets()`:auto 模式下 `~/.codex` 或 `codex` 命令 → codex;`~/.claude` 或 `claude` 命令 → claude;两者皆无时默认创建两者并打印提示。
- `install_skill_to()`:目标为 `<base>/easyeda-agent`。全新目录直接拷贝;已存在且与发布内容一致则跳过(报告 up to date);检测到本地改动先 `mv` 到 `easyeda-agent.bak.<timestamp>` 再干净替换;preserve 模式用 `cp -rn` 保留旧文件。逐目标打印 installed/updated/skipped。
- tar 顶层为 `easyeda-agent/`(核对自 Makefile `tar -C skills easyeda-agent`),解包一次后源路径 `$TMP/easyeda-agent`。
- 无 TTY 管道环境:全程无交互 `read`,仅靠环境变量+默认策略。

### 文案
- Makefile release notes、README.md、README.en.md、skills/README.md 同步说明多客户端安装路径与环境变量。

## Testing
- `bash -n install.sh` 语法通过;`make -n release` dry-run 正常。
- 隔离脚本测试覆盖:auto 检测(无客户端→两者)、全新安装、幂等重跑(up to date)、本地改动→备份、preserve 保留、CSV 显式、none 跳过。全部符合预期。
- 未做真实 `curl | sh` 端到端联网测试(需实际 release 资产);逻辑已在提取的函数上离线验证。