### PR TITLE
fix: autoconnect hard-rejects stubs touching foreign wires/pins

### DIFF
--- a/extension/src/actions.ts
+++ b/extension/src/actions.ts
@@ -511,6 +511,11 @@ const schematicComponentsList: Handler = async (payload) => {
 	// (via eda.sch_Primitive.getPrimitivesBBox) so the agent / `sch layout-lint`
 	// can reason about size, spacing, and overlap — mirrors pcb.components.list.
 	const includeBBox = optionalBoolean(payload, 'includeBBox') === true;
+	// includeWires attaches existing wire segments {x0,y0,x1,y1,net} so `sch
+	// autoconnect` can hard-reject any candidate stub that would touch a foreign-net
+	// wire — EasyEDA merges nets at an endpoint-on-wire junction, a silent short the
+	// post-hoc DRC can't catch. See issue #64.
+	const includeWires = optionalBoolean(payload, 'includeWires') === true;
 	// tagPages attributes each component to its owning page (pageUuid/pageName).
 	// Opt-in because it briefly cycles the active page; autoconnect requests it so
 	// its off-page error can point at the exact `doc switch` target.
@@ -573,7 +578,21 @@ const schematicComponentsList: Handler = async (payload) => {
 		serialized.push(record);
 	}
 
-	return { result: { components: serialized, count: serialized.length } };
+	// Existing wire geometry for the autoconnect scorer (issue #64). Flatten every
+	// wire's polyline into per-edge segments tagged with the wire's net, so the Go
+	// side can hard-reject a stub that would touch a foreign-net wire.
+	const wires: Array<{ x0: number; y0: number; x1: number; y1: number; net: string }> = [];
+	if (includeWires) {
+		let rawWires: Array<{ getState_Line: () => Array<number>; getState_Net?: () => string; getState_PrimitiveId?: () => string }> = [];
+		try { rawWires = (await eda.sch_PrimitiveWire.getAll() ?? []) as typeof rawWires; }
+		catch { rawWires = []; }
+		const segs = collectWireSegments(rawWires);
+		for (const s of segs) {
+			wires.push({ x0: s.seg[0], y0: s.seg[1], x1: s.seg[2], y1: s.seg[3], net: s.net });
+		}
+	}
+
+	return { result: { components: serialized, count: serialized.length, wires } };
 };
 
 const schematicComponentPlace: Handler = async (payload) => {

--- a/internal/app/cmd_sch_autoconnect.go
+++ b/internal/app/cmd_sch_autoconnect.go
@@ -80,12 +80,22 @@ type acComponent struct {
 	PageName   string
 }
 
+// wireSegment is one existing schematic wire segment (a single polyline edge),
+// tagged with its net when known. autoconnect uses these to HARD-REJECT any
+// candidate stub that would touch a foreign-net wire — EasyEDA merges nets at an
+// endpoint-on-wire junction, a silent short the post-hoc DRC can't catch. See #64.
+type wireSegment struct {
+	X0, Y0, X1, Y1 float64
+	Net            string // "" when the wire carries no resolvable net name
+}
+
 // acScene is the full geometric context one autoconnect run reasons against.
 // Flags grows as connections are placed so later labels stagger off earlier ones.
 type acScene struct {
 	Parts                 []layoutBBox  // real part bboxes (componentType "part")
 	Pins                  []acPin       // every pin across all parts
 	Flags                 []layoutBBox  // existing netflag/netport/netlabel bboxes
+	Wires                 []wireSegment // existing wire segments (issue #64)
 	Components            []acComponent // every part seen (by designator), even pin-less off-page ones
 	TitleBlock            *layoutBBox   // derived keep-out (nil if not applied)
 	TitleBlockProvisional bool          // true when no sheet bbox was found (keep-out NOT geometrically applied)
@@ -116,18 +126,31 @@ type acCandidate struct {
 // Cost-table constants (issue #24). Kept as named constants so the scorer reads
 // like the table and the unit tests can assert exact figures.
 const (
-	costPartOverlap   = 10000 // endpoint/label bbox overlaps a real part bbox
-	costTitleBlock    = 10000 // endpoint/label bbox enters the title-block keep-out
-	costPinCross      = 5000  // stub crosses a non-target pin
-	costFlagCollision = 1000  // endpoint/label collides with an existing flag/port/label
-	costThroughPart   = 500   // stub passes through another component bbox
-	costFanoutChannel = 100   // too close to a preserved pin-fanout channel
-	costOffsetPerUnit = 0.1   // +offset * 0.1 — prefer shorter stubs
-	bonusOutwardSide  = -20   // direction matches the pin's outward side
-	bonusKindDefault  = -10   // direction matches the kind default (GND down / power up / port outward)
-	acLabelHalfExtent = 4.0   // nominal half-size of a placed flag/label marker box (schematic units)
-	acCoordEps        = 0.01  // coordinate-equality tolerance
-	acOverlapEps      = 1e-6  // positive-length threshold for interval/area overlap
+	// costHardReject is a sentinel far above any reachable sum of penalties +
+	// offset cost, so a candidate carrying it is effectively UNUSABLE — the planner
+	// only falls back to it when EVERY option is a hard reject. Used for hazards
+	// EasyEDA would silently turn into a wrong connection (endpoint/path on a
+	// foreign-net wire, stub crossing a non-target pin). See issue #64.
+	costHardReject  = 1e9
+	costPartOverlap = 10000 // endpoint/label bbox overlaps a real part bbox
+	costTitleBlock  = 10000 // endpoint/label bbox enters the title-block keep-out
+	// costPinCross is a HARD reject (issue #64 rec 2): a stub crossing a non-target
+	// pin gets trimmed+connected by EasyEDA, and the post-hoc wire-over-pin rule
+	// exempts endpoints on pins, so the short goes unnoticed. Never a soft penalty.
+	costPinCross = costHardReject
+	// costWireTouch is a HARD reject (issue #64 rec 1): a candidate stub whose
+	// endpoint or path touches an existing foreign-net wire merges the two nets at
+	// the junction. Never a soft penalty.
+	costWireTouch     = costHardReject
+	costFlagCollision = 1000 // endpoint/label collides with an existing flag/port/label
+	costThroughPart   = 500  // stub passes through another component bbox
+	costFanoutChannel = 100  // too close to a preserved pin-fanout channel
+	costOffsetPerUnit = 0.1  // +offset * 0.1 — prefer shorter stubs
+	bonusOutwardSide  = -20  // direction matches the pin's outward side
+	bonusKindDefault  = -10  // direction matches the kind default (GND down / power up / port outward)
+	acLabelHalfExtent = 4.0  // nominal half-size of a placed flag/label marker box (schematic units)
+	acCoordEps        = 0.01 // coordinate-equality tolerance
+	acOverlapEps      = 1e-6 // positive-length threshold for interval/area overlap
 )
 
 // endpointFor computes where connect_pin will land the stub end for a given
@@ -252,11 +275,81 @@ func boxesOverlap(a, b layoutBBox) bool {
 	return ox > acOverlapEps && oy > acOverlapEps
 }
 
+// orient2D is the signed area (cross product) of (b-a)×(c-a): >0 left turn,
+// <0 right turn, ~0 collinear. Used by the general segment-touch test so a stub
+// can be checked against an arbitrarily-oriented existing wire.
+func orient2D(ax, ay, bx, by, cx, cy float64) float64 {
+	return (bx-ax)*(cy-ay) - (by-ay)*(cx-ax)
+}
+
+// pointOnSeg reports whether (px,py) lies on segment (x0,y0)-(x1,y1), endpoints
+// INCLUDED. Any contact counts, because EasyEDA merges nets wherever a stub end
+// or path meets a wire (junction), not just at a proper interior crossing.
+func pointOnSeg(px, py, x0, y0, x1, y1 float64) bool {
+	if math.Abs(orient2D(x0, y0, x1, y1, px, py)) > acCoordEps*math.Max(1, math.Hypot(x1-x0, y1-y0)) {
+		return false
+	}
+	return px >= math.Min(x0, x1)-acCoordEps && px <= math.Max(x0, x1)+acCoordEps &&
+		py >= math.Min(y0, y1)-acCoordEps && py <= math.Max(y0, y1)+acCoordEps
+}
+
+// segmentsTouch reports whether segments A(a0→a1) and B(b0→b1) share ANY point —
+// a proper crossing, a shared/touching endpoint, or a collinear overlap. This is
+// deliberately inclusive: for wire-merge hazard detection any contact is a short.
+func segmentsTouch(ax0, ay0, ax1, ay1, bx0, by0, bx1, by1 float64) bool {
+	d1 := orient2D(bx0, by0, bx1, by1, ax0, ay0)
+	d2 := orient2D(bx0, by0, bx1, by1, ax1, ay1)
+	d3 := orient2D(ax0, ay0, ax1, ay1, bx0, by0)
+	d4 := orient2D(ax0, ay0, ax1, ay1, bx1, by1)
+	if ((d1 > 0 && d2 < 0) || (d1 < 0 && d2 > 0)) &&
+		((d3 > 0 && d4 < 0) || (d3 < 0 && d4 > 0)) {
+		return true // proper crossing
+	}
+	// Collinear / endpoint-touch cases: any endpoint lying on the other segment.
+	return pointOnSeg(ax0, ay0, bx0, by0, bx1, by1) ||
+		pointOnSeg(ax1, ay1, bx0, by0, bx1, by1) ||
+		pointOnSeg(bx0, by0, ax0, ay0, ax1, ay1) ||
+		pointOnSeg(bx1, by1, ax0, ay0, ax1, ay1)
+}
+
+// stubTouchesForeignWire reports whether a candidate stub (target pin → endpoint)
+// touches any existing wire that would merge into a FOREIGN net. A wire already
+// on the SAME target net is skipped — connecting to it is the whole point. Wires
+// with no resolvable net ("") are treated as foreign (unknown → conservative hard
+// reject), since a silent cross-net merge is the worse outcome. Degenerate
+// zero-length wires are ignored. See issue #64.
+func stubTouchesForeignWire(pinX, pinY, endX, endY float64, targetNet string, wires []wireSegment) bool {
+	// Trim the stub start a hair away from the pin. A foreign wire that touches
+	// ONLY at the pin coordinate is a PRE-EXISTING condition (the pin already sits
+	// on that net) — the idempotency net check classifies that as a conflict, so it
+	// must not hard-reject every direction here. We only care about contact along
+	// the rest of the stub, including its far endpoint.
+	dx, dy := endX-pinX, endY-pinY
+	length := math.Hypot(dx, dy)
+	if length < acCoordEps {
+		return false // degenerate stub
+	}
+	trimX := pinX + dx/length*(acCoordEps*4)
+	trimY := pinY + dy/length*(acCoordEps*4)
+	for _, w := range wires {
+		if w.Net != "" && w.Net == targetNet {
+			continue // same net — legitimate connection target, not a hazard
+		}
+		if math.Abs(w.X1-w.X0) < acCoordEps && math.Abs(w.Y1-w.Y0) < acCoordEps {
+			continue // degenerate zero-length wire
+		}
+		if segmentsTouch(trimX, trimY, endX, endY, w.X0, w.Y0, w.X1, w.Y1) {
+			return true
+		}
+	}
+	return false
+}
+
 // scoreCandidate is the PURE deterministic core: given a pin, a direction, an
 // offset, the canonical kind, the scene, and the rules, return the scored
 // candidate with its signed cost breakdown. No I/O, no mutation — the whole
 // reason this is unit-testable.
-func scoreCandidate(pin acPin, dir string, offset float64, canonicalKind string, scene acScene, rules autoconnectRules) acCandidate {
+func scoreCandidate(pin acPin, dir string, offset float64, canonicalKind, targetNet string, scene acScene, rules autoconnectRules) acCandidate {
 	endX, endY := endpointFor(pin.X, pin.Y, offset, dir)
 	lbl := labelBox(endX, endY)
 	var reasons []acReason
@@ -274,15 +367,23 @@ func scoreCandidate(pin acPin, dir string, offset float64, canonicalKind string,
 		reasons = append(reasons, acReason{costTitleBlock, "label enters title-block keep-out"})
 	}
 
-	// +5000 stub crosses a non-target pin.
+	// HARD REJECT: stub crosses a non-target pin (issue #64). EasyEDA trims and
+	// connects the stub at that pin, and the wire-over-pin DRC exempts endpoints on
+	// pins, so the short is invisible after the fact. Never a soft penalty.
 	for _, op := range scene.Pins {
 		if math.Abs(op.X-pin.X) < acCoordEps && math.Abs(op.Y-pin.Y) < acCoordEps {
 			continue // the target pin itself
 		}
 		if pinOnSegment(pin.X, pin.Y, endX, endY, op.X, op.Y) {
-			reasons = append(reasons, acReason{costPinCross, "stub crosses a non-target pin"})
+			reasons = append(reasons, acReason{costPinCross, "stub crosses a non-target pin (hard reject)"})
 			break
 		}
+	}
+
+	// HARD REJECT: stub endpoint or path touches an existing foreign-net wire
+	// (issue #64). EasyEDA merges the two nets at the junction — a silent short.
+	if stubTouchesForeignWire(pin.X, pin.Y, endX, endY, targetNet, scene.Wires) {
+		reasons = append(reasons, acReason{costWireTouch, "stub touches an existing (foreign-net) wire (hard reject)"})
 	}
 
 	// +1000 endpoint/label collides with an existing flag/port/label.
@@ -369,12 +470,12 @@ var acDirections = []string{"up", "down", "left", "right"}
 // and returns them sorted best-first. Deterministic tie-break: score asc, then
 // direction lexical (down<left<right<up), then offset asc — so the same scene +
 // spec always yields the same selection (acceptance: "deterministic result").
-func planConnection(pin acPin, canonicalKind string, scene acScene, rules autoconnectRules) []acCandidate {
+func planConnection(pin acPin, canonicalKind, targetNet string, scene acScene, rules autoconnectRules) []acCandidate {
 	offsets := candidateOffsets(rules)
 	all := make([]acCandidate, 0, len(acDirections)*len(offsets))
 	for _, dir := range acDirections {
 		for _, off := range offsets {
-			all = append(all, scoreCandidate(pin, dir, off, canonicalKind, scene, rules))
+			all = append(all, scoreCandidate(pin, dir, off, canonicalKind, targetNet, scene, rules))
 		}
 	}
 	sort.SliceStable(all, func(i, j int) bool {
@@ -387,6 +488,19 @@ func planConnection(pin acPin, canonicalKind string, scene acScene, rules autoco
 		return all[i].Offset < all[j].Offset
 	})
 	return all
+}
+
+// candidateHardRejected reports whether a candidate carries a hard-reject cost
+// (pin-cross or foreign-wire touch, issue #64). When the BEST candidate is still
+// hard-rejected, every direction/offset was a hazard — the caller must refuse to
+// mutate rather than place a stub it knows would short two nets.
+func candidateHardRejected(c acCandidate) bool {
+	for _, r := range c.Reasons {
+		if r.Cost >= costHardReject {
+			return true
+		}
+	}
+	return false
 }
 
 // ── idempotency: three-state pin/net decision (issue #50) ───────────────────

--- a/internal/app/cmd_sch_autoconnect_run.go
+++ b/internal/app/cmd_sch_autoconnect_run.go
@@ -178,8 +178,35 @@ func buildScene(result map[string]any) acScene {
 			}
 		}
 	}
+	scene.Wires = buildWireSegments(result)
 	scene.TitleBlock, scene.TitleBlockProvisional = titleBlockKeepout(sheet)
 	return scene
+}
+
+// buildWireSegments parses the extension's `wires` payload (issue #64) into the
+// scene's wire segments. The extension emits one entry per polyline edge:
+// {x0,y0,x1,y1, net}. Missing/malformed entries are skipped so a partial payload
+// degrades gracefully rather than panicking the scorer.
+func buildWireSegments(result map[string]any) []wireSegment {
+	raw, _ := result["wires"].([]any)
+	if len(raw) == 0 {
+		return nil
+	}
+	segs := make([]wireSegment, 0, len(raw))
+	for _, item := range raw {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		segs = append(segs, wireSegment{
+			X0:  asFloat(m["x0"]),
+			Y0:  asFloat(m["y0"]),
+			X1:  asFloat(m["x1"]),
+			Y1:  asFloat(m["y1"]),
+			Net: asString(m["net"]),
+		})
+	}
+	return segs
 }
 
 // titleBlockKeepout derives the title-block keep-out for the autoconnect scorer.
@@ -256,7 +283,10 @@ func runAutoconnect(cfg *appConfig, window string, conns []acConnSpec, rules aut
 	res, err := requestAction(cfg, "schematic.components.list", window, map[string]any{
 		"includeBBox": true,
 		"includePins": true,
-		"allPages":    allPages,
+		// includeWires attaches existing wire segments (issue #64) so the scorer can
+		// hard-reject any stub that would touch a foreign-net wire (silent merge).
+		"includeWires": true,
+		"allPages":     allPages,
 		// With --all-pages, parts on non-active pages come through pin-less; tagPages
 		// attributes each to its owning page so an off-page pin ref yields a precise
 		// `doc switch` hint instead of a misleading "not placed".
@@ -343,10 +373,21 @@ func runAutoconnect(cfg *appConfig, window string, conns []acConnSpec, rules aut
 			}
 		}
 
-		all := planConnection(pin, canonicalKind, scene, rules)
+		all := planConnection(pin, canonicalKind, c.Net, scene, rules)
 		selected := all[0]
 		cr.Selected = &selected
 		cr.Rejected = summarizeRejected(all, selected)
+
+		// Hard-reject guard (issue #64): if even the best candidate would cross a
+		// non-target pin or touch a foreign-net wire, EVERY direction/offset is a
+		// silent-short hazard. Refuse to place a stub — report it as a failure so a
+		// human resolves the layout instead of the tool creating a wrong connection.
+		if candidateHardRejected(selected) {
+			cr.Error = fmt.Sprintf("no safe candidate: every direction/offset would short (%s) — resolve the layout (move the part, clear the wire) and retry", dominantReason(selected))
+			report.OK = false
+			report.Connections = append(report.Connections, cr)
+			continue
+		}
 
 		if !dryRun {
 			payload := map[string]any{

--- a/internal/app/cmd_sch_autoconnect_test.go
+++ b/internal/app/cmd_sch_autoconnect_test.go
@@ -35,7 +35,7 @@ func TestPlanConnection_GroundPrefersDownShortest(t *testing.T) {
 	// A pin below its owner center → outward = down; kind gnd default = down.
 	// Both bonuses stack on 'down', and the shortest offset wins ties.
 	pin := acPin{X: 100, Y: 200, OwnerBBox: bb(80, 150, 120, 190)}
-	all := planConnection(pin, "ground", clearScene(), rulesFor())
+	all := planConnection(pin, "ground", "GND", clearScene(), rulesFor())
 	sel := all[0]
 	if sel.Direction != "down" {
 		t.Fatalf("expected down (outward + kind default), got %s", sel.Direction)
@@ -55,7 +55,7 @@ func TestScoreCandidate_PartOverlapDominates(t *testing.T) {
 	// A part bbox sits right where the 'down' endpoint would land → +10000.
 	pin := acPin{X: 100, Y: 100}
 	scene := acScene{Parts: []layoutBBox{bb(90, 115, 110, 135).deref()}}
-	c := scoreCandidate(pin, "down", 24, "ground", scene, rulesFor())
+	c := scoreCandidate(pin, "down", 24, "ground", "GND", scene, rulesFor())
 	if c.Score < costPartOverlap {
 		t.Fatalf("expected part-overlap penalty (>=%d), got %.2f", costPartOverlap, c.Score)
 	}
@@ -65,7 +65,7 @@ func TestScoreCandidate_StubCrossesPin(t *testing.T) {
 	pin := acPin{X: 100, Y: 100}
 	// Another pin sits on the downward stub path (x=100, between y=100 and 130).
 	scene := acScene{Pins: []acPin{{X: 100, Y: 115, Designator: "U2", PinNumber: "1"}}}
-	c := scoreCandidate(pin, "down", 30, "ground", scene, rulesFor())
+	c := scoreCandidate(pin, "down", 30, "ground", "GND", scene, rulesFor())
 	hasCross := false
 	for _, r := range c.Reasons {
 		if r.Cost == costPinCross {
@@ -77,11 +77,92 @@ func TestScoreCandidate_StubCrossesPin(t *testing.T) {
 	}
 }
 
+// TestScoreCandidate_PinCrossIsHardReject: a stub crossing a non-target pin must
+// be a HARD reject (issue #64), not a soft penalty a long offset could out-vote.
+func TestScoreCandidate_PinCrossIsHardReject(t *testing.T) {
+	pin := acPin{X: 100, Y: 100}
+	scene := acScene{Pins: []acPin{{X: 100, Y: 115, Designator: "U2", PinNumber: "1"}}}
+	c := scoreCandidate(pin, "down", 30, "ground", "GND", scene, rulesFor())
+	if !candidateHardRejected(c) {
+		t.Fatalf("pin-cross should hard-reject, score=%.2f reasons=%+v", c.Score, c.Reasons)
+	}
+}
+
+// TestScoreCandidate_StubTouchesForeignWireHardRejects: a stub whose endpoint or
+// path lands on an existing wire of a DIFFERENT net is a silent net merge — must
+// hard-reject (issue #64).
+func TestScoreCandidate_StubTouchesForeignWireHardRejects(t *testing.T) {
+	pin := acPin{X: 100, Y: 100}
+	// A +5V wire runs horizontally across y=130; the downward stub endpoint (100,130)
+	// lands on it → foreign-net junction.
+	scene := acScene{Wires: []wireSegment{{X0: 50, Y0: 130, X1: 200, Y1: 130, Net: "+5V"}}}
+	c := scoreCandidate(pin, "down", 30, "ground", "GND", scene, rulesFor())
+	if !candidateHardRejected(c) {
+		t.Fatalf("stub touching a foreign-net wire should hard-reject, reasons=%+v", c.Reasons)
+	}
+}
+
+// TestScoreCandidate_SameNetWireNotRejected: touching a wire ALREADY on the
+// target net is the whole point of connecting — it must NOT hard-reject.
+func TestScoreCandidate_SameNetWireNotRejected(t *testing.T) {
+	pin := acPin{X: 100, Y: 100}
+	scene := acScene{Wires: []wireSegment{{X0: 50, Y0: 130, X1: 200, Y1: 130, Net: "GND"}}}
+	c := scoreCandidate(pin, "down", 30, "ground", "GND", scene, rulesFor())
+	if candidateHardRejected(c) {
+		t.Fatalf("same-net wire touch must NOT hard-reject, reasons=%+v", c.Reasons)
+	}
+}
+
+// TestScoreCandidate_UnnamedWireIsForeign: a wire with no resolvable net is
+// treated conservatively as foreign — touching it hard-rejects.
+func TestScoreCandidate_UnnamedWireIsForeign(t *testing.T) {
+	pin := acPin{X: 100, Y: 100}
+	scene := acScene{Wires: []wireSegment{{X0: 50, Y0: 130, X1: 200, Y1: 130, Net: ""}}}
+	c := scoreCandidate(pin, "down", 30, "ground", "GND", scene, rulesFor())
+	if !candidateHardRejected(c) {
+		t.Fatalf("unnamed (foreign) wire touch should hard-reject, reasons=%+v", c.Reasons)
+	}
+}
+
+// TestPlanConnection_AvoidsForeignWireDirection: with a foreign-net wire blocking
+// the 'down' endpoint but the other directions clear, the planner must pick a
+// non-rejected direction.
+func TestPlanConnection_AvoidsForeignWireDirection(t *testing.T) {
+	pin := acPin{X: 100, Y: 100}
+	scene := acScene{Wires: []wireSegment{{X0: 50, Y0: 130, X1: 200, Y1: 130, Net: "+5V"}}}
+	all := planConnection(pin, "ground", "GND", scene, rulesFor())
+	if candidateHardRejected(all[0]) {
+		t.Fatalf("planner picked a hard-rejected candidate: %+v", all[0])
+	}
+}
+
+// TestBuildScene_ParsesWires verifies wires flow from the extension payload into
+// the scene (issue #64).
+func TestBuildScene_ParsesWires(t *testing.T) {
+	result := map[string]any{
+		"components": []any{},
+		"wires": []any{
+			map[string]any{"x0": 10.0, "y0": 20.0, "x1": 30.0, "y1": 20.0, "net": "+5V"},
+			map[string]any{"x0": 30.0, "y0": 20.0, "x1": 30.0, "y1": 40.0, "net": ""},
+		},
+	}
+	scene := buildScene(result)
+	if len(scene.Wires) != 2 {
+		t.Fatalf("expected 2 wire segments, got %d", len(scene.Wires))
+	}
+	if scene.Wires[0].Net != "+5V" || scene.Wires[0].X1 != 30 {
+		t.Errorf("wire 0 parsed wrong: %+v", scene.Wires[0])
+	}
+	if scene.Wires[1].Net != "" {
+		t.Errorf("wire 1 net should be empty, got %q", scene.Wires[1].Net)
+	}
+}
+
 func TestPlanConnection_AvoidsOverlappingDirection(t *testing.T) {
 	// A wall of parts blocks 'down'; 'up' is clear. Planner must not pick down.
 	pin := acPin{X: 100, Y: 100}
 	scene := acScene{Parts: []layoutBBox{bb(80, 110, 120, 200).deref()}}
-	all := planConnection(pin, "ground", scene, rulesFor())
+	all := planConnection(pin, "ground", "GND", scene, rulesFor())
 	if all[0].Direction == "down" {
 		t.Fatalf("planner chose blocked direction down; scene=%+v score=%.2f", scene, all[0].Score)
 	}
@@ -89,8 +170,8 @@ func TestPlanConnection_AvoidsOverlappingDirection(t *testing.T) {
 
 func TestPlanConnection_Deterministic(t *testing.T) {
 	pin := acPin{X: 100, Y: 100, OwnerBBox: bb(80, 80, 120, 95)}
-	a := planConnection(pin, "power", clearScene(), rulesFor())
-	b := planConnection(pin, "power", clearScene(), rulesFor())
+	a := planConnection(pin, "power", "+5V", clearScene(), rulesFor())
+	b := planConnection(pin, "power", "+5V", clearScene(), rulesFor())
 	if len(a) != len(b) {
 		t.Fatalf("candidate count differs: %d vs %d", len(a), len(b))
 	}
@@ -107,7 +188,7 @@ func TestPlanConnection_TieBreakStable(t *testing.T) {
 	// the lexical tie-break must order down<left<right<up. Confirm offsets too:
 	// shortest first within a direction.
 	pin := acPin{X: 0, Y: 0}
-	all := planConnection(pin, "ground", clearScene(), rulesFor())
+	all := planConnection(pin, "ground", "GND", clearScene(), rulesFor())
 	if all[0].Direction != "down" || all[0].Offset != 18 {
 		t.Fatalf("expected down@18 first, got %s@%.0f", all[0].Direction, all[0].Offset)
 	}

--- a/skills/easyeda-agent/references/schematic.md
+++ b/skills/easyeda-agent/references/schematic.md
@@ -125,11 +125,21 @@ flag/netport, never a netflag on a bare pin), but it still makes YOU pick
 `--direction` and `--offset`, so layout quality depends on judgment. **`sch
 autoconnect` removes that judgment**: it pulls the real geometry (part bboxes,
 pin coords, existing flag/port/label bboxes, title-block keep-out), scores every
-`up/down/left/right × offset` candidate with a deterministic cost function (part
-overlap / title-block / pin-crossing / flag-collision / through-part penalties,
-shortest-offset + outward-side + kind-default bonuses), picks the lowest-cost
-one, and delegates the mutation to `connect_pin`. Same schematic state + spec →
-same selection (deterministic).
+`up/down/left/right × offset` candidate with a deterministic cost function
+(flag-collision / through-part penalties, shortest-offset + outward-side +
+kind-default bonuses), picks the lowest-cost one, and delegates the mutation to
+`connect_pin`. Same schematic state + spec → same selection (deterministic).
+
+**Hard rejects (issue #64):** two hazards are never soft penalties — they make a
+candidate *unusable* no matter the offset, because EasyEDA would silently merge
+nets and the post-hoc DRC can't see it: (1) a stub whose endpoint or path touches
+an existing **foreign-net wire** (endpoint-on-wire = junction = net merge), and
+(2) a stub **crossing a non-target pin** (EasyEDA trims+connects there, and the
+wire-over-pin rule exempts pin endpoints). autoconnect now pulls existing wire
+geometry into the scene automatically; a wire already on the target net is fine
+(that's the connection point). If EVERY direction/offset is a
+hard reject, autoconnect refuses to place the stub and reports the connection as
+failed — resolve the layout (move the part / clear the wire) and retry.
 
 ```bash
 # single pin by designator:pin (number OR name)


### PR DESCRIPTION
Fixes #64

## 问题
autoconnect 的评分器工作在一个**不含导线几何**的场景上：`acScene` 没有 `Wires` 字段,`buildScene` 不收集任何导线,`scoreCandidate` 的成本项也没有一项针对既有 wire。当 stub 远端点落在既有导线线段上时,EasyEDA 判定端点触线=junction,两网直接合并——形成隐性短接。此外 `costPinCross` 只是罚分(5000),足够长的 offset 可以把它投票淹没。

## 改动
1. **数据面(extension)**:`schematic.components.list` 新增 `includeWires` 开关,复用现成的 `collectWireSegments` + `sch_PrimitiveWire.getAll()`,输出每条 wire 的线段坐标 `{x0,y0,x1,y1,net}`。
2. **Go 场景**:`acScene` 增加 `Wires []wireSegment`;`buildScene` 解析 payload 中的 `wires`;autoconnect 请求 `includeWires:true`。
3. **评分器硬拒**(建议 1+2):
   - 候选 stub 的端点或路径触及任何**非目标网络**的既有导线 → 硬拒(sentinel `costHardReject=1e9`,而非罚分)。已在目标网络上的导线跳过(那正是连接点);无名导线保守视为 foreign。
   - `costPinCross` 从罚分改为同样的硬拒(穿 pin 会被 EasyEDA 静默截断连上)。
4. **守卫**:当最优候选仍是硬拒(所有方向/offset 都会短接),`runAutoconnect` 拒绝落图,把该连接报为失败并提示人工调整布局,而不是制造错误连接。
5. 起点触线豁免:foreign wire 仅在 pin 坐标处相接属于**既有状态**(由幂等 net 冲突检查负责),不会误拒所有方向。

## 测试
- Go 单测新增:pin-cross 硬拒、stub 端点落在 foreign wire 上硬拒、同名网 wire 不拒、无名 wire 视为 foreign、planner 避开 foreign-wire 方向、`buildScene` 解析 wires。`go test ./...` 全绿,gofmt/vet 干净。
- extension:`npm run typecheck` 通过,`npm test` 43 passed。
- 建议 3(同件多 pin 方向互斥)属 `planConnection` 联合求解,复杂度更高,按 issue 建议留作单独跟进;本 PR 先落地 1/2 止血。

## 未验证
真机回归(box-v2 P1 场景 `sch read` 不再跨轨合并)需要 EasyEDA 环境,本地无硬件/工程,未执行。