### PR TITLE
fix: page-rename 写后自校验,消除 doc ls 读到旧页名

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -6,6 +6,14 @@ follow [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- `schematic.page.rename` 改完立即 `doc ls` 读到旧页名(issue #55):
+  `modifySchematicPageName` 返回 `ok:true` 后,新名不会立刻进
+  `getAllSchematicPagesInfo()` 的元数据缓存,要等后续某个写操作才刷新。现在
+  `page.rename` 成功后做写后自校验——短间隔重试读回页面列表确认新名生效,命中返回
+  `verified:true`;重试耗尽仍未同步返回 `verified:false` + `warning`,把平台异步性
+  如实报给调用方,而不是盲目 echo `ok`。
+
 ## [0.8.11] - 2026-07-07
 
 探针轮次 #3(esp32MiniRequire 回归)实测暴露的两处修复。

--- a/extension/src/actions.ts
+++ b/extension/src/actions.ts
@@ -354,7 +354,20 @@ const schematicPageCreate: Handler = async (payload) => {
 	return { result: { pageUuid: uuid } };
 };
 
-/** Rename a schematic page. */
+/**
+ * Rename a schematic page.
+ *
+ * Platform quirk (issue #55): `modifySchematicPageName` returns ok=true, but the
+ * new name does NOT immediately show up in `getAllSchematicPagesInfo()` — the
+ * platform's page-metadata cache only refreshes after some later write op fires,
+ * so an immediate `doc ls` reads the STALE old name. This is the same family of
+ * platform-async traps as the getState_Rotation echo (schematic-layout-conventions.md).
+ *
+ * We can't fix the platform, so we do a write-after read-back verification here:
+ * retry `getAllSchematicPagesInfo()` a few times with small delays and confirm the
+ * target page's name is actually the new value. Report the truth to the caller via
+ * `verified` (+ a `warning` when it never settles) instead of blindly echoing ok.
+ */
 const schematicPageRename: Handler = async (payload) => {
 	const pageUuid = requireString(payload, 'pageUuid');
 	const name = requireString(payload, 'name');
@@ -365,8 +378,44 @@ const schematicPageRename: Handler = async (payload) => {
 	catch (err) {
 		throw edaError(err, 'Failed to rename schematic page.');
 	}
-	return { result: { ok } };
+	// Write-after self-verification: poll the page list until the new name lands,
+	// so callers doing an immediate `doc ls` don't read the stale old name.
+	const verified = await verifySchematicPageName(pageUuid, name);
+	if (verified) {
+		return { result: { ok, verified: true } };
+	}
+	return {
+		result: {
+			ok,
+			verified: false,
+			warning: '重命名已提交，但页面列表元数据尚未同步为新名（EasyEDA 平台异步缓存，issue #55）；'
+				+ '请稍后重试或触发任意其他写操作后再用 doc ls 确认。',
+		},
+	};
 };
+
+/**
+ * Poll `getAllSchematicPagesInfo()` up to a few times until the target page's name
+ * equals `expected`. Returns true once observed, false if it never settles.
+ * Best-effort: read errors are swallowed and treated as "not yet settled".
+ */
+async function verifySchematicPageName(pageUuid: string, expected: string): Promise<boolean> {
+	const delays = [0, 120, 250, 500]; // ~0.87s worst case, small enough to stay snappy
+	for (const wait of delays) {
+		if (wait > 0) {
+			await new Promise<void>(resolve => setTimeout(resolve, wait));
+		}
+		try {
+			const pages = await eda.dmt_Schematic.getAllSchematicPagesInfo();
+			const hit = pages.find(p => p.uuid === pageUuid);
+			if (hit && hit.name === expected) return true;
+		}
+		catch {
+			/* best-effort — treat as not-yet-settled and keep polling */
+		}
+	}
+	return false;
+}
 
 /** Delete a schematic page. */
 const schematicPageDelete: Handler = async (payload) => {

--- a/internal/protocol/actions.go
+++ b/internal/protocol/actions.go
@@ -164,9 +164,9 @@ func AllActions() []ActionSpec {
 			Phase:       1,
 			Mutates:     true,
 			NeedsWindow: true,
-			Description: "Rename a schematic page.",
+			Description: "Rename a schematic page. Verifies the new name landed in the page list (issue #55 platform-async cache); returns verified=false + warning if it hasn't synced yet.",
 			Inputs:      []string{"pageUuid", "name"},
-			Outputs:     []string{"ok"},
+			Outputs:     []string{"ok", "verified", "warning"},
 		},
 		{
 			Name:         "schematic.page.delete",

--- a/skills/easyeda-agent/references/schematic-layout-conventions.md
+++ b/skills/easyeda-agent/references/schematic-layout-conventions.md
@@ -292,6 +292,7 @@ LED 也可用 `LED1` 这种语义化命名（兼容 `D1`），EasyEDA 不强制 
 - 对超大模块（pin > 100），九宫格容纳能力有限，可能要分多页（用 `schematic.pages.list` + `schematic.page.open`）。
 - 多页之间通过 `net_port` (`createNetPort('IN/OUT/BI')`) 在页间建立电气连接，net 名称相同视为同网。
 - `getCurrentRenderedAreaImage` **实测不可靠**：在后台标签 / 某些状态下它返回的是**缓存的旧渲染**——既不跟随 `zoomToSelectedPrimitives` / `zoomToRegion`，也可能不反映刚做的增删（实测：两次不同板面状态下截图逐字节相同、md5 一致）。用它做"改完截图确认"前，务必先确认它真的刷新了（例如截图前后做一处明显改动并比对像素）；否则改用纯数据校验（如 schematic-lint）或直接肉眼看 EasyEDA 界面。
+- ⚠️ **`schematic.page.rename` 改完立即 `doc ls` 会读到旧页名（issue #55）**：`modifySchematicPageName` 返回 `ok:true` 后，新名字**不会立刻**写进 `getAllSchematicPagesInfo()`（`schematic.pages.list` / `doc ls` 的数据源）——平台的页面元数据缓存要等某个**后续写操作**触发才刷新（`sch clear` 等任意无关动作会"顺便"刷到，造成"看似延迟生效"）。同属 `createNetFlag` 立即回显那一类平台异步陷阱。**连接器已内建写后自校验**：`page.rename` 成功后会短间隔重试读回 `getAllSchematicPagesInfo()` 确认新名生效，命中返回 `verified:true`；重试耗尽仍未同步返回 `verified:false` + `warning`。**确认重命名真的生效的可靠做法 = 看返回值的 `verified` 字段**（而不是紧接着 `doc ls`）；若拿到 `verified:false`，稍后重试或触发任意写操作后再 `doc ls`。
 - 目前两份 reference（§7 motobox、§8 ESP32S3R8N8）覆盖了「贴近 3×3 理想」与「RF MCU 占角 + 横向电源链」两种典型。若再采集到第三种（例如纯模拟前端、或多电源域工控板），应继续补充以避免 agent 过拟合到单一案例。
 
 ## 11. 图纸边界与标题栏 keep-out (sheet / title-block keep-out)


### PR DESCRIPTION
Fixes #55

## 问题
`schematic.page.rename`(`modifySchematicPageName`)返回 `ok:true` 后,新页名不会立刻写进 `getAllSchematicPagesInfo()` 的元数据缓存,紧接着的 `doc ls` 读到的仍是旧名,要等某个后续写操作触发平台内部同步才刷新。属 EasyEDA 平台异步缓存陷阱(同 createNetFlag 立即回显那一类)。

## 改动
- `extension/src/actions.ts` `schematicPageRename`:成功后做写后自校验,新增 `verifySchematicPageName()` 以 [0,120,250,500]ms 间隔重试读回 `getAllSchematicPagesInfo()`,确认目标 pageUuid 的 name 已等于新值。命中返回 `{ok, verified:true}`;重试耗尽仍未同步返回 `{ok, verified:false, warning}`,把不确定性如实报给调用方而非盲目 echo ok。
- `internal/protocol/actions.go`:`schematic.page.rename` 的 Outputs 增补 `verified`/`warning`,Description 说明平台异步行为。
- `schematic-layout-conventions.md` §10:记录该平台陷阱,并给出可靠确认做法(看返回 `verified` 字段,而非紧接着 doc ls)。
- CHANGELOG 补记。

## 测试
- `npm run typecheck` 通过;`npm test`(扩展 24 项)全过。
- `go test ./...` 全过(含 protocol/app)。
- **未做真机回归**:worktree 环境无已连接的 EasyEDA Pro 窗口,`page-rename` 后立即 `doc ls` 的活体验证需在真机执行。重试的间隔上界(~0.87s)是基于 issue 描述的经验值,若真机上同步延迟更长,可能仍返回 `verified:false`(此时 warning 已如实提示),需据实测调整 delays。