### PR TITLE
feat(sch place): 支持 --designator 参数,免二次 modify

### DIFF
--- a/extension/src/actions.test.ts
+++ b/extension/src/actions.test.ts
@@ -83,3 +83,45 @@ test('normalizeDeviceRef: non-string uuid/libraryUuid coerced to empty', () => {
 	const ref = normalizeDeviceRef({ libraryUuid: 123, uuid: null }, 'X');
 	assert.deepEqual(ref, { libraryUuid: '', uuid: '', name: 'X' });
 });
+
+import { schematicComponentPlace } from './actions';
+
+/** Install a fake `eda.sch_PrimitiveComponent` on the global for one test.
+ *  create() returns a placeholder-designator component; modify() records its
+ *  args and returns the post-assignment component. Returns the call log. */
+function installEdaStub(placeholderDesignator = 'R?') {
+	const calls: { modify: Array<{ id: string; patch: any }> } = { modify: [] };
+	(globalThis as any).eda = {
+		sch_PrimitiveComponent: {
+			create: async () => mockComponent({ Designator: placeholderDesignator, PrimitiveId: 'p1' }),
+			modify: async (id: string, patch: any) => {
+				calls.modify.push({ id, patch });
+				return mockComponent({ Designator: patch.designator, PrimitiveId: id });
+			},
+		},
+	};
+	return calls;
+}
+
+test('place with designator: assigns atomically and returns final designator (issue #68)', async () => {
+	const calls = installEdaStub('R?');
+	const res: any = await schematicComponentPlace({
+		libraryUuid: 'LIB-A', uuid: 'DEV-A', x: 100, y: 200, designator: 'R12',
+	});
+	assert.equal(calls.modify.length, 1);
+	assert.equal(calls.modify[0].id, 'p1');
+	assert.deepEqual(calls.modify[0].patch, { designator: 'R12' });
+	assert.equal(res.result.primitiveId, 'p1');
+	assert.equal((res.result.component as any).designator, 'R12');
+	delete (globalThis as any).eda;
+});
+
+test('place without designator: no modify call, keeps placeholder (issue #68)', async () => {
+	const calls = installEdaStub('C?');
+	const res: any = await schematicComponentPlace({
+		libraryUuid: 'LIB-A', uuid: 'DEV-A', x: 100, y: 200,
+	});
+	assert.equal(calls.modify.length, 0);
+	assert.equal((res.result.component as any).designator, 'C?');
+	delete (globalThis as any).eda;
+});

--- a/extension/src/actions.ts
+++ b/extension/src/actions.ts
@@ -576,7 +576,7 @@ const schematicComponentsList: Handler = async (payload) => {
 	return { result: { components: serialized, count: serialized.length } };
 };
 
-const schematicComponentPlace: Handler = async (payload) => {
+export const schematicComponentPlace: Handler = async (payload) => {
 	const libraryUuid = requireString(payload, 'libraryUuid');
 	const uuid = requireString(payload, 'uuid');
 	const x = requireNumber(payload, 'x');
@@ -586,6 +586,7 @@ const schematicComponentPlace: Handler = async (payload) => {
 	const mirror = optionalBoolean(payload, 'mirror');
 	const addIntoBom = optionalBoolean(payload, 'addIntoBom');
 	const addIntoPcb = optionalBoolean(payload, 'addIntoPcb');
+	const designator = optionalString(payload, 'designator');
 
 	let component;
 	try {
@@ -606,6 +607,30 @@ const schematicComponentPlace: Handler = async (payload) => {
 	if (!component) {
 		throw new ActionError(ErrorCodes.EDA_CALL_FAILED, 'Component placement returned no primitive.');
 	}
+
+	// Atomically assign the final designator on the connector side so batch
+	// placement skips the place→list→modify round-trip (issue #68). The freshly
+	// placed component keeps a placeholder designator (e.g. U?/C?); the modify
+	// return is the authoritative post-assignment state, so overwrite the local
+	// reference with it before serializing.
+	if (designator) {
+		const primitiveId = component.getState_PrimitiveId();
+		let modified;
+		try {
+			modified = await eda.sch_PrimitiveComponent.modify(primitiveId, { designator });
+		}
+		catch (err) {
+			throw edaError(err, `Placed component "${primitiveId}" but failed to assign designator "${designator}".`);
+		}
+		if (!modified) {
+			throw new ActionError(
+				ErrorCodes.EDA_CALL_FAILED,
+				`Placed component "${primitiveId}" but designator assignment "${designator}" returned no primitive.`,
+			);
+		}
+		component = modified;
+	}
+
 	return {
 		result: {
 			primitiveId: component.getState_PrimitiveId(),

--- a/internal/app/cmd_sch.go
+++ b/internal/app/cmd_sch.go
@@ -349,7 +349,7 @@ before feeding it back into ` + "`sch place --uuid`" + `.`,
 	// ── place ─────────────────────────────────────────────────────────────
 	// schematic.component.place
 	{
-		var lib, uuid string
+		var lib, uuid, designator string
 		var x, y, rotation float64
 		var mirror bool
 		c := &cobra.Command{
@@ -362,9 +362,16 @@ before feeding it back into ` + "`sch place --uuid`" + `.`,
 the uuid-looking fields ` + "`component`/`symbol`/`footprint`/`uniqueId`" + ` that
 ` + "`easyeda sch list`" + ` reports — those are placed-INSTANCE ids and are not valid
 ` + "`sch place`" + ` inputs. Passing an instance uuid makes the EasyEDA API hang; this
-command fails fast after a short timeout with a hint instead of stalling.`,
+command fails fast after a short timeout with a hint instead of stalling.
+
+Pass --designator to atomically assign the final designator on the connector
+side right after create, so you skip the place→` + "`sch list`" + `→` + "`sch modify`" + ` round-trip
+and the coordinate-based primitiveId re-matching that batch placement otherwise
+needs. The response's ` + "`primitiveId`" + ` and ` + "`component.designator`" + ` reflect the
+final placed state.`,
 			Example: `  easyeda sch place --lib <libraryUuid> --uuid <deviceUuid> --x 100 --y 200
-  easyeda sch place --lib <l> --uuid <u> --x 100 --y 200 --rotation 90 --mirror`,
+  easyeda sch place --lib <l> --uuid <u> --x 100 --y 200 --rotation 90 --mirror
+  easyeda sch place --lib <l> --uuid <u> --x 100 --y 200 --designator R12`,
 			RunE: func(cmd *cobra.Command, args []string) error {
 				if lib == "" {
 					return fmt.Errorf("--lib is required")
@@ -384,6 +391,9 @@ command fails fast after a short timeout with a hint instead of stalling.`,
 				if cmd.Flags().Changed("mirror") {
 					payload["mirror"] = mirror
 				}
+				if cmd.Flags().Changed("designator") {
+					payload["designator"] = designator
+				}
 				err := dispatchTimed(cfg, "schematic.component.place", window, payload, placeTimeout, stdout, stderr)
 				if err != nil && errors.Is(err, context.DeadlineExceeded) {
 					return placeUUIDHint(placeTimeout)
@@ -397,6 +407,7 @@ command fails fast after a short timeout with a hint instead of stalling.`,
 		c.Flags().Float64Var(&y, "y", 0, "Y coordinate")
 		c.Flags().Float64Var(&rotation, "rotation", 0, "rotation in degrees (0/90/180/270)")
 		c.Flags().BoolVar(&mirror, "mirror", false, "mirror the component")
+		c.Flags().StringVar(&designator, "designator", "", "final designator to assign atomically after placement, e.g. R12 (avoids the place→list→modify round-trip; the response's component.designator reflects the assigned value)")
 		sch.AddCommand(c)
 	}
 

--- a/internal/app/cmd_sch_place_test.go
+++ b/internal/app/cmd_sch_place_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -75,5 +76,53 @@ func TestPlaceUUIDHint(t *testing.T) {
 		if !strings.Contains(strings.ToLower(msg), want) {
 			t.Fatalf("hint missing %q: %s", want, msg)
 		}
+	}
+}
+
+// place with --designator forwards the field so the connector can assign the
+// final designator atomically (issue #68), sparing the place→list→modify
+// round-trip.
+func TestSchPlace_WiresDesignator(t *testing.T) {
+	cfg, cap, cleanup := newCapturingDaemon(t)
+	defer cleanup()
+
+	var stdout, stderr bytes.Buffer
+	cmd := newSchCmd(cfg, &stdout, &stderr)
+	cmd.SetArgs([]string{"place", "--lib", "lib1", "--uuid", "dev1", "--x", "100", "--y", "200", "--designator", "R12"})
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v (stderr=%s)", err, stderr.String())
+	}
+
+	cap.mu.Lock()
+	defer cap.mu.Unlock()
+	if cap.action != "schematic.component.place" {
+		t.Fatalf("expected action schematic.component.place, got %q", cap.action)
+	}
+	if cap.payload["designator"] != "R12" {
+		t.Errorf("designator: got %v, want R12", cap.payload["designator"])
+	}
+}
+
+// Without --designator the field is omitted (not sent empty), so old extensions
+// and non-batch flows keep their existing behavior.
+func TestSchPlace_OmitsDesignatorWhenUnset(t *testing.T) {
+	cfg, cap, cleanup := newCapturingDaemon(t)
+	defer cleanup()
+
+	var stdout, stderr bytes.Buffer
+	cmd := newSchCmd(cfg, &stdout, &stderr)
+	cmd.SetArgs([]string{"place", "--lib", "lib1", "--uuid", "dev1", "--x", "100", "--y", "200"})
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v (stderr=%s)", err, stderr.String())
+	}
+
+	cap.mu.Lock()
+	defer cap.mu.Unlock()
+	if _, ok := cap.payload["designator"]; ok {
+		t.Error("designator should be omitted when --designator is unset")
 	}
 }


### PR DESCRIPTION
Fixes #68

## 变更内容
为 `sch place` 新增可选 `--designator` 参数,放置组件后由连接器侧原子设置最终位号,免去 place→`sch list`→`sch modify` 的二次操作与批量场景下按坐标回配 primitiveId(网格吸附/微调后失配、实测产生重复件)。

- **internal/app/cmd_sch.go**:place 子命令新增 `--designator` flag,仅当显式设置时写入 payload;更新 Long/Example 文案。
- **extension/src/actions.ts**:`schematicComponentPlace` 在 create 后读取 designator,非空则调用 `sch_PrimitiveComponent.modify` 并用返回覆盖组件引用,保证响应中的 `primitiveId` 与 `component.designator` 为最终落图状态;modify 失败明确报错(保留已 create 的组件,避免孤儿件)。
- **skills/easyeda-agent/scripts/sch.py**:`place()` 走 debug.exec_js,已在单次 JS 里 create+modify,天然原子,无需改动。

## 测试
- Go:`internal/app/cmd_sch_place_test.go` 新增两例——带 `--designator` 时 payload 含该字段、不带时省略。`go test ./internal/app/` 全绿。
- 扩展:`extension/src/actions.test.ts` 新增两例——带 designator 触发一次 modify 且返回体 designator 为最终值、不带时零 modify 且保留占位符。`npm test`(45 例)与 `npm run typecheck` 全绿。
- 版本兼容:CLI 仅在设置时透传字段,旧扩展忽略未知字段不报错;新扩展生效。未做位号唯一性校验(交由调用方保证,保持单一职责)。