### PR TITLE
fix: detect coincident pins of different components in sch layout-lint

### DIFF
--- a/internal/app/cmd_sch.go
+++ b/internal/app/cmd_sch.go
@@ -1047,7 +1047,7 @@ check for a faster read.`,
 	// too-tight spacing (WARN) so layout overlap is mechanically caught, not
 	// eyeballed. Exits non-zero when overlaps exist → usable as a gate.
 	{
-		var minGap float64
+		var minGap, pinEps float64
 		var asJSON, allPages, includeNonParts bool
 		c := &cobra.Command{
 			Use:   "layout-lint",
@@ -1057,8 +1057,15 @@ check for a faster read.`,
 Pulls every component's rendered extent (schematic.components.list --include-bbox)
 and runs two pairwise checks in Go:
 
-  • overlap  — two component bounding boxes intersect            → ERROR
-  • spacing  — bbox gap is below --min-gap (default 2.54mm)      → WARN
+  • overlap          — two component bounding boxes intersect            → ERROR
+  • pin-coincidence  — two pins of DIFFERENT parts land on the same point → ERROR
+  • spacing          — bbox gap is below --min-gap (default 2.54mm)       → WARN
+
+Pin coincidence is an implicit short: any wire/stub through the shared point ties
+the two nets together, yet the bboxes may never touch (a small 2-pin part tucked
+against a large one), so bbox-only overlap detection misses it. Pins are compared
+across different components only; a symbol's own pins are expected to sit at fixed
+offsets. Use --pin-eps to treat near-coincident pins (within N mm) as errors too.
 
 Only real parts (componentType "part") are checked by default. The drawing
 sheet / title block (图框) spans the whole page, so including it would false-flag
@@ -1074,10 +1081,11 @@ Exits non-zero when any overlap is found, so it can gate a workflow.`,
   easyeda sch layout-lint --min-gap 5.08
   easyeda sch layout-lint --all-pages --json`,
 			RunE: func(cmd *cobra.Command, args []string) error {
-				return runLayoutLint(cfg, window, minGap, allPages, asJSON, includeNonParts, stdout, stderr)
+				return runLayoutLint(cfg, window, minGap, pinEps, allPages, asJSON, includeNonParts, stdout, stderr)
 			},
 		}
 		c.Flags().Float64Var(&minGap, "min-gap", 2.54, "minimum gap between component bboxes in mm (closer = WARN)")
+		c.Flags().Float64Var(&pinEps, "pin-eps", 0, "max distance in mm for two pins of DIFFERENT components to count as coincident (implicit short → ERROR); 0 = strict equality")
 		c.Flags().BoolVar(&asJSON, "json", false, "emit the report as JSON")
 		c.Flags().BoolVar(&allPages, "all-pages", false, "lint components across all schematic pages (WARNING: non-active pages return shallow data — components with no bbox are SKIPPED from overlap checks, not confirmed clear; use `doc switch` to that page for accurate linting)")
 		c.Flags().BoolVar(&includeNonParts, "include-non-parts", false, "also lint non-part primitives (sheet/title-frame, netflag/netport/…); excluded by default")

--- a/internal/app/cmd_sch_autolayout.go
+++ b/internal/app/cmd_sch_autolayout.go
@@ -467,7 +467,7 @@ func planAutolayout(modules []alModuleSpec, parts []alPart, sheet *layoutBBox, r
 	}
 
 	// ── validation summary ──────────────────────────────────────────────────
-	overlapRep := analyzeLayout(placedComps, 0) // minGap 0 → count true overlaps only
+	overlapRep := analyzeLayout(placedComps, 0, -1) // minGap 0 → count true overlaps only
 	rep.Validation.PartOverlaps = len(overlapRep.Overlaps)
 	if rules.AvoidTitleBlock && tb != nil {
 		for _, b := range placed {

--- a/internal/app/cmd_sch_autolayout_run.go
+++ b/internal/app/cmd_sch_autolayout_run.go
@@ -197,7 +197,7 @@ func applyAutolayout(cfg *appConfig, window string, rep *alReport, stderr io.Wri
 		return
 	}
 	kept, _ := filterLayoutComps(comps, false)
-	lrep := analyzeLayout(kept, 0)
+	lrep := analyzeLayout(kept, 0, -1)
 	rep.Validation.PartOverlaps = len(lrep.Overlaps)
 	if len(lrep.Overlaps) > 0 {
 		rep.OK = false

--- a/internal/app/cmd_sch_autoplace_free_run.go
+++ b/internal/app/cmd_sch_autoplace_free_run.go
@@ -117,7 +117,7 @@ func applyFreePlace(cfg *appConfig, window string, rep *freePlaceReport, stderr 
 		return
 	}
 	kept, _ := filterLayoutComps(comps, false)
-	if lrep := analyzeLayout(kept, 0); len(lrep.Overlaps) > 0 {
+	if lrep := analyzeLayout(kept, 0, -1); len(lrep.Overlaps) > 0 {
 		rep.OK = false
 		rep.Note = strings.TrimSpace(rep.Note + fmt.Sprintf(" ⚠ post-apply layout-lint still sees %d overlap(s).", len(lrep.Overlaps)))
 	}

--- a/internal/app/cmd_sch_layout.go
+++ b/internal/app/cmd_sch_layout.go
@@ -25,12 +25,23 @@ type layoutBBox struct {
 	MaxY float64 `json:"maxY"`
 }
 
+// layoutPin is one pin's number + coordinate in schematic mm (y-up). Used by the
+// pin-coincidence check: two pins from DIFFERENT components landing on the same
+// point is an implicit short (any wire/stub through that point ties the two nets)
+// that bbox-only overlap detection cannot see. See issue #63.
+type layoutPin struct {
+	Number string
+	X      float64
+	Y      float64
+}
+
 // layoutComp is the minimal per-component shape layout-lint reasons about.
 type layoutComp struct {
 	ID            string
 	Designator    string
 	ComponentType string // "part" | "sheet" | "netflag" | "netport" | … (from the connector)
 	BBox          *layoutBBox
+	Pins          []layoutPin
 }
 
 // schLayoutPartType is the componentType of a real placed device. Only these
@@ -60,14 +71,20 @@ func filterLayoutComps(comps []layoutComp, includeNonParts bool) (kept []layoutC
 	return kept, skipped
 }
 
-// layoutFinding is one pairwise issue (overlap or tight spacing).
+// layoutFinding is one pairwise issue (overlap, tight spacing, or pin coincidence).
 type layoutFinding struct {
-	Type string  `json:"type"` // "overlap" | "spacing"
+	Type string  `json:"type"` // "overlap" | "spacing" | "pin-coincidence"
 	A    string  `json:"a"`    // designator (or id)
 	B    string  `json:"b"`
 	OvX  float64 `json:"overlapX,omitempty"` // overlap extent (mm), overlap only
 	OvY  float64 `json:"overlapY,omitempty"`
 	Gap  float64 `json:"gap,omitempty"` // edge-to-edge gap (mm), spacing only
+	// pin-coincidence only: the two colliding pins and their shared point.
+	APin string  `json:"aPin,omitempty"`
+	BPin string  `json:"bPin,omitempty"`
+	X    float64 `json:"x,omitempty"`
+	Y    float64 `json:"y,omitempty"`
+	Dist float64 `json:"dist,omitempty"` // pin-to-pin distance (mm), pin-coincidence only
 }
 
 // layoutReport is the full normalized result of a layout-lint run.
@@ -80,14 +97,16 @@ type layoutReport struct {
 	NoBBox          []string        `json:"noBBox,omitempty"`
 	Overlaps        []layoutFinding `json:"overlaps"`
 	TightPairs      []layoutFinding `json:"tightSpacing"`
+	PinCoincidences []layoutFinding `json:"pinCoincidences"`
+	PinEps          float64         `json:"pinEps"`
 	Summary         string          `json:"summary"`
 }
 
 // analyzeLayout is the pure core: given components and a min-gap threshold,
 // return every overlapping and too-close pair. Deterministic ordering so output
 // and tests are stable. Kept free of I/O for unit-testing.
-func analyzeLayout(comps []layoutComp, minGap float64) layoutReport {
-	rep := layoutReport{MinGap: minGap, Total: len(comps)}
+func analyzeLayout(comps []layoutComp, minGap, pinEps float64) layoutReport {
+	rep := layoutReport{MinGap: minGap, PinEps: pinEps, Total: len(comps)}
 
 	withBBox := make([]layoutComp, 0, len(comps))
 	for _, c := range comps {
@@ -119,13 +138,85 @@ func analyzeLayout(comps []layoutComp, minGap float64) layoutReport {
 		}
 	}
 
+	rep.PinCoincidences = detectPinCoincidence(comps, pinEps)
+
 	sortFindings(rep.Overlaps)
 	sortFindings(rep.TightPairs)
+	sortFindings(rep.PinCoincidences)
 
-	rep.OK = len(rep.Overlaps) == 0
-	rep.Summary = fmt.Sprintf("%d components (%d with bbox): %d overlap, %d tight (<%.2fmm)",
-		rep.Total, rep.WithBBox, len(rep.Overlaps), len(rep.TightPairs), minGap)
+	// Both bbox overlaps and pin coincidences are hard errors: a coincident pin
+	// pair is an implicit short even when the bboxes never touch.
+	rep.OK = len(rep.Overlaps) == 0 && len(rep.PinCoincidences) == 0
+	rep.Summary = fmt.Sprintf("%d components (%d with bbox): %d overlap, %d tight (<%.2fmm), %d pin-coincidence",
+		rep.Total, rep.WithBBox, len(rep.Overlaps), len(rep.TightPairs), minGap, len(rep.PinCoincidences))
 	return rep
+}
+
+// detectPinCoincidence finds pins from DIFFERENT components that land on the same
+// point (distance <= eps). It buckets pins by quantized coordinate so only pins in
+// the same/adjacent cell are compared — avoiding a full O(n²) scan over every pin
+// pair on the page. Same-component pins never collide with each other (a symbol's
+// own pins are expected to sit at fixed offsets). See issue #63.
+func detectPinCoincidence(comps []layoutComp, eps float64) []layoutFinding {
+	if eps < 0 {
+		return nil // negative eps disables the check (internal bbox-only callers)
+	}
+	// Cell size: eps>0 buckets by eps so neighbors fall within ±1 cell; eps==0
+	// (strict equality) buckets on an exact grid so identical points collide.
+	cell := eps
+	if cell <= 0 {
+		cell = 1e-6
+	}
+	type keyed struct {
+		comp int
+		pin  layoutPin
+	}
+	buckets := make(map[[2]int64][]keyed)
+	key := func(x, y float64) [2]int64 {
+		return [2]int64{int64(math.Floor(x / cell)), int64(math.Floor(y / cell))}
+	}
+	var out []layoutFinding
+	seen := make(map[[2]int]bool) // dedupe pair by (compA,compB) — one finding per part pair
+	for ci := range comps {
+		for _, p := range comps[ci].Pins {
+			k := key(p.X, p.Y)
+			// Compare against pins already placed in this and neighbouring cells.
+			for dx := int64(-1); dx <= 1; dx++ {
+				for dy := int64(-1); dy <= 1; dy++ {
+					for _, other := range buckets[[2]int64{k[0] + dx, k[1] + dy}] {
+						if other.comp == ci {
+							continue // same component: skip
+						}
+						if math.Hypot(p.X-other.pin.X, p.Y-other.pin.Y) > eps {
+							continue
+						}
+						lo, hi := other.comp, ci
+						if lo > hi {
+							lo, hi = hi, lo
+						}
+						if seen[[2]int{lo, hi}] {
+							continue
+						}
+						seen[[2]int{lo, hi}] = true
+						la, lb := label(comps[other.comp]), label(comps[ci])
+						pa, pb := other.pin, p
+						if lb < la {
+							la, lb = lb, la
+							pa, pb = p, other.pin
+						}
+						out = append(out, layoutFinding{
+							Type: "pin-coincidence", A: la, B: lb,
+							APin: pa.Number, BPin: pb.Number,
+							X: round2(pa.X), Y: round2(pa.Y),
+							Dist: round2(math.Hypot(p.X-other.pin.X, p.Y-other.pin.Y)),
+						})
+					}
+				}
+			}
+			buckets[k] = append(buckets[k], keyed{comp: ci, pin: p})
+		}
+	}
+	return out
 }
 
 // overlapExtent reports the intersection extent of two bboxes and whether they
@@ -173,8 +264,8 @@ func sortFindings(f []layoutFinding) {
 
 // runLayoutLint fetches components with bbox, analyzes, renders, and returns a
 // non-nil error when overlaps exist so the command exits non-zero (gate-able).
-func runLayoutLint(cfg *appConfig, window string, minGap float64, allPages, asJSON, includeNonParts bool, stdout, stderr io.Writer) error {
-	payload := map[string]any{"includeBBox": true}
+func runLayoutLint(cfg *appConfig, window string, minGap, pinEps float64, allPages, asJSON, includeNonParts bool, stdout, stderr io.Writer) error {
+	payload := map[string]any{"includeBBox": true, "includePins": true}
 	if allPages {
 		payload["allPages"] = true
 	}
@@ -188,7 +279,7 @@ func runLayoutLint(cfg *appConfig, window string, minGap float64, allPages, asJS
 		return perr
 	}
 	parts, skipped := filterLayoutComps(comps, includeNonParts)
-	rep := analyzeLayout(parts, minGap)
+	rep := analyzeLayout(parts, minGap, pinEps)
 	rep.SkippedNonParts = skipped
 
 	if asJSON {
@@ -202,7 +293,8 @@ func runLayoutLint(cfg *appConfig, window string, minGap float64, allPages, asJS
 	}
 
 	if !rep.OK {
-		return fmt.Errorf("layout-lint: %d overlap(s) found", len(rep.Overlaps))
+		return fmt.Errorf("layout-lint: %d overlap(s), %d pin-coincidence(s) found",
+			len(rep.Overlaps), len(rep.PinCoincidences))
 	}
 	return nil
 }
@@ -231,6 +323,19 @@ func parseLayoutComps(result map[string]any) ([]layoutComp, error) {
 				MinY: asFloat(bm["minY"]),
 				MaxX: asFloat(bm["maxX"]),
 				MaxY: asFloat(bm["maxY"]),
+			}
+		}
+		if pins, ok := m["pins"].([]any); ok {
+			for _, pp := range pins {
+				pm, ok := pp.(map[string]any)
+				if !ok {
+					continue
+				}
+				c.Pins = append(c.Pins, layoutPin{
+					Number: asString(pm["pinNumber"]),
+					X:      asFloat(pm["x"]),
+					Y:      asFloat(pm["y"]),
+				})
 			}
 		}
 		out = append(out, c)
@@ -262,6 +367,10 @@ func renderLayoutReport(rep layoutReport, w io.Writer) {
 	for _, f := range rep.Overlaps {
 		fmt.Fprintf(w, "  ERROR  overlap  %s ↔ %s   (overlap %.2f × %.2f mm)\n", f.A, f.B, f.OvX, f.OvY)
 	}
+	for _, f := range rep.PinCoincidences {
+		fmt.Fprintf(w, "  ERROR  pin-coincidence  %s:%s ↔ %s:%s   (both at %.2f,%.2f — implicit short)\n",
+			f.A, f.APin, f.B, f.BPin, f.X, f.Y)
+	}
 	for _, f := range rep.TightPairs {
 		fmt.Fprintf(w, "  WARN   spacing  %s ↔ %s   (gap %.2fmm < %.2fmm)\n", f.A, f.B, f.Gap, rep.MinGap)
 	}
@@ -276,8 +385,9 @@ func renderLayoutReport(rep layoutReport, w io.Writer) {
 		skipCaveat = fmt.Sprintf("; %d component(s) NOT checked (skipped ≠ confirmed clear)", len(rep.NoBBox))
 	}
 	if rep.OK {
-		fmt.Fprintf(w, "✓ no overlaps among checked components; %d tight pair(s)%s\n", len(rep.TightPairs), skipCaveat)
+		fmt.Fprintf(w, "✓ no overlaps or pin coincidences among checked components; %d tight pair(s)%s\n", len(rep.TightPairs), skipCaveat)
 	} else {
-		fmt.Fprintf(w, "✗ %d overlap(s), %d tight pair(s)%s\n", len(rep.Overlaps), len(rep.TightPairs), skipCaveat)
+		fmt.Fprintf(w, "✗ %d overlap(s), %d pin-coincidence(s), %d tight pair(s)%s\n",
+			len(rep.Overlaps), len(rep.PinCoincidences), len(rep.TightPairs), skipCaveat)
 	}
 }

--- a/internal/app/cmd_sch_layout_test.go
+++ b/internal/app/cmd_sch_layout_test.go
@@ -11,7 +11,7 @@ func TestAnalyzeLayout_Overlap(t *testing.T) {
 		{Designator: "R1", BBox: bb(0, 0, 10, 10)},
 		{Designator: "C2", BBox: bb(5, 5, 15, 15)}, // overlaps R1 by 5×5
 	}
-	rep := analyzeLayout(comps, 2.54)
+	rep := analyzeLayout(comps, 2.54, -1)
 	if rep.OK {
 		t.Fatal("expected OK=false when components overlap")
 	}
@@ -32,7 +32,7 @@ func TestAnalyzeLayout_TightSpacing(t *testing.T) {
 		{Designator: "U1", BBox: bb(0, 0, 10, 10)},
 		{Designator: "C5", BBox: bb(11, 0, 21, 10)}, // 1mm gap horizontally
 	}
-	rep := analyzeLayout(comps, 2.54)
+	rep := analyzeLayout(comps, 2.54, -1)
 	if !rep.OK {
 		t.Fatal("tight spacing alone should not fail OK (only overlaps do)")
 	}
@@ -49,7 +49,7 @@ func TestAnalyzeLayout_Clear(t *testing.T) {
 		{Designator: "U1", BBox: bb(0, 0, 10, 10)},
 		{Designator: "C5", BBox: bb(20, 0, 30, 10)}, // 10mm gap, well clear
 	}
-	rep := analyzeLayout(comps, 2.54)
+	rep := analyzeLayout(comps, 2.54, -1)
 	if !rep.OK || len(rep.Overlaps) != 0 || len(rep.TightPairs) != 0 {
 		t.Fatalf("expected clean report, got %+v", rep)
 	}
@@ -60,7 +60,7 @@ func TestAnalyzeLayout_TouchingEdgesNotOverlap(t *testing.T) {
 		{Designator: "A", BBox: bb(0, 0, 10, 10)},
 		{Designator: "B", BBox: bb(10, 0, 20, 10)}, // shares an edge, gap 0
 	}
-	rep := analyzeLayout(comps, 2.54)
+	rep := analyzeLayout(comps, 2.54, -1)
 	if len(rep.Overlaps) != 0 {
 		t.Fatalf("touching edges must not count as overlap, got %d", len(rep.Overlaps))
 	}
@@ -74,7 +74,7 @@ func TestAnalyzeLayout_UnassignedDesignatorFallsBackToID(t *testing.T) {
 		{ID: "aaa111", Designator: "C?", BBox: bb(0, 0, 10, 10)},
 		{ID: "bbb222", Designator: "C?", BBox: bb(5, 5, 15, 15)}, // overlap
 	}
-	rep := analyzeLayout(comps, 2.54)
+	rep := analyzeLayout(comps, 2.54, -1)
 	if len(rep.Overlaps) != 1 {
 		t.Fatalf("expected 1 overlap, got %d", len(rep.Overlaps))
 	}
@@ -142,7 +142,7 @@ func TestFilterLayoutComps_SheetNoLongerFalseOverlaps(t *testing.T) {
 		{Designator: "C2", ComponentType: "part", BBox: bb(20, 0, 30, 10)},
 	}
 	parts, skipped := filterLayoutComps(comps, false)
-	rep := analyzeLayout(parts, 2.54)
+	rep := analyzeLayout(parts, 2.54, -1)
 	rep.SkippedNonParts = skipped
 	if !rep.OK {
 		t.Fatalf("expected clean report after excluding sheet, got %+v", rep.Overlaps)
@@ -157,11 +157,111 @@ func TestAnalyzeLayout_NoBBoxSkipped(t *testing.T) {
 		{Designator: "R1", BBox: bb(0, 0, 10, 10)},
 		{Designator: "R2"}, // no bbox → skipped, recorded
 	}
-	rep := analyzeLayout(comps, 2.54)
+	rep := analyzeLayout(comps, 2.54, -1)
 	if rep.WithBBox != 1 {
 		t.Errorf("expected WithBBox=1, got %d", rep.WithBBox)
 	}
 	if len(rep.NoBBox) != 1 || rep.NoBBox[0] != "R2" {
 		t.Errorf("expected R2 recorded as no-bbox, got %v", rep.NoBBox)
+	}
+}
+
+func pin(num string, x, y float64) layoutPin { return layoutPin{Number: num, X: x, Y: y} }
+
+func TestAnalyzeLayout_PinCoincidenceError(t *testing.T) {
+	// Issue #63: a 1210 cap and a 0402 resistor whose pins land on the same
+	// point — bboxes never touch, but the shared pin is an implicit short.
+	comps := []layoutComp{
+		{Designator: "C1", BBox: bb(255, 200, 265, 210), Pins: []layoutPin{pin("1", 255, 205), pin("2", 260, 205)}},
+		{Designator: "R_Q3G", BBox: bb(260, 205, 270, 215), Pins: []layoutPin{pin("1", 260, 205), pin("2", 265, 205)}},
+	}
+	rep := analyzeLayout(comps, 2.54, 0)
+	if rep.OK {
+		t.Fatal("expected OK=false when pins of different parts coincide")
+	}
+	if len(rep.PinCoincidences) != 1 {
+		t.Fatalf("expected 1 pin-coincidence, got %d: %+v", len(rep.PinCoincidences), rep.PinCoincidences)
+	}
+	f := rep.PinCoincidences[0]
+	if f.Type != "pin-coincidence" {
+		t.Errorf("expected type pin-coincidence, got %q", f.Type)
+	}
+	if f.A != "C1" || f.B != "R_Q3G" {
+		t.Errorf("expected pair C1↔R_Q3G, got %s↔%s", f.A, f.B)
+	}
+	if f.APin != "2" || f.BPin != "1" {
+		t.Errorf("expected pins C1:2 ↔ R_Q3G:1, got %s ↔ %s", f.APin, f.BPin)
+	}
+	if f.X != 260 || f.Y != 205 {
+		t.Errorf("expected shared point (260,205), got (%.2f,%.2f)", f.X, f.Y)
+	}
+}
+
+func TestAnalyzeLayout_SamePartPinsNoFalsePositive(t *testing.T) {
+	// A single symbol's own pins sit at fixed offsets; they must never collide
+	// with each other even if numerically close.
+	comps := []layoutComp{
+		{Designator: "U1", BBox: bb(0, 0, 20, 20), Pins: []layoutPin{pin("1", 5, 5), pin("2", 5, 5)}},
+	}
+	rep := analyzeLayout(comps, 2.54, 0)
+	if len(rep.PinCoincidences) != 0 {
+		t.Fatalf("same-component pins must not flag, got %+v", rep.PinCoincidences)
+	}
+	if !rep.OK {
+		t.Fatal("single component must report OK")
+	}
+}
+
+func TestAnalyzeLayout_PinEpsBoundary(t *testing.T) {
+	// Two pins 0.5mm apart: clear under strict eps=0, flagged under eps=0.5.
+	comps := []layoutComp{
+		{Designator: "R1", BBox: bb(0, 0, 10, 10), Pins: []layoutPin{pin("1", 5, 5)}},
+		{Designator: "R2", BBox: bb(20, 0, 30, 10), Pins: []layoutPin{pin("1", 5.5, 5)}},
+	}
+	if rep := analyzeLayout(comps, 2.54, 0); len(rep.PinCoincidences) != 0 {
+		t.Fatalf("eps=0 must not flag pins 0.5mm apart, got %+v", rep.PinCoincidences)
+	}
+	rep := analyzeLayout(comps, 2.54, 0.5)
+	if len(rep.PinCoincidences) != 1 {
+		t.Fatalf("eps=0.5 must flag pins exactly 0.5mm apart, got %d", len(rep.PinCoincidences))
+	}
+}
+
+func TestAnalyzeLayout_PinCheckDisabled(t *testing.T) {
+	// Negative eps disables the pin check (internal bbox-only callers).
+	comps := []layoutComp{
+		{Designator: "C1", BBox: bb(0, 0, 10, 10), Pins: []layoutPin{pin("1", 5, 5)}},
+		{Designator: "R1", BBox: bb(20, 0, 30, 10), Pins: []layoutPin{pin("1", 5, 5)}},
+	}
+	rep := analyzeLayout(comps, 2.54, -1)
+	if len(rep.PinCoincidences) != 0 || !rep.OK {
+		t.Fatalf("negative eps must disable pin check, got %+v OK=%v", rep.PinCoincidences, rep.OK)
+	}
+}
+
+func TestParseLayoutComps_ExtractsPins(t *testing.T) {
+	result := map[string]any{
+		"components": []any{
+			map[string]any{
+				"primitiveId": "aaa",
+				"designator":  "C1",
+				"componentType": "part",
+				"bbox": map[string]any{"minX": 255.0, "minY": 200.0, "maxX": 265.0, "maxY": 210.0},
+				"pins": []any{
+					map[string]any{"pinNumber": "1", "x": 255.0, "y": 205.0},
+					map[string]any{"pinNumber": "2", "x": 260.0, "y": 205.0},
+				},
+			},
+		},
+	}
+	comps, err := parseLayoutComps(result)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if len(comps) != 1 || len(comps[0].Pins) != 2 {
+		t.Fatalf("expected 1 comp with 2 pins, got %+v", comps)
+	}
+	if comps[0].Pins[1].Number != "2" || comps[0].Pins[1].X != 260 || comps[0].Pins[1].Y != 205 {
+		t.Errorf("unexpected pin[1]: %+v", comps[0].Pins[1])
 	}
 }


### PR DESCRIPTION
Fixes #63

## 问题
`sch layout-lint` 只检器件 bbox 重叠，不检引脚坐标重合。两个不相干器件的引脚落在同一坐标（如 box-v2 P1 页 C1:2 与 R_Q3G:1 均在 (260,205)）会构成隐性短路，但 lint 报 0 overlap，autolayout 碰撞域也不含引脚点。

## 改动（cmd_sch_layout.go 单文件为主）
- 数据链路：`runLayoutLint` 的 payload 增加 `includePins: true`；`layoutComp` 增加 `Pins []layoutPin{Number,X,Y}`，`parseLayoutComps` 解析连接器已输出的 `pins[].pinNumber/x/y`（连接器 serializePin 已具备，无需改 TS）。
- 新规则 `detectPinCoincidence`：对**不同器件**的引脚两两比较，距离 <= eps → `type: "pin-coincidence"` 的 ERROR，纳入 `rep.OK` 与非零退出。用坐标桶（按量化坐标分桶 + 邻域比较）避免全量 O(n²) pin 对；同器件内引脚不参与比较。
- 新增 `--pin-eps` flag（默认 0 = 严格相等；>0 = near-coincident 容差）。
- `renderLayoutReport` 输出脚号 + 共享坐标。
- autolayout / autoplace-free 的内部 self-check 调用传 `-1` 显式关闭 pin 检查（保持 bbox-only 行为不变）。

## 测试
- `go build ./...`、`go vet`、`go test ./internal/app/` 全绿。
- 新增用例：两器件同点 pin → ERROR；同器件双脚不误报；`--pin-eps` 边界（0.5mm 在 eps=0 放行、eps=0.5 命中）；负 eps 关闭；parseLayoutComps 解析 pins。

## 未覆盖
- autolayout 治本项（把 pin 点纳入碰撞域/保证 2-pin 件 pin-field 间距）按 issue 建议拆为独立 issue，本 PR 不耦合。
- `--all-pages` 非激活页 pin 数据残缺沿用 #54 的 no-bbox 披露口径（skipped ≠ confirmed clear），未新增额外披露。
- 未做连接 EasyEDA 的运行时联调（无 EDA 环境），仅单元测试验证纯逻辑与解析。