### PR TITLE
fix: sch check/drc/sheet --json 包统一 {id,type,version,ok,result} 信封

### DIFF
--- a/internal/app/cmd_sch.go
+++ b/internal/app/cmd_sch.go
@@ -947,7 +947,7 @@ still surfacing warnings for review.`,
 		}
 		c.Flags().BoolVar(&strict, "strict", false, "treat warnings as errors (SDK strict mode)")
 		c.Flags().BoolVar(&verbose, "verbose", false, "also print each violation's raw EDA object")
-		c.Flags().BoolVar(&asJSON, "json", false, "emit the normalized report as JSON")
+		c.Flags().BoolVar(&asJSON, "json", false, "emit the normalized report in the {id,type,version,ok,result} envelope (report under result)")
 		sch.AddCommand(c)
 	}
 
@@ -975,7 +975,11 @@ The floating-pin output is the exact input 'sch no-connect' takes, so the loop i
 sch check → wire the real ones / sch no-connect the intentional ones → sch check.
 
 Exit code: 0 by default (floating IO pins are normal until NC-marked); --strict
-exits non-zero when there are any findings, to use it as a gate.`,
+exits non-zero when there are any findings, to use it as a gate.
+
+--json wraps the report in the same {id,type,version,ok,result} envelope the
+other sch commands emit; the findings are under result.findings (v0.10.0+;
+prior versions emitted a bare {passed,summary,findings}).`,
 			Args: cobra.NoArgs,
 			Example: `  easyeda sch check
   easyeda sch check --json
@@ -986,7 +990,7 @@ exits non-zero when there are any findings, to use it as a gate.`,
 		}
 		c.Flags().BoolVar(&allPages, "all-pages", false, "check components across all schematic pages (WARNING: non-active pages return shallow data — pins/bbox may be empty; use `doc switch` to that page for accurate data)")
 		c.Flags().BoolVar(&strict, "strict", false, "exit non-zero when there are findings (gate mode)")
-		c.Flags().BoolVar(&asJSON, "json", false, "emit the report as JSON")
+		c.Flags().BoolVar(&asJSON, "json", false, "emit the report in the {id,type,version,ok,result} envelope (findings under result.findings)")
 		sch.AddCommand(c)
 	}
 
@@ -1112,7 +1116,7 @@ The keepouts[] format is what sch autoconnect / autolayout consume.`,
 				return runSheetGeometry(cfg, window, asJSON, stdout, stderr)
 			},
 		}
-		c.Flags().BoolVar(&asJSON, "json", false, "emit the geometry as JSON")
+		c.Flags().BoolVar(&asJSON, "json", false, "emit the geometry in the {id,type,version,ok,result} envelope (geometry under result)")
 		sch.AddCommand(c)
 	}
 

--- a/internal/app/cmd_sch_check.go
+++ b/internal/app/cmd_sch_check.go
@@ -89,9 +89,10 @@ func runSchCheck(cfg *appConfig, window string, allPages, strict, asJSON bool, s
 	}
 
 	if asJSON {
-		enc := json.NewEncoder(stdout)
-		enc.SetIndent("", "  ")
-		if err := enc.Encode(rep); err != nil {
+		// Wrap the reconstructed report in the same {id,type,version,ok,result}
+		// envelope the transparent commands (sch list/read/place) stream, so a
+		// uniform-envelope parser reading result.findings works here too (#66).
+		if err := encodeResultEnvelope(res, rep, stdout); err != nil {
 			return err
 		}
 	} else {

--- a/internal/app/cmd_sch_check_test.go
+++ b/internal/app/cmd_sch_check_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -109,6 +110,72 @@ func TestRenderCheck_NetNames(t *testing.T) {
 	for _, want := range []string{"net-marker mismatch", "multi-net wire", "marker=+3V3 wire=BOOT_IO0", "nets=[EN,EN]", "net names"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("render missing %q\n--- output ---\n%s", want, out)
+		}
+	}
+}
+
+// #66: --json output must be wrapped in the {id,type,version,ok,result}
+// envelope the transparent sch commands stream, so a uniform-envelope parser
+// reading result.findings works here too (previously it emitted a bare
+// {passed,summary,findings} and result.findings was silently empty).
+func TestEncodeResultEnvelope_CheckReport(t *testing.T) {
+	rep := checkReport{
+		Passed:  false,
+		Summary: checkSummary{FloatingPins: 2, Total: 1},
+		Findings: []checkFinding{
+			{Type: "floating-pin", Level: "warn", Designator: "U1", Pins: []string{"4", "5"}},
+		},
+	}
+	res := &actionResult{ID: "req-1", Type: "response", Version: "1", OK: true}
+
+	var buf bytes.Buffer
+	if err := encodeResultEnvelope(res, rep, &buf); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	var env struct {
+		ID      string `json:"id"`
+		Type    string `json:"type"`
+		Version string `json:"version"`
+		OK      bool   `json:"ok"`
+		Result  struct {
+			Passed   bool           `json:"passed"`
+			Findings []checkFinding `json:"findings"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal envelope: %v\n%s", err, buf.String())
+	}
+	if env.ID != "req-1" || env.Type != "response" || env.Version != "1" || !env.OK {
+		t.Errorf("envelope metadata lost: %+v", env)
+	}
+	// The whole point of #66: result.findings must be reachable and non-empty.
+	if len(env.Result.Findings) != 1 || env.Result.Findings[0].Designator != "U1" {
+		t.Errorf("result.findings not reachable via envelope: %+v", env.Result)
+	}
+	if env.Result.Passed {
+		t.Error("expected result.passed=false")
+	}
+}
+
+// Envelope metadata is optional: when the daemon response carries no id/type/
+// version, those keys are omitted rather than emitted empty, but ok/result
+// stay present.
+func TestEncodeResultEnvelope_OmitsEmptyMeta(t *testing.T) {
+	rep := checkReport{Passed: true}
+	res := &actionResult{OK: true}
+
+	var buf bytes.Buffer
+	if err := encodeResultEnvelope(res, rep, &buf); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	out := buf.String()
+	if strings.Contains(out, "\"id\"") || strings.Contains(out, "\"type\"") || strings.Contains(out, "\"version\"") {
+		t.Errorf("expected empty meta omitted, got:\n%s", out)
+	}
+	for _, want := range []string{"\"ok\"", "\"result\""} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %s present, got:\n%s", want, out)
 		}
 	}
 }

--- a/internal/app/cmd_sch_drc.go
+++ b/internal/app/cmd_sch_drc.go
@@ -75,9 +75,9 @@ func runSchDrc(cfg *appConfig, window string, strict, verbose, asJSON bool, stdo
 	}
 
 	if asJSON {
-		enc := json.NewEncoder(stdout)
-		enc.SetIndent("", "  ")
-		if err := enc.Encode(rep); err != nil {
+		// Same {id,type,version,ok,result} envelope as the transparent commands,
+		// so the whole sch family parses uniformly (#66).
+		if err := encodeResultEnvelope(res, rep, stdout); err != nil {
 			return err
 		}
 	} else {

--- a/internal/app/cmd_sch_sheet.go
+++ b/internal/app/cmd_sch_sheet.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"math"
@@ -205,9 +204,10 @@ func runSheetGeometry(cfg *appConfig, window string, asJSON bool, stdout, stderr
 	g := deriveSheetGeometry(sheet, showTB)
 
 	if asJSON {
-		enc := json.NewEncoder(stdout)
-		enc.SetIndent("", "  ")
-		return enc.Encode(g)
+		// Wrap in the same {id,type,version,ok,result} envelope the rest of the
+		// sch family emits (#66). Envelope metadata comes from the primary
+		// components.list response (res).
+		return encodeResultEnvelope(res, g, stdout)
 	}
 	renderSheetGeometry(g, stdout)
 	return nil

--- a/internal/app/dispatch.go
+++ b/internal/app/dispatch.go
@@ -96,8 +96,14 @@ type artifactRef struct {
 }
 
 // actionResult is the parsed form of an /action response, for callers that need
-// to read the result programmatically instead of streaming it to stdout.
+// to read the result programmatically instead of streaming it to stdout. The
+// envelope fields (ID/Type/Version) are preserved so reconstruct-then-render
+// commands (sch check/drc/sheet) can re-wrap their typed report in the same
+// {id,type,version,ok,result} envelope the transparent commands stream (#66).
 type actionResult struct {
+	ID        string         `json:"id"`
+	Type      string         `json:"type"`
+	Version   string         `json:"version"`
 	OK        bool           `json:"ok"`
 	Result    map[string]any `json:"result"`
 	Artifacts []artifactRef  `json:"artifacts"`
@@ -121,6 +127,9 @@ func requestActionTimed(cfg *appConfig, action, window string, payload any, time
 	}
 
 	var parsed struct {
+		ID        string         `json:"id"`
+		Type      string         `json:"type"`
+		Version   string         `json:"version"`
 		OK        bool           `json:"ok"`
 		Result    map[string]any `json:"result"`
 		Artifacts []artifactRef  `json:"artifacts"`
@@ -132,7 +141,7 @@ func requestActionTimed(cfg *appConfig, action, window string, payload any, time
 	if err := json.Unmarshal(respBody, &parsed); err != nil {
 		return nil, fmt.Errorf("decode %s response: %w", action, err)
 	}
-	res := &actionResult{OK: parsed.OK, Result: parsed.Result, Artifacts: parsed.Artifacts, Context: parsed.Context}
+	res := &actionResult{ID: parsed.ID, Type: parsed.Type, Version: parsed.Version, OK: parsed.OK, Result: parsed.Result, Artifacts: parsed.Artifacts, Context: parsed.Context}
 	if !parsed.OK {
 		msg := "ok=false"
 		if parsed.Error != nil && parsed.Error.Message != "" {
@@ -142,6 +151,31 @@ func requestActionTimed(cfg *appConfig, action, window string, payload any, time
 		return res, fmt.Errorf("%s failed: %s", action, msg)
 	}
 	return res, nil
+}
+
+// encodeResultEnvelope writes a reconstructed typed report wrapped in the same
+// {id,type,version,ok,result} envelope the transparent (stdout-streaming)
+// commands emit, so `sch check/drc/sheet --json` are consistent with `sch
+// list/read/place` and a uniform-envelope parser reading result.* works across
+// all of them (#66). The envelope metadata is taken from the daemon's response
+// (res); ok mirrors res.OK.
+func encodeResultEnvelope(res *actionResult, report any, stdout io.Writer) error {
+	env := map[string]any{
+		"ok":     res.OK,
+		"result": report,
+	}
+	if res.ID != "" {
+		env["id"] = res.ID
+	}
+	if res.Type != "" {
+		env["type"] = res.Type
+	}
+	if res.Version != "" {
+		env["version"] = res.Version
+	}
+	enc := json.NewEncoder(stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(env)
 }
 
 // dispatchCapture runs an action like dispatch (streaming the raw response to


### PR DESCRIPTION
Fixes #66

## 问题
`sch check --json` 直接输出裸 `{passed,summary,findings}`,而 `sch list/read/place` 输出 `{id,type,version,ok,result:{...}}` 信封。按统一信封解析脚本读 `result.findings` 恒空,静默误判为检查通过。

## 根因
`sch check`(以及同族 `sch drc`/`sch sheet`)走"抽 res.Result 重建成 typed report → enc.Encode(report)"路径,丢弃了信封;而透传族在 dispatch.go 原样 stdout.Write 完整 protocol.Response。

## 改动
- `dispatch.go`: actionResult 保留 id/type/version;新增 encodeResultEnvelope 把 typed report 重新包进 {id,type,version,ok,result} 信封(空 meta 省略)。
- `cmd_sch_check.go` / `cmd_sch_drc.go` / `cmd_sch_sheet.go`: --json 分支改用 encodeResultEnvelope,同族对齐,避免只修 check 引入新的不一致。
- `cmd_sch.go`: --help 与 check Long 文档标注信封格式 + 版本注记(v0.10.0+)。

## Breaking change
`--json` 输出结构变化(裸对象 → 信封)。已在 --help/Long 注明。

## 退出码
issue 附带建议 passed=false 时非零退出。现有 `--strict` 已在有 findings 时返回非零(即 shell 门禁机制),且 check 的 findings 常为信息级(悬空 IO 打 NC 前属正常),默认 rc=0 是刻意设计。为避免二次破坏默认语义,本次沿用 --strict 门禁,未改默认退出码。

## 测试
- 新增 TestEncodeResultEnvelope_CheckReport / _OmitsEmptyMeta,断言 result.findings 可经信封读取、空 meta 省略。
- go build ./... 与 go test ./... 全绿,go vet 无告警。
- 未做 daemon 运行时联调(需连接 EasyEDA connector 的真实工程);逻辑改动为纯 CLI 序列化层,已由单测覆盖。