### PR TITLE
fix: warn --all-pages returns shallow data for non-active pages

### DIFF
--- a/internal/app/cmd_sch.go
+++ b/internal/app/cmd_sch.go
@@ -326,7 +326,7 @@ func newSchCmd(cfg *appConfig, stdout, stderr io.Writer) *cobra.Command {
 				return dispatch(cfg, "schematic.components.list", window, payload, stdout, stderr)
 			},
 		}
-		c.Flags().BoolVar(&allPages, "all-pages", false, "list components across all schematic pages")
+		c.Flags().BoolVar(&allPages, "all-pages", false, "list components across all schematic pages (WARNING: non-active pages return shallow data — pins/bbox may be empty; use `doc switch` to that page for accurate data)")
 		c.Flags().BoolVar(&includeBBox, "include-bbox", false, "attach each component's rendered extent {minX,minY,maxX,maxY}")
 		c.Flags().BoolVar(&includePins, "include-pins", false, "attach each pin's {pinName,pinNumber,x,y,noConnected} — the data plane for routing/connectivity checks (output grows, esp. with --all-pages)")
 		sch.AddCommand(c)
@@ -884,7 +884,7 @@ exits non-zero when there are any findings, to use it as a gate.`,
 				return runSchCheck(cfg, window, allPages, strict, asJSON, stdout, stderr)
 			},
 		}
-		c.Flags().BoolVar(&allPages, "all-pages", false, "check components across all schematic pages")
+		c.Flags().BoolVar(&allPages, "all-pages", false, "check components across all schematic pages (WARNING: non-active pages return shallow data — pins/bbox may be empty; use `doc switch` to that page for accurate data)")
 		c.Flags().BoolVar(&strict, "strict", false, "exit non-zero when there are findings (gate mode)")
 		c.Flags().BoolVar(&asJSON, "json", false, "emit the report as JSON")
 		sch.AddCommand(c)
@@ -921,7 +921,7 @@ check for a faster read.`,
 				return dispatch(cfg, "schematic.read", window, payload, stdout, stderr)
 			},
 		}
-		c.Flags().BoolVar(&allPages, "all-pages", false, "read components across all schematic pages")
+		c.Flags().BoolVar(&allPages, "all-pages", false, "read components across all schematic pages (WARNING: non-active pages return shallow data — pins/bbox may be empty; use `doc switch` to that page for accurate data)")
 		c.Flags().BoolVar(&noCheck, "no-check", false, "skip the geometric design check for a faster read")
 		sch.AddCommand(c)
 	}
@@ -975,7 +975,7 @@ Exits non-zero when any overlap is found, so it can gate a workflow.`,
 		}
 		c.Flags().Float64Var(&minGap, "min-gap", 2.54, "minimum gap between component bboxes in mm (closer = WARN)")
 		c.Flags().BoolVar(&asJSON, "json", false, "emit the report as JSON")
-		c.Flags().BoolVar(&allPages, "all-pages", false, "lint components across all schematic pages")
+		c.Flags().BoolVar(&allPages, "all-pages", false, "lint components across all schematic pages (WARNING: non-active pages return shallow data — components with no bbox are SKIPPED from overlap checks, not confirmed clear; use `doc switch` to that page for accurate linting)")
 		c.Flags().BoolVar(&includeNonParts, "include-non-parts", false, "also lint non-part primitives (sheet/title-frame, netflag/netport/…); excluded by default")
 		sch.AddCommand(c)
 	}

--- a/internal/app/cmd_sch_layout.go
+++ b/internal/app/cmd_sch_layout.go
@@ -269,11 +269,15 @@ func renderLayoutReport(rep layoutReport, w io.Writer) {
 		fmt.Fprintf(w, "  note: %d non-part primitive(s) excluded (sheet/title-frame, netflag/netport/…); pass --include-non-parts to include\n", rep.SkippedNonParts)
 	}
 	if len(rep.NoBBox) > 0 {
-		fmt.Fprintf(w, "  note: %d component(s) had no bbox (skipped): %v\n", len(rep.NoBBox), rep.NoBBox)
+		fmt.Fprintf(w, "  WARN   no-bbox  %d component(s) NOT CHECKED (no bbox — likely non-active-page shallow data under --all-pages; `doc switch` to that page to lint it): %v\n", len(rep.NoBBox), rep.NoBBox)
+	}
+	skipCaveat := ""
+	if len(rep.NoBBox) > 0 {
+		skipCaveat = fmt.Sprintf("; %d component(s) NOT checked (skipped ≠ confirmed clear)", len(rep.NoBBox))
 	}
 	if rep.OK {
-		fmt.Fprintf(w, "✓ no overlaps; %d tight pair(s)\n", len(rep.TightPairs))
+		fmt.Fprintf(w, "✓ no overlaps among checked components; %d tight pair(s)%s\n", len(rep.TightPairs), skipCaveat)
 	} else {
-		fmt.Fprintf(w, "✗ %d overlap(s), %d tight pair(s)\n", len(rep.Overlaps), len(rep.TightPairs))
+		fmt.Fprintf(w, "✗ %d overlap(s), %d tight pair(s)%s\n", len(rep.Overlaps), len(rep.TightPairs), skipCaveat)
 	}
 }

--- a/internal/protocol/actions.go
+++ b/internal/protocol/actions.go
@@ -207,7 +207,7 @@ func AllActions() []ActionSpec {
 			Phase:       1,
 			NeedsWindow: true,
 			Description: "List components on the active schematic page. includeBBox attaches each component's rendered extent {minX,minY,maxX,maxY} (used by `easyeda sch layout-lint` for overlap/spacing checks). NOTE: the component/symbol/footprint/uniqueId fields are placed-INSTANCE ids — they are NOT device-library uuids and cannot be replayed into `schematic.component.place`. To re-place the same part, get a fresh device uuid from `schematic.library.search`.",
-			Inputs:      []string{"allPages optional", "includePins optional", "includeBBox optional"},
+			Inputs:      []string{"allPages optional (WARNING: non-active pages return shallow data — pins/bbox may be empty even when wired; switch to the page via document.switch for accurate data)", "includePins optional", "includeBBox optional"},
 			Outputs:     []string{"component primitives", "designator", "name", "pins", "bbox"},
 		},
 		{


### PR DESCRIPTION
Fixes #54

## 落地范围：最小修复（诚实文档 + 更醒目的警告）

issue 明确指出 pins/bbox 缺失是否源自 SDK 对非激活页只提供浅层信息「需真机确认，不要假设」。理想修复（逐页 doc switch 聚合）依赖该结论且涉及连接器/SDK 交互与性能评估，本次不冒进，先落地必须交付的最小修复。

## 改动
- **cmd_sch.go**：sch read/list/check/layout-lint 四个 `--all-pages` flag 帮助文本加警告——非激活页数据浅层、pins/bbox 可能为空，需 `doc switch` 到该页取精确数据。
- **protocol/actions.go**：schematic.components.list 的 `allPages` Inputs 描述同步加警告。
- **cmd_sch_layout.go**：把 'no bbox (skipped)' 从脚注 note 提升为醒目的 `WARN no-bbox ... NOT CHECKED` 行；并在最终结论行追加 'skipped ≠ confirmed clear' 提示，`✓` 行改为 'no overlaps among checked components'，避免空 overlap 结果被误读为全清。

## 测试
- `go build ./...` 通过
- `go test ./internal/app/... ./internal/protocol/...` 通过

## 未覆盖（需真机）
- 未做真机回归：pins/bbox 缺失是否确为 SDK 浅层返回、理想聚合修复是否必要，仍需在 EasyEDA + 多页工程环境确认。本 PR 仅确保用户不会在不知情下依赖残缺数据。