### PR TITLE
fix: floating-pin 加 netlist-JSON 交叉校验(补漏报)

### DIFF
--- a/extension/src/actions.ts
+++ b/extension/src/actions.ts
@@ -15,6 +15,7 @@ import {
 import {
 	asPayload,
 	blobToBase64,
+	classifyPinConnectivity,
 	newArtifactId,
 	normalizeRegion,
 	normalizeWirePoints,
@@ -1371,7 +1372,7 @@ interface CheckPinDetail {
 
 // One reconstructed design-check finding. Reuses the DRC severity buckets.
 interface CheckFinding {
-	type: string; // 'floating-pin' | 'wire-crossing' | 'wire-over-pin' | 'net-marker-mismatch' | 'multi-net-wire' | 'zero-length-wire' | 'dangling-wire'
+	type: string; // 'floating-pin' | 'geom-net-mismatch' | 'wire-crossing' | 'wire-over-pin' | 'net-marker-mismatch' | 'multi-net-wire' | 'zero-length-wire' | 'dangling-wire'
 	level: DrcSeverity;
 	designator?: string;
 	primitiveId?: string; // owning component (floating-pin / wire-over-pin)
@@ -1444,17 +1445,28 @@ function collectWireSegments(wires: Array<{ getState_Line: () => Array<number>; 
 	return segs;
 }
 
-async function collectNetlistPinNets(): Promise<Map<string, Map<string, string>>> {
+// Result of reading the JSON-authoritative netlist. `available` distinguishes
+// "netlist fetched+parsed" (trust its pin→net facts, even the ABSENCE of a net)
+// from "couldn't fetch/parse" (netlist muted → geometry alone decides). Without
+// this flag an uncompiled/missing netlist would look like "every pin has no net"
+// and manufacture geom-net-mismatch false reports.
+interface NetlistPinNets {
+	byDesignator: Map<string, Map<string, string>>;
+	available: boolean;
+}
+
+async function collectNetlistPinNets(): Promise<NetlistPinNets> {
 	const byDesignator = new Map<string, Map<string, string>>();
+	const muted = (): NetlistPinNets => ({ byDesignator, available: false });
 	let file: File | undefined;
 	try { file = await eda.sch_ManufactureData.getNetlistFile(); }
-	catch { return byDesignator; }
-	if (!file) return byDesignator;
+	catch { return muted(); }
+	if (!file) return muted();
 	let parsed: unknown;
 	try { parsed = JSON.parse(await file.text()); }
-	catch { return byDesignator; }
+	catch { return muted(); }
 	const components = (parsed as { components?: Record<string, NetlistComponentInfo> })?.components;
-	if (!components || typeof components !== 'object') return byDesignator;
+	if (!components || typeof components !== 'object') return muted();
 	for (const comp of Object.values(components)) {
 		const designator = String(comp.props?.Designator ?? '');
 		if (!designator || !comp.pinInfoMap) continue;
@@ -1466,7 +1478,7 @@ async function collectNetlistPinNets(): Promise<Map<string, Map<string, string>>
 		}
 		byDesignator.set(designator, pins);
 	}
-	return byDesignator;
+	return { byDesignator, available: true };
 }
 
 type Seg = [number, number, number, number];
@@ -1513,7 +1525,7 @@ function interiorOnSegment(px: number, py: number, s: Seg): boolean {
 const schematicCheck: Handler = async (payload) => {
 	const allPages = optionalBoolean(payload, 'allPages') === true;
 	let components, wires;
-	const netlistPinNets = await collectNetlistPinNets();
+	const { byDesignator: netlistPinNets, available: netlistAvailable } = await collectNetlistPinNets();
 	try {
 		components = await eda.sch_PrimitiveComponent.getAll(undefined, allPages);
 		wires = await eda.sch_PrimitiveWire.getAll();
@@ -1621,6 +1633,9 @@ const schematicCheck: Handler = async (payload) => {
 
 	let floatingTotal = 0;
 	let componentsWithFloating = 0;
+	// Geometry says the pin is wired but the authoritative netlist puts it on no net
+	// — a suspected MISSED report (the cross-check's "补漏报" direction).
+	let geomNetMismatches = 0;
 	// All component pins, kept for the wire-over-pin rule below.
 	const allPins: Array<{ designator: string; number: string; x: number; y: number }> = [];
 
@@ -1646,17 +1661,35 @@ const schematicCheck: Handler = async (payload) => {
 			try { if (p.getState_NoConnected && p.getState_NoConnected()) continue; }
 			catch { /* treat as not-NC */ }
 			const netlistNet = netlistPinNets.get(designator)?.get(num) ?? '';
-			const connected = Boolean(netlistNet)
-				|| segs.some(s => pointOnSegment(px, py, s[0], s[1], s[2], s[3]))
-				// A pin landing directly on a netflag/netport/netlabel is connected too.
+			// Pure-geometry connectivity: a wire touches the pin, or it sits on a
+			// netflag/netport/netlabel anchor.
+			const geomConnected = segs.some(s => pointOnSegment(px, py, s[0], s[1], s[2], s[3]))
 				|| connectionMarkers.some(m => Math.hypot(px - m.x, py - m.y) <= COINCIDE_TOL);
-			if (!connected) {
+			// Cross-check geometry against the JSON-authoritative netlist:
+			//   connected         → netlist has a net (drops #15-class false positives),
+			//                        or netlist muted + geometry wires it
+			//   floating          → neither source connects it (real floating pin)
+			//   geom-net-mismatch → geometry wires it but netlist has NO net (补漏报)
+			const status = classifyPinConnectivity(Boolean(netlistNet), geomConnected, netlistAvailable);
+			if (status === 'floating') {
 				floating.push(num);
 				const name = (() => {
 					try { return String(p.getState_PinName?.() ?? ''); }
 					catch { return ''; }
 				})();
 				floatingDetails.push({ number: num, name: name || undefined, x: px, y: py });
+			}
+			else if (status === 'geom-net-mismatch') {
+				geomNetMismatches++;
+				findings.push({
+					type: 'geom-net-mismatch',
+					level: 'warn',
+					designator,
+					primitiveId,
+					pins: [num],
+					at: { x: px, y: py },
+					message: '导线触碰该引脚但网表未将其归入任何 net(疑似漏连:未编译网表或仅几何贴合未真正连通)',
+				});
 			}
 		}
 		if (floating.length > 0) {
@@ -1792,6 +1825,7 @@ const schematicCheck: Handler = async (payload) => {
 	const summary = {
 		floatingPins: floatingTotal,
 		componentsWithFloating,
+		geomNetMismatches,
 		netMarkerMismatches,
 		multiNetWires,
 		wireCrossings: crossingTotal,
@@ -1859,7 +1893,7 @@ const schematicRead: Handler = async (payload) => {
 	}
 
 	// JSON-authoritative pin→net per designator (same source as schematic.check).
-	const pinNets = await collectNetlistPinNets();
+	const { byDesignator: pinNets } = await collectNetlistPinNets();
 
 	const netToPins = new Map<string, Array<string>>();
 	const floating: Array<string> = [];

--- a/extension/src/util.test.ts
+++ b/extension/src/util.test.ts
@@ -8,7 +8,7 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
 import { ActionError } from './protocol';
-import { normalizeRegion, normalizeWirePoints } from './util';
+import { classifyPinConnectivity, normalizeRegion, normalizeWirePoints } from './util';
 
 test('normalizeWirePoints: flat input is returned unchanged', () => {
 	assert.deepEqual(normalizeWirePoints([195, 350, 215, 350]), [195, 350, 215, 350]);
@@ -67,4 +67,31 @@ test('normalizeRegion: zero-area box (collapsed axis) throws', () => {
 test('normalizeRegion: non-finite bound throws', () => {
 	assert.throws(() => normalizeRegion(NaN, 730, 300, 520), ActionError);
 	assert.throws(() => normalizeRegion(400, Infinity, 300, 520), ActionError);
+});
+
+// ─── classifyPinConnectivity: geometry × JSON-authoritative netlist cross-check ──
+// The three acceptance scenarios from issue #45, plus the netlist-muted guard.
+
+test('classifyPinConnectivity: geometry + netlist agree connected → connected', () => {
+	// netlist has a net AND geometry sees a wire.
+	assert.equal(classifyPinConnectivity(true, true, true), 'connected');
+});
+
+test('classifyPinConnectivity: geom floating but netlist has net → connected (降误报 #15)', () => {
+	// #15-class false positive: geometry misses the connection, netlist is authoritative.
+	assert.equal(classifyPinConnectivity(true, false, true), 'connected');
+});
+
+test('classifyPinConnectivity: geom connected but netlist no net → geom-net-mismatch (补漏报)', () => {
+	assert.equal(classifyPinConnectivity(false, true, true), 'geom-net-mismatch');
+});
+
+test('classifyPinConnectivity: neither source connects → floating', () => {
+	assert.equal(classifyPinConnectivity(false, false, true), 'floating');
+});
+
+test('classifyPinConnectivity: netlist muted → pure geometry, never mismatch', () => {
+	// getNetlistFile failed: geom-connected pins must NOT surface as mismatches.
+	assert.equal(classifyPinConnectivity(false, true, false), 'connected');
+	assert.equal(classifyPinConnectivity(false, false, false), 'floating');
 });

--- a/extension/src/util.ts
+++ b/extension/src/util.ts
@@ -267,3 +267,37 @@ export function normalizeRegion(
 	}
 	return { left: minX, right: maxX, top: minY, bottom: maxY };
 }
+
+/**
+ * Cross-check a pin's GEOMETRIC connectivity against the JSON-authoritative
+ * netlist (getNetlistFile → pin→net). Pure (no `eda` runtime) so it can be unit
+ * tested; the schematic.check handler feeds it live geometry + netlist facts.
+ *
+ * @param hasNetlistNet    - the authoritative netlist assigns this pin a non-empty net
+ * @param geomConnected    - geometry says the pin is touched by a wire / net marker
+ * @param netlistAvailable - the netlist JSON was actually fetched+parsed. When it is
+ *                           NOT available (getNetlistFile failed / empty), the netlist
+ *                           source is muted and we fall back to PURE geometry — a
+ *                           geom-connected pin is 'connected', never a mismatch, so a
+ *                           missing/uncompiled netlist can't manufacture false reports.
+ * @returns
+ *   - 'connected'         netlist has a net (authoritative — drops #15-class geometric
+ *                         false positives), OR netlist unavailable + geometry connects
+ *   - 'floating'          neither source connects it → real floating pin
+ *   - 'geom-net-mismatch' netlist available + geometry says wired but netlist has NO
+ *                         net → suspected missed report: a wire touches the pin yet it
+ *                         is on no net (cosmetic touch, or a not-yet-compiled netlist)
+ */
+export type PinConnectivity = 'connected' | 'floating' | 'geom-net-mismatch';
+
+export function classifyPinConnectivity(
+	hasNetlistNet: boolean,
+	geomConnected: boolean,
+	netlistAvailable: boolean,
+): PinConnectivity {
+	if (hasNetlistNet) return 'connected';
+	// Netlist muted (couldn't fetch) → trust geometry alone, no mismatch signal.
+	if (!netlistAvailable) return geomConnected ? 'connected' : 'floating';
+	if (geomConnected) return 'geom-net-mismatch';
+	return 'floating';
+}

--- a/internal/app/cmd_sch_check.go
+++ b/internal/app/cmd_sch_check.go
@@ -13,8 +13,12 @@ import (
 // {count,type} — the per-item detail the UI panel shows is not exposed by any
 // public API. schematic.check reconstructs the actionable findings from the
 // primitives directly (connector side). Rule 1: floating pins via geometric
-// connectivity. This file renders that report and (with --strict) gates on it.
-// Output is by designator + pin number — feed it straight into `sch no-connect`.
+// connectivity CROSS-CHECKED against the JSON-authoritative netlist — a net in
+// the netlist drops #15-class geometric false positives, while geometry that
+// touches a pin the netlist puts on no net surfaces as a geom-net-mismatch
+// (suspected missed report). This file renders that report and (with --strict)
+// gates on it. Output is by designator + pin number — feed it straight into
+// `sch no-connect`.
 
 type checkPinDetail struct {
 	Number string  `json:"number"`
@@ -46,6 +50,7 @@ type checkFinding struct {
 type checkSummary struct {
 	FloatingPins           int `json:"floatingPins"`
 	ComponentsWithFloating int `json:"componentsWithFloating"`
+	GeomNetMismatches      int `json:"geomNetMismatches"`
 	NetMarkerMismatches    int `json:"netMarkerMismatches"`
 	MultiNetWires          int `json:"multiNetWires"`
 	WireCrossings          int `json:"wireCrossings"`
@@ -131,8 +136,8 @@ func checkLevelTag(level string) string {
 
 func renderCheckReport(rep checkReport, w io.Writer) {
 	s := rep.Summary
-	fmt.Fprintf(w, "sch check: %d finding(s) — %d floating pin(s)/%d comp, %d net-marker mismatch(es), %d multi-net wire(s), %d wire-crossing(s), %d wire-over-pin(s), %d zero-length wire(s), %d dangling wire(s)\n",
-		s.Total, s.FloatingPins, s.ComponentsWithFloating, s.NetMarkerMismatches, s.MultiNetWires, s.WireCrossings, s.WireOverPins, s.ZeroLengthWires, s.DanglingWires)
+	fmt.Fprintf(w, "sch check: %d finding(s) — %d floating pin(s)/%d comp, %d geom-net mismatch(es), %d net-marker mismatch(es), %d multi-net wire(s), %d wire-crossing(s), %d wire-over-pin(s), %d zero-length wire(s), %d dangling wire(s)\n",
+		s.Total, s.FloatingPins, s.ComponentsWithFloating, s.GeomNetMismatches, s.NetMarkerMismatches, s.MultiNetWires, s.WireCrossings, s.WireOverPins, s.ZeroLengthWires, s.DanglingWires)
 
 	for _, f := range rep.Findings {
 		tag := checkLevelTag(f.Level)
@@ -185,6 +190,11 @@ func renderCheckReport(rep checkReport, w io.Writer) {
 	if s.FloatingPins > 0 {
 		// The floating-pin list is the exact input `sch no-connect` takes.
 		fmt.Fprintln(w, "→ floating pins: wire them, or (where supported) mark intentional ones NC")
+	}
+	if s.GeomNetMismatches > 0 {
+		// Geometry touches the pin but the authoritative netlist has no net for it —
+		// recompile the netlist, or fix the wire so it electrically connects.
+		fmt.Fprintln(w, "→ geom-net mismatch: wire touches pin but netlist has no net — recompile netlist, or fix the stub so it truly connects")
 	}
 	if s.WireCrossings > 0 || s.WireOverPins > 0 {
 		fmt.Fprintln(w, "→ routing: reroute crossings in clear channels (L-bends); never run a wire through a pin")

--- a/internal/app/cmd_sch_check_test.go
+++ b/internal/app/cmd_sch_check_test.go
@@ -122,3 +122,43 @@ func TestRenderCheck_Clean(t *testing.T) {
 		t.Errorf("expected clean line, got:\n%s", buf.String())
 	}
 }
+
+// geom-net-mismatch: geometry touches the pin but the JSON-authoritative netlist
+// puts it on no net (the "补漏报" direction of the #45 cross-check). Render shows
+// the type, designator, pin, coords, and the recompile/fix hint.
+func TestParseAndRenderCheck_GeomNetMismatch(t *testing.T) {
+	result := map[string]any{
+		"passed": false,
+		"summary": map[string]any{
+			"geomNetMismatches": float64(1),
+			"total":             float64(1),
+		},
+		"findings": []any{
+			map[string]any{
+				"type":        "geom-net-mismatch",
+				"level":       "warn",
+				"designator":  "U1",
+				"primitiveId": "c1",
+				"pins":        []any{"7"},
+				"at":          map[string]any{"x": float64(120), "y": float64(-80)},
+				"message":     "导线触碰该引脚但网表未将其归入任何 net",
+			},
+		},
+	}
+	rep, err := parseCheckReport(result)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if rep.Summary.GeomNetMismatches != 1 || len(rep.Findings) != 1 {
+		t.Errorf("unexpected summary/findings: %+v", rep)
+	}
+
+	var buf bytes.Buffer
+	renderCheckReport(rep, &buf)
+	out := buf.String()
+	for _, want := range []string{"WARN", "geom-net-mismatch", "U1", "[7]", "@(120.00,-80.00)", "geom-net mismatch"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("render missing %q\n--- output ---\n%s", want, out)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #45

## 背景
floating-pin 规则的"降误报"半（netlist 有 net 即判连接）此前已在 `actions.ts` 落地。本 PR 补齐"补漏报"半：几何连通但权威网表无 net 的引脚，产出新 finding 类型 `geom-net-mismatch`。

## 改动
- `extension/src/util.ts`：新增纯函数 `classifyPinConnectivity(hasNetlistNet, geomConnected, netlistAvailable)`，把几何 × netlist 交叉判定收敛为 connected/floating/geom-net-mismatch 三态（eda-free，可单测）。
- `extension/src/actions.ts`：`collectNetlistPinNets` 返回 `{byDesignator, available}`，区分"网表取不到"与"取到但空"；floating-pin 判定改用 `classifyPinConnectivity`；新增 `geom-net-mismatch` finding 与 `summary.geomNetMismatches`。
- `internal/app/cmd_sch_check.go`：`checkSummary` 加 `GeomNetMismatches`，summary 行与提示渲染新类型。

## 边角处理
网表不可用（`getNetlistFile` 失败/为空）时用 `netlistAvailable=false` 守卫，回退纯几何判定，避免未编译/缺失网表把所有几何连通引脚误报为 mismatch。

## 测试
- TS：`util.test.ts` 覆盖三类验收场景（一致/几何浮空但 netlist 有 net/几何连通但 netlist 无 net）+ 网表 muted 守卫，17 项全通过；`tsc --noEmit` 干净。
- Go：`cmd_sch_check_test.go` 新增 `TestParseAndRenderCheck_GeomNetMismatch`，`go test ./internal/app` 全通过，`go build ./...` 干净。
- 未测：#42/#43 ESP32 端到端回归需 EDA runtime，无法在本地执行；`schematicCheck` 依赖 `eda.*` 的部分靠抽纯函数 + Go 渲染测兜底。