### PR TITLE
fix: settle doc switch/reload race + --page for sch check/read/list

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -16,6 +16,13 @@ follow [SemVer](https://semver.org/).
   自动更新(市场专属能力),故只检测+提示、不静默替换。install.sh 装完 skill 写
   `.version` 标记与 daemon 对齐避免重复下载。**连接器代码未变,升级无需重导 `.eext`。**
 
+### Fixed
+- **切页竞态收口(#67)**:`document.open` / `schematic.page.open` 现在在返回前
+  轮询活动页器件数直到 settle(连续两次相同即视为装载完成,`0 → N` 的装载中态
+  不会被误判为空页),并在 result 中带 `ready:true/false`。修复「`doc switch`
+  返回成功后立即 `sch check` 拿到空 findings、隔 2-4 秒才完整」的问题。PCB 无
+  components 可轮询,乐观返回 `ready:true`。
+
 ## [0.9.0] - 2026-07-08
 
 自 0.8.3 以来的整体收口版本:PCB 布线/DRC 从「能放」走到「能连、能查、能救」,

--- a/extension/src/actions.ts
+++ b/extension/src/actions.ts
@@ -309,7 +309,10 @@ const schematicPageOpen: Handler = async (payload) => {
 	if (tabId === undefined) {
 		throw new ActionError(ErrorCodes.EDA_CALL_FAILED, `Failed to open schematic page "${schematicPageUuid}".`);
 	}
-	return { result: { tabId } };
+	// openDocument returns before the page's primitives finish loading; wait for
+	// the data to settle so a read fired right after isn't empty/stale (#67).
+	const ready = await waitSchematicPageSettle();
+	return { result: { tabId, ready } };
 };
 
 // ─── Schematic / page管理 + 明细表 (title block) ───────────────────────
@@ -446,6 +449,44 @@ async function verifySchematicPageName(pageUuid: string, expected: string): Prom
 		catch {
 			/* best-effort — treat as not-yet-settled and keep polling */
 		}
+	}
+	return false;
+}
+
+/**
+ * Wait for a just-opened schematic page's data to settle. `openDocument`
+ * resolves as soon as the tab exists — BEFORE the page's primitives finish
+ * (re)loading — so a read fired right after would sample a half-loaded page
+ * (empty findings, stale mixed-page data — issue #67). The SDK exposes no
+ * load-complete signal, so we poll the active page's component count and treat
+ * two identical consecutive reads as settled. A non-empty stable count settles
+ * immediately; a stable 0 only settles after the full delay window, so a page
+ * mid-load (0 → N) is not mistaken for a genuinely empty page. Returns true if
+ * it settled, false on timeout — best-effort, read errors keep polling.
+ */
+async function waitSchematicPageSettle(): Promise<boolean> {
+	const delays = [0, 200, 300, 400, 500, 600]; // ~2s worst case
+	let last: number | undefined;
+	let sawStableEmpty = 0;
+	for (const wait of delays) {
+		if (wait > 0) {
+			await new Promise<void>(resolve => setTimeout(resolve, wait));
+		}
+		let count: number | undefined;
+		try {
+			const comps = await eda.sch_PrimitiveComponent.getAll();
+			count = Array.isArray(comps) ? comps.length : undefined;
+		}
+		catch {
+			count = undefined; // treat as not-yet-settled, keep polling
+		}
+		if (count === undefined) continue;
+		if (last !== undefined && last === count) {
+			if (count > 0) return true;
+			sawStableEmpty++;
+			if (sawStableEmpty >= 2) return true; // stable-empty confirmed
+		}
+		last = count;
 	}
 	return false;
 }
@@ -3289,7 +3330,21 @@ const documentOpen: Handler = async (payload) => {
 	if (tabId === undefined) {
 		throw new ActionError(ErrorCodes.EDA_CALL_FAILED, `Failed to open document "${uuid}".`);
 	}
-	return { result: { tabId } };
+	// openDocument returns before the document finishes loading. For schematic
+	// pages, wait for the primitive data to settle so a read fired right after
+	// isn't empty/stale (#67). A PCB has no components.list to poll, so we skip
+	// the wait and report ready:true optimistically.
+	let ready = true;
+	try {
+		const doc = await eda.dmt_SelectControl.getCurrentDocumentInfo();
+		if (doc && documentTypeLabel(doc.documentType) === 'schematic') {
+			ready = await waitSchematicPageSettle();
+		}
+	}
+	catch {
+		/* type probe is best-effort — leave ready:true */
+	}
+	return { result: { tabId, ready } };
 };
 
 // ─── PCB (Phase 2 — read-only skeleton) ──────────────────────────────

--- a/internal/app/cmd_doc.go
+++ b/internal/app/cmd_doc.go
@@ -89,8 +89,17 @@ func newDocCmd(cfg *appConfig, stdout, stderr io.Writer) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			// document.open returns as soon as the tab exists — BEFORE the page's
+			// primitives/netlist finish loading. Wait for the page data to settle
+			// (schematic pages only; a PCB has no components.list) so a read fired
+			// right after the switch doesn't sample a half-loaded page (issue #67).
+			ready := true
+			if match.Type == "schematic" {
+				ready = waitDocSettle(cfg, win)
+			}
 			out := map[string]any{
 				"switchedTo": match,
+				"ready":      ready,
 			}
 			if cur.Context != nil {
 				out["active"] = cur.Context
@@ -99,6 +108,9 @@ func newDocCmd(cfg *appConfig, stdout, stderr io.Writer) *cobra.Command {
 				return writeJSON(stdout, out)
 			}
 			fmt.Fprintf(stdout, "✓ switched to %s %q (%s)\n", match.Type, match.Name, match.UUID)
+			if !ready {
+				fmt.Fprintln(stdout, "⚠ page did not settle within the wait window — data may still be loading; re-read if results look empty")
+			}
 			return nil
 		},
 	}
@@ -124,7 +136,12 @@ thermal-spoke generation). Run "pcb pour-rebuild" after reloading a PCB.
 
 The target document is saved first (schematic.save / pcb.save by type), so no
 edits are lost. Defaults to the active document; pass a name/uuid to reload
-another (it is brought to the front first).`,
+another (it is brought to the front first).
+
+The reopen leaves the reloaded document foreground, so reloading a NON-active
+page would move the active tab. This command restores the pre-reload active
+document afterward and reports it as "activeRestored", so the ★ does not drift
+(issue #67).`,
 		Args: cobra.MaximumNArgs(1),
 		Example: `  easyeda doc reload                      # reload the active document
   easyeda doc reload PCB3 --project ceshi # reload a specific PCB
@@ -188,11 +205,35 @@ another (it is brought to the front first).`,
 				}
 				time.Sleep(500 * time.Millisecond)
 			}
-			out := map[string]any{"reloaded": target, "documentType": docType, "saved": true}
+			// Restore the pre-reload active document. reopen leaves the target
+			// foreground even when the caller reloaded a NON-active page, so
+			// without this the ★ silently drifts and later commands land on the
+			// wrong page (issue #67). Best-effort: a restore failure is reported
+			// but the reload itself already succeeded.
+			restored := activeUUID
+			if activeUUID != "" && activeUUID != target {
+				if _, rerr := requestAction(cfg, "document.open", win,
+					map[string]any{"uuid": activeUUID}); rerr != nil {
+					restored = ""
+				}
+			}
+			out := map[string]any{
+				"reloaded":       target,
+				"documentType":   docType,
+				"saved":          true,
+				"activeRestored": restored,
+			}
 			if jsonOut {
 				return writeJSON(stdout, out)
 			}
 			fmt.Fprintf(stdout, "✓ reloaded %s %s (saved → closed → reopened)\n", docType, target)
+			if activeUUID != "" && activeUUID != target {
+				if restored != "" {
+					fmt.Fprintf(stdout, "  ↩ restored active document to %s\n", restored)
+				} else {
+					fmt.Fprintf(stdout, "  ⚠ could not restore active document %s — active is now %s\n", activeUUID, target)
+				}
+			}
 			return nil
 		},
 	}

--- a/internal/app/cmd_doc_settle.go
+++ b/internal/app/cmd_doc_settle.go
@@ -1,0 +1,130 @@
+package app
+
+import (
+	"time"
+)
+
+// Doc/page state is an implicit global in EasyEDA: `document.open` returns as
+// soon as the tab is created, BEFORE the page's primitives/netlist finish
+// (re)loading. A read command fired immediately after a switch therefore
+// samples a half-loaded page and gets empty/stale data (issue #67). These
+// helpers close that race by (1) confirming the target is the live active
+// document and (2) waiting until its data stops changing.
+
+// settleTracker decides when a sequence of sampled primitive counts has
+// "settled" — the connector exposes no load-complete signal, so we treat a
+// count that is identical across two consecutive polls as loaded. A non-empty
+// stable count settles immediately; a stable count of 0 only settles after a
+// grace window (minEmptySamples), so a page mid-load (0 → 93) is not mistaken
+// for a genuinely empty page.
+type settleTracker struct {
+	last            int
+	hasLast         bool
+	samples         int
+	minEmptySamples int
+}
+
+// observe records one sample and reports whether the page has settled.
+func (s *settleTracker) observe(count int) bool {
+	s.samples++
+	prev, had := s.last, s.hasLast
+	s.last, s.hasLast = count, true
+	if !had || prev != count {
+		return false
+	}
+	if count > 0 {
+		return true
+	}
+	return s.samples >= s.minEmptySamples
+}
+
+// docSettleDeadline bounds how long waitDocSettle polls before giving up and
+// letting the caller proceed with whatever the page currently holds.
+const docSettleDeadline = 8 * time.Second
+
+// docSettleInterval is the gap between primitive-count samples.
+const docSettleInterval = 400 * time.Millisecond
+
+// countActivePagePrimitives reads the active page's component count via
+// schematic.components.list (active page only — no allPages). A read error
+// yields (0,false) so the caller keeps polling rather than aborting.
+func countActivePagePrimitives(cfg *appConfig, window string) (int, bool) {
+	res, err := requestAction(cfg, "schematic.components.list", window, nil)
+	if err != nil || res.Result == nil {
+		return 0, false
+	}
+	if c, ok := res.Result["count"].(float64); ok {
+		return int(c), true
+	}
+	if comps, ok := res.Result["components"].([]any); ok {
+		return len(comps), true
+	}
+	return 0, false
+}
+
+// waitDocSettle polls the active page's primitive count until it stabilizes
+// (two identical consecutive reads) or the deadline passes. It returns true if
+// the page settled, false on timeout — callers proceed either way, using the
+// bool to flag ready:false when the page never quieted down.
+func waitDocSettle(cfg *appConfig, window string) bool {
+	tracker := &settleTracker{minEmptySamples: 3}
+	deadline := time.Now().Add(docSettleDeadline)
+	for {
+		count, ok := countActivePagePrimitives(cfg, window)
+		if ok && tracker.observe(count) {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(docSettleInterval)
+	}
+}
+
+// pageScope captures the state switchToPage changed so a caller can restore the
+// original active document after a page-scoped read.
+type pageScope struct {
+	window     string
+	prevActive string // active document uuid before the switch (may be "")
+	switched   bool   // true if we actually changed the active document
+	settled    bool   // true if the target page settled before the deadline
+}
+
+// switchToPage resolves a --page target (name or uuid) in the given window,
+// brings it to the front if it is not already active, and waits for its data to
+// settle. It returns a pageScope so the caller can optionally restore the prior
+// active document. Making the page an explicit parameter removes the implicit
+// global-state race: check/read/list act on the page the caller named, not
+// whatever tab happened to be foreground.
+func switchToPage(cfg *appConfig, window, target string) (pageScope, error) {
+	docs, activeUUID, win, err := discoverDocs(cfg, window)
+	if err != nil {
+		return pageScope{}, err
+	}
+	match, err := resolveDoc(docs, target)
+	if err != nil {
+		return pageScope{}, err
+	}
+	sc := pageScope{window: win, prevActive: activeUUID}
+	if match.UUID != activeUUID {
+		if _, err := requestAction(cfg, "document.open", win,
+			map[string]any{"uuid": match.UUID}); err != nil {
+			return pageScope{}, err
+		}
+		sc.switched = true
+	}
+	sc.settled = waitDocSettle(cfg, win)
+	return sc, nil
+}
+
+// restore switches back to the document that was active before switchToPage, if
+// switchToPage actually changed it. Best-effort: a restore failure is returned
+// so the caller can surface it, but the primary read has already happened.
+func (sc pageScope) restore(cfg *appConfig) error {
+	if !sc.switched || sc.prevActive == "" {
+		return nil
+	}
+	_, err := requestAction(cfg, "document.open", sc.window,
+		map[string]any{"uuid": sc.prevActive})
+	return err
+}

--- a/internal/app/cmd_doc_settle_test.go
+++ b/internal/app/cmd_doc_settle_test.go
@@ -1,0 +1,48 @@
+package app
+
+import "testing"
+
+// A non-empty count that repeats settles immediately; the whole point of the
+// settle wait is to catch the 0 → N load, not to stall a page that already has
+// its parts.
+func TestSettleTracker_NonEmptyStable(t *testing.T) {
+	s := &settleTracker{minEmptySamples: 3}
+	if s.observe(93) {
+		t.Fatal("first sample must not settle (no prior to compare)")
+	}
+	if !s.observe(93) {
+		t.Fatal("two identical non-empty samples should settle")
+	}
+}
+
+// A page mid-load (0 → 0 → 93 → 93) must NOT settle on the early zeros before
+// the grace window, or `sch check` fired right after a switch gets empty
+// findings.
+func TestSettleTracker_LoadingNotMistakenEmpty(t *testing.T) {
+	s := &settleTracker{minEmptySamples: 3}
+	if s.observe(0) {
+		t.Fatal("first zero must not settle")
+	}
+	if s.observe(0) {
+		t.Fatal("second zero is within the grace window, must not settle")
+	}
+	if s.observe(93) {
+		t.Fatal("count changed 0→93, must not settle yet")
+	}
+	if !s.observe(93) {
+		t.Fatal("two identical non-empty samples after load should settle")
+	}
+}
+
+// A genuinely empty page (stable 0 past the grace window) eventually settles so
+// the wait doesn't burn the full deadline on every empty page.
+func TestSettleTracker_GenuinelyEmptySettles(t *testing.T) {
+	s := &settleTracker{minEmptySamples: 3}
+	got := []bool{s.observe(0), s.observe(0), s.observe(0)}
+	if got[0] || got[1] {
+		t.Fatalf("zeros before grace window must not settle: %v", got)
+	}
+	if !got[2] {
+		t.Fatal("stable zero past minEmptySamples should settle")
+	}
+}

--- a/internal/app/cmd_sch.go
+++ b/internal/app/cmd_sch.go
@@ -301,7 +301,8 @@ func newSchCmd(cfg *appConfig, stdout, stderr io.Writer) *cobra.Command {
 	// ── list ─────────────────────────────────────────────────────────────
 	// schematic.components.list
 	{
-		var allPages, includeBBox, includePins bool
+		var allPages, includeBBox, includePins, stay bool
+		var page string
 		c := &cobra.Command{
 			Use:   "list",
 			Short: "List components on the active (or all) schematic page(s)",
@@ -324,6 +325,19 @@ before feeding it back into ` + "`sch place --uuid`" + `.`,
   easyeda sch list --include-bbox
   easyeda sch list --include-pins`,
 			RunE: func(cmd *cobra.Command, args []string) error {
+				if page != "" && allPages {
+					return fmt.Errorf("--page and --all-pages are mutually exclusive")
+				}
+				if page != "" {
+					scope, err := switchToPage(cfg, window, page)
+					if err != nil {
+						return err
+					}
+					if !stay {
+						defer func() { _ = scope.restore(cfg) }()
+					}
+					window = scope.window
+				}
 				payload := map[string]any{}
 				if allPages {
 					payload["allPages"] = true
@@ -341,6 +355,8 @@ before feeding it back into ` + "`sch place --uuid`" + `.`,
 			},
 		}
 		c.Flags().BoolVar(&allPages, "all-pages", false, "list components across all schematic pages (WARNING: non-active pages return shallow data — pins/bbox may be empty; use `doc switch` to that page for accurate data)")
+		c.Flags().StringVar(&page, "page", "", "switch to this page (name|uuid), wait for it to settle, then list — makes the page an explicit parameter instead of relying on the active tab (issue #67)")
+		c.Flags().BoolVar(&stay, "stay", false, "with --page, stay on the target page after listing instead of switching back")
 		c.Flags().BoolVar(&includeBBox, "include-bbox", false, "attach each component's rendered extent {minX,minY,maxX,maxY}")
 		c.Flags().BoolVar(&includePins, "include-pins", false, "attach each pin's {pinName,pinNumber,x,y,noConnected,net} — the data plane for routing/connectivity checks (net is the pin's current authoritative net, null when the netlist is unavailable; output grows, esp. with --all-pages)")
 		sch.AddCommand(c)
@@ -968,7 +984,8 @@ still surfacing warnings for review.`,
 	// only an aggregate, so the itemized findings the UI panel shows are computed
 	// here from primitives. Output (designator + pin numbers) feeds `sch no-connect`.
 	{
-		var allPages, strict, asJSON bool
+		var allPages, strict, asJSON, stay bool
+		var page string
 		c := &cobra.Command{
 			Use:   "check",
 			Short: "Reconstructed per-item design check the SDK DRC can't itemize",
@@ -996,10 +1013,25 @@ prior versions emitted a bare {passed,summary,findings}).`,
   easyeda sch check --json
   easyeda sch check --strict      # non-zero exit if any findings`,
 			RunE: func(cmd *cobra.Command, args []string) error {
+				if page != "" && allPages {
+					return fmt.Errorf("--page and --all-pages are mutually exclusive")
+				}
+				if page != "" {
+					scope, err := switchToPage(cfg, window, page)
+					if err != nil {
+						return err
+					}
+					if !stay {
+						defer func() { _ = scope.restore(cfg) }()
+					}
+					window = scope.window
+				}
 				return runSchCheck(cfg, window, allPages, strict, asJSON, stdout, stderr)
 			},
 		}
 		c.Flags().BoolVar(&allPages, "all-pages", false, "check components across all schematic pages (WARNING: non-active pages return shallow data — pins/bbox may be empty; use `doc switch` to that page for accurate data)")
+		c.Flags().StringVar(&page, "page", "", "switch to this page (name|uuid), wait for it to settle, then check — makes the page an explicit parameter instead of relying on the active tab (issue #67)")
+		c.Flags().BoolVar(&stay, "stay", false, "with --page, stay on the target page after checking instead of switching back")
 		c.Flags().BoolVar(&strict, "strict", false, "exit non-zero when there are findings (gate mode)")
 		c.Flags().BoolVar(&asJSON, "json", false, "emit the report in the {id,type,version,ok,result} envelope (findings under result.findings)")
 		sch.AddCommand(c)
@@ -1062,7 +1094,8 @@ to a page for authoritative results.`,
 	// schematic.read — one-call semantic snapshot (components + pin nets + nets +
 	// check), so the agent reads the whole circuit at once.
 	{
-		var allPages, noCheck bool
+		var allPages, noCheck, stay bool
+		var page string
 		c := &cobra.Command{
 			Use:   "read",
 			Short: "One-call semantic snapshot of the circuit (components + nets + check)",
@@ -1079,6 +1112,19 @@ check for a faster read.`,
   easyeda sch read --all-pages
   easyeda sch read --no-check`,
 			RunE: func(cmd *cobra.Command, args []string) error {
+				if page != "" && allPages {
+					return fmt.Errorf("--page and --all-pages are mutually exclusive")
+				}
+				if page != "" {
+					scope, err := switchToPage(cfg, window, page)
+					if err != nil {
+						return err
+					}
+					if !stay {
+						defer func() { _ = scope.restore(cfg) }()
+					}
+					window = scope.window
+				}
 				payload := map[string]any{}
 				if allPages {
 					payload["allPages"] = true
@@ -1090,6 +1136,8 @@ check for a faster read.`,
 			},
 		}
 		c.Flags().BoolVar(&allPages, "all-pages", false, "read components across all schematic pages (WARNING: non-active pages return shallow data — pins/bbox may be empty; use `doc switch` to that page for accurate data)")
+		c.Flags().StringVar(&page, "page", "", "switch to this page (name|uuid), wait for it to settle, then read — makes the page an explicit parameter instead of relying on the active tab (issue #67)")
+		c.Flags().BoolVar(&stay, "stay", false, "with --page, stay on the target page after reading instead of switching back")
 		c.Flags().BoolVar(&noCheck, "no-check", false, "skip the geometric design check for a faster read")
 		sch.AddCommand(c)
 	}


### PR DESCRIPTION
Fixes #67

## 背景
页面/文档状态在 EasyEDA 中是隐式全局的,且切换动作不等待数据 settle,导致三类竞态:
1. `doc switch` 返回成功后立即 `sch check` → 空 findings(页面还在装载),隔 2-4 秒才完整。
2. 大量 mutation 后 `sch read` 返回陈旧混页数据。
3. `doc reload` 后活动页漂移到非预期页,后续命令落错页。

## 改动
- **connector 侧 settle**:`document.open` / `schematic.page.open` 在返回前轮询活动页器件数直到 settle(连续两次相同即视为装载完成;`0 → N` 的装载中态不会被误判为空页;PCB 无 components 可轮询,乐观返回 `ready:true`),result 带 `ready:true/false`。
- **CLI `doc switch`**:复用同一 settle 等待(仅 schematic),输出 `ready` 字段,未就绪时打印提示。
- **`sch check` / `sch read` / `sch list` 新增 `--page <name|uuid>`**:内部切页 → 等 settle → 执行,默认执行后切回原页;`--stay` 可保留在目标页。让页面成为显式参数,而非隐式全局状态。`--page` 与 `--all-pages` 互斥。
- **`doc reload` 恢复活动页**:reload 起始记录调用前活动页,reopen 完成后若原活动页 ≠ 目标页则切回,消除 ★ 漂移;输出 `activeRestored`,并在 `Long` 文档注明。

## 测试
- Go:新增 `cmd_doc_settle_test.go`(settleTracker 三种场景:非空稳定即 settle、装载中 0→N 不误判、真空页宽限后 settle);`go test ./...` 全绿,`go vet` 干净。
- Connector:`npm run typecheck` 通过,`npm test` 43/43 通过。

## 未测(需真实硬件/EasyEDA 环境)
settle 轮询与 `--page` 切页的端到端行为依赖运行中的 EasyEDA connector,本地无该环境,未做整机联调验证;逻辑核心(settleTracker 判据)已单测覆盖。