### PR TITLE
fix: multi-net-wire 同名重复不再误报,仅异名并线告警

### DIFF
--- a/extension/src/actions.ts
+++ b/extension/src/actions.ts
@@ -1854,15 +1854,18 @@ const schematicCheck: Handler = async (payload) => {
 		const nets = refs.map(r => r.net).filter(Boolean);
 		if (nets.length <= 1) continue;
 		const unique = [...new Set(nets)];
-		if (unique.length > 1 || nets.length !== unique.length) {
+		// Only distinct net names on one wire is a real short (异名并线).
+		// Repeated same-name flags (e.g. ["GND","GND"] from共线合并的 stub) are
+		// legal — collapse to unique so we don't drown 3 real shorts under 83 dupes.
+		if (unique.length > 1) {
 			multiNetWires++;
 			findings.push({
 				type: 'multi-net-wire',
 				level: 'warn',
 				wirePrimitiveId: wireId,
-				nets,
-				count: nets.length,
-				message: `导线有多个网络名: ${nets.join('、')}`,
+				nets: unique,
+				count: unique.length,
+				message: `导线有多个网络名: ${unique.join('、')}`,
 			});
 		}
 	}

--- a/internal/app/cmd_sch_check_test.go
+++ b/internal/app/cmd_sch_check_test.go
@@ -98,15 +98,15 @@ func TestRenderCheck_NetNames(t *testing.T) {
 				Type:            "multi-net-wire",
 				Level:           "warn",
 				WirePrimitiveId: "w2",
-				Nets:            []string{"EN", "EN"},
-				Message:         "导线有多个网络名: EN、EN",
+				Nets:            []string{"EN", "GND"},
+				Message:         "导线有多个网络名: EN、GND",
 			},
 		},
 	}
 	var buf bytes.Buffer
 	renderCheckReport(rep, &buf)
 	out := buf.String()
-	for _, want := range []string{"net-marker mismatch", "multi-net wire", "marker=+3V3 wire=BOOT_IO0", "nets=[EN,EN]", "net names"} {
+	for _, want := range []string{"net-marker mismatch", "multi-net wire", "marker=+3V3 wire=BOOT_IO0", "nets=[EN,GND]", "net names"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("render missing %q\n--- output ---\n%s", want, out)
 		}


### PR DESCRIPTION
Fixes #65

## 问题
共线合并后的长导线挂多个同名 flag（如一排电容的 GND stub 合并成一条线），`sch check` 对每条这样的线都报 `multi-net-wire`。实测一页 83 条噪音淹没了 3 条真正异名（真短路）的告警。

## 根因
`extension/src/actions.ts:1857` 的判定条件 `unique.length > 1 || nets.length !== unique.length` 的第二支在「网名重复但唯一值只有一个」时为真（如 `["GND","GND"]` → unique==1 但 nets(2)!==1），把合法的同名并线也当成 multi-net-wire 报出。

## 修改
- `extension/src/actions.ts`: 条件收窄为仅 `unique.length > 1`,只有异名并线（真短路）才 warn;上报 `nets`/`count` 改为去重后的 `unique`。
- `internal/app/cmd_sch_check_test.go`: 将 multi-net-wire 渲染样例由同名 `[EN,EN]` 改为异名 `[EN,GND]`,使测试覆盖修复后的真短路语义。

## 验证
- `go test ./internal/app/ -run TestRenderCheck` 通过。
- extension `npm run typecheck` 通过。
- 未在真实 EDA 运行时（eda.sch_* API）复跑 —— 该逻辑依赖 IDE 内环境,无独立最小复现数据集,需人工在车机V2-fable P1 场景确认 83 条噪音归零、3 条真短路保留。