### PR TITLE
feat: add sch bridge-check for bridge/orphan detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ clawhub install easyeda-agent
 
 **原理图**
 - 从立创/LCSC 库按 uuid 放**真实器件**再布线;电源/地**网络标志**用 `connect_pin`(自动补偿旋转存储的坑)。
-- **DRC**(`sch drc`)+ 重建的逐项**设计检查**(`sch check`——悬空引脚、导线交叉、导线压引脚)+ 几何 **layout-lint**(重叠/间距)。
+- **DRC**(`sch drc`)+ 重建的逐项**设计检查**(`sch check`——悬空引脚、导线交叉、导线压引脚)+ 几何 **layout-lint**(重叠/间距)+ **树粒度桥接检测**(`sch bridge-check`——共线合并短路 BRIDGE / 孤儿桩 ORPHAN,`sch check` 的单线视角看不全的盲区)。
 - 模块感知**自动布局**(放置→校验→调整)、一次调用 **`sch read`**(器件+网络+悬空引脚+检查)、**BOM**/**网表**导出(BOM 自动补 LCSC C 号)。
 
 **PCB — 布局**

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -188,12 +188,13 @@ Workspace → Project → **Board** → schematic + PCB. Map to `eda.dmt_Board.*
 |---|---|
 | `schematic.library.search` | Free-text search of the EasyEDA device library (`eda.lib_Device.search`); returns `libraryUuid` + `uuid` ready for `schematic.component.place`, plus name/value/footprint/lcsc/description. Replaces ad-hoc `debug.exec_js` lookups. **See the search caveat under Roadmap.** |
 
-### Verify (2 actions)
+### Verify (3 actions)
 
 | Action | What |
 |---|---|
 | `schematic.drc.check` | Run the official schematic DRC SDK gate; current EasyEDA builds may return only boolean/aggregate detail. Use `schematic.check` for reconstructed per-item warnings. |
 | `schematic.check` | Reconstructed schematic design check from primitives + official netlist JSON: net-marker mismatch, multi-net wire, floating pins, wire crossings, and wire-over-pin hazards. |
+| `schematic.bridgeCheck` | **Tree-granularity** net-vs-copper consistency check (`sch bridge-check`). Groups every page wire into trees by shared vertices (union-find), then aggregates the netflag/netport net names anchored on each tree: `len(set(nets)) > 1` → **BRIDGE** (共线合并短路, real short, ERROR/gate); empty nets + touches a pin → **ORPHAN** (孤儿桩, WARN). Catches the盲区 `schematic.check`'s per-single-wire `multi-net-wire` rule under-reports when one merge spans several wires. Reports wire ids / flag ids / touched `designator:pin` per problem tree. Read-only. |
 | `schematic.snapshot` | Capture the current rendered area as a PNG artifact. |
 
 ### Export (2 actions)

--- a/extension/src/actions.ts
+++ b/extension/src/actions.ts
@@ -2119,6 +2119,133 @@ const schematicCheck: Handler = async (payload) => {
 	return { result: { passed: findings.length === 0, summary, findings } };
 };
 
+// ─── Bridge check (tree-granularity net-vs-copper consistency) ─────────
+//
+// `sch check`'s multi-net-wire rule works per SINGLE wire primitive, but when
+// EasyEDA merges two collinear touching stubs of DIFFERENT nets into one tree,
+// the short spans SEVERAL wires — no single wire carries two net names, so the
+// per-wire rule under-reports. bridge-check groups wires into trees by shared
+// vertices (union-find) and aggregates the net names of every netflag/netport
+// anchored on that tree:
+//   • len(set(nets)) > 1  → BRIDGE (real short, ERROR)
+//   • nets empty & tree touches a component pin → ORPHAN (dangling stub, WARN)
+// Read-only: reports wire ids / flag ids / touched pins (designator:pin) per
+// problem tree so the fix (integral-tree delete + occupancy-aware reconnect)
+// can be driven by hand or a later --repair pass (issue #73).
+
+interface BridgeTree {
+	kind: 'BRIDGE' | 'ORPHAN';
+	wireIds: Array<string>;
+	flagIds: Array<string>;
+	pins: Array<string>; // "designator:pin"
+	nets: Array<string>;
+}
+
+const schematicBridgeCheck: Handler = async (payload) => {
+	const allPages = optionalBoolean(payload, 'allPages') === true;
+	let components, wires;
+	try {
+		components = await eda.sch_PrimitiveComponent.getAll(undefined, allPages);
+		wires = await eda.sch_PrimitiveWire.getAll();
+	}
+	catch (err) {
+		throw edaError(err, 'Failed to read schematic for bridge check.');
+	}
+	const wireSegs = collectWireSegments((wires ?? []) as Array<{ getState_Line: () => Array<number>; getState_Net?: () => string; getState_PrimitiveId?: () => string }>);
+	const COINCIDE_TOL = CHECK_EPS * 8;
+
+	// Netflags/netports/netlabels carry the net name we aggregate per tree.
+	const NET_MARKER_TYPES = new Set(['netflag', 'netport', 'netlabel', 'short_symbol']);
+	const markers: Array<{ x: number; y: number; net: string; primitiveId: string }> = [];
+	const pins: Array<{ designator: string; number: string; x: number; y: number }> = [];
+	for (const c of components ?? []) {
+		let type: string;
+		try { type = String(c.getState_ComponentType?.() ?? ''); }
+		catch { continue; }
+		if (NET_MARKER_TYPES.has(type)) {
+			try {
+				markers.push({ x: c.getState_X(), y: c.getState_Y(), net: String(c.getState_Net?.() ?? ''), primitiveId: String(c.getState_PrimitiveId?.() ?? '') });
+			}
+			catch { /* marker without coords */ }
+			continue;
+		}
+		const primitiveId = c.getState_PrimitiveId();
+		let compPins;
+		try { compPins = await eda.sch_PrimitiveComponent.getAllPinsByPrimitiveId(primitiveId); }
+		catch { continue; }
+		if (!compPins || compPins.length === 0) continue;
+		const designator = String(c.getState_Designator?.() ?? '');
+		for (const p of compPins) {
+			try { pins.push({ designator, number: String(p.getState_PinNumber?.() ?? ''), x: p.getState_X(), y: p.getState_Y() }); }
+			catch { /* pin without coords */ }
+		}
+	}
+
+	// ── Union-find over wires: two wires join a tree when they share a vertex. ──
+	const wireList = wireSegs.length > 0
+		? [...new Map(wireSegs.filter(w => w.wirePrimitiveId).map(w => [w.wirePrimitiveId, w])).keys()]
+		: [];
+	// Vertices per wire primitive id (from every segment endpoint).
+	const wireVerts = new Map<string, Array<[number, number]>>();
+	for (const ws of wireSegs) {
+		if (!ws.wirePrimitiveId) continue;
+		const arr = wireVerts.get(ws.wirePrimitiveId) ?? [];
+		arr.push([ws.seg[0], ws.seg[1]], [ws.seg[2], ws.seg[3]]);
+		wireVerts.set(ws.wirePrimitiveId, arr);
+	}
+	const idx = new Map<string, number>();
+	wireList.forEach((id, i) => idx.set(id, i));
+	const parent = wireList.map((_, i) => i);
+	const find = (a: number): number => { while (parent[a] !== a) { parent[a] = parent[parent[a]]; a = parent[a]; } return a; };
+	const union = (a: number, b: number) => { parent[find(a)] = find(b); };
+	for (let i = 0; i < wireList.length; i++) {
+		for (let j = i + 1; j < wireList.length; j++) {
+			const vi = wireVerts.get(wireList[i]) ?? [];
+			const vj = wireVerts.get(wireList[j]) ?? [];
+			const touch = vi.some(a => vj.some(b => Math.hypot(a[0] - b[0], a[1] - b[1]) <= COINCIDE_TOL));
+			if (touch) union(i, j);
+		}
+	}
+
+	// ── Aggregate each tree's wires + anchored flags/pins + net names. ──
+	const treeMap = new Map<number, { wireIds: Set<string>; verts: Array<[number, number]> }>();
+	for (const id of wireList) {
+		const root = find(idx.get(id)!);
+		const t = treeMap.get(root) ?? { wireIds: new Set<string>(), verts: [] };
+		t.wireIds.add(id);
+		t.verts.push(...(wireVerts.get(id) ?? []));
+		treeMap.set(root, t);
+	}
+
+	const trees: Array<BridgeTree> = [];
+	for (const t of treeMap.values()) {
+		const onTree = (x: number, y: number) => t.verts.some(v => Math.hypot(v[0] - x, v[1] - y) <= COINCIDE_TOL);
+		const flagIds: Array<string> = [];
+		const nets = new Set<string>();
+		for (const m of markers) {
+			if (!onTree(m.x, m.y)) continue;
+			if (m.primitiveId) flagIds.push(m.primitiveId);
+			if (m.net) nets.add(m.net);
+		}
+		const touchedPins: Array<string> = [];
+		for (const p of pins) {
+			if (onTree(p.x, p.y)) touchedPins.push(`${p.designator}:${p.number}`);
+		}
+		const netList = [...nets];
+		if (netList.length > 1) {
+			trees.push({ kind: 'BRIDGE', wireIds: [...t.wireIds], flagIds, pins: [...new Set(touchedPins)], nets: netList });
+		}
+		else if (netList.length === 0 && touchedPins.length > 0) {
+			trees.push({ kind: 'ORPHAN', wireIds: [...t.wireIds], flagIds, pins: [...new Set(touchedPins)], nets: netList });
+		}
+	}
+
+	const bridges = trees.filter(t => t.kind === 'BRIDGE').length;
+	const orphans = trees.filter(t => t.kind === 'ORPHAN').length;
+	const summary = { trees: trees.length, bridges, orphans, wireTreesTotal: treeMap.size };
+	return { result: { passed: bridges === 0 && orphans === 0, summary, trees } };
+};
+
 // ─── Save ─────────────────────────────────────────────────────────────
 
 const schematicSave: Handler = async () => {
@@ -6368,6 +6495,7 @@ const HANDLERS: Record<string, Handler> = {
 	'schematic.snapshot': schematicSnapshot,
 	'schematic.drc.check': schematicDrcCheck,
 	'schematic.check': schematicCheck,
+	'schematic.bridgeCheck': schematicBridgeCheck,
 	'schematic.read': schematicRead,
 	'schematic.save': schematicSave,
 	'schematic.export.netlist': schematicExportNetlist,

--- a/internal/app/cmd_sch.go
+++ b/internal/app/cmd_sch.go
@@ -1005,6 +1005,59 @@ prior versions emitted a bare {passed,summary,findings}).`,
 		sch.AddCommand(c)
 	}
 
+	// ── bridge-check ────────────────────────────────────────────────────────
+	// schematic.bridgeCheck — tree-granularity net-vs-copper consistency gate.
+	// `sch check`'s multi-net-wire rule is per SINGLE wire; when EasyEDA merges
+	// collinear touching stubs of DIFFERENT nets into one tree the short spans
+	// several wires and no single wire carries two names, so it under-reports.
+	// bridge-check groups wires into trees (shared-vertex union-find) and
+	// aggregates the netflag/netport net names per tree: >1 net → BRIDGE (real
+	// short, ERROR, non-zero exit = gate); empty + touches a pin → ORPHAN (WARN).
+	{
+		var allPages, asJSON bool
+		c := &cobra.Command{
+			Use:   "bridge-check",
+			Short: "Detect共线合并短路 (bridges) and孤儿桩 (orphans) at wire-tree granularity",
+			Long: `Tree-granularity net-vs-copper consistency check — the盲区 'sch check' can't see.
+
+EasyEDA merges two collinear touching stubs of DIFFERENT nets into ONE wire tree
+that spans several wire primitives. No single wire then carries two net names, so
+'sch check''s per-wire multi-net-wire rule under-reports the short. 'sch drc'
+doesn't flag it either (the merged tree looks like an ordinary wire). Only the
+"one wire tree carries several net names" data view exposes it.
+
+bridge-check groups every page wire into trees by shared vertices (union-find),
+then aggregates the net names of the netflag/netport anchored on each tree:
+
+  • len(set(nets)) > 1                    → BRIDGE (real short)        ERROR
+  • nets empty & tree touches a comp pin  → ORPHAN (dangling stub)     WARN
+
+Each problem tree reports its wire ids / flag ids / touched pins (designator:pin)
+so the fix — delete the whole tree (sch prim-delete) then re-connect each pin to
+its own net (sch connect) — is actionable. This is the third pillar of the S5
+verification gate: layout-lint (placement) + check/drc (structure) + bridge-check
+(network-semantics vs physical-copper).
+
+Exit code: non-zero when any BRIDGE exists (real short → gate). Orphans alone
+exit 0 (they are WARN). Run it after autoconnect / manual routing as a self-heal
+post-step.
+
+NOTE: --all-pages reads non-active pages shallowly (same limit as 'sch check' /
+'sch list' — pins may be empty), so cross-page trees can be under-reported; switch
+to a page for authoritative results.`,
+			Args: cobra.NoArgs,
+			Example: `  easyeda sch bridge-check
+  easyeda sch bridge-check --json
+  easyeda sch bridge-check --all-pages`,
+			RunE: func(cmd *cobra.Command, args []string) error {
+				return runSchBridgeCheck(cfg, window, allPages, asJSON, stdout, stderr)
+			},
+		}
+		c.Flags().BoolVar(&allPages, "all-pages", false, "check wire trees across all schematic pages (WARNING: non-active pages return shallow data — pins may be empty; use `doc switch` to that page for accurate results)")
+		c.Flags().BoolVar(&asJSON, "json", false, "emit the report in the {id,type,version,ok,result} envelope (trees under result.trees)")
+		sch.AddCommand(c)
+	}
+
 	// ── read ──────────────────────────────────────────────────────────────
 	// schematic.read — one-call semantic snapshot (components + pin nets + nets +
 	// check), so the agent reads the whole circuit at once.

--- a/internal/app/cmd_sch_bridge_check.go
+++ b/internal/app/cmd_sch_bridge_check.go
@@ -1,0 +1,136 @@
+package app
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// ── sch bridge-check: tree-granularity net-vs-copper consistency gate ────────
+//
+// `sch check`'s multi-net-wire rule looks at a SINGLE wire primitive at a time,
+// but EasyEDA merges two collinear touching stubs of DIFFERENT nets into one
+// wire tree spanning several wire primitives — no single wire then carries two
+// net names, so the per-wire rule under-reports the short. bridge-check groups
+// wires into trees by shared vertices (union-find, connector side) and
+// aggregates the net names of the netflag/netport anchored on each tree:
+//
+//   • len(set(nets)) > 1                     → BRIDGE (real short, ERROR, gate)
+//   • nets empty & tree touches a comp pin   → ORPHAN (dangling stub, WARN)
+//
+// It is the third pillar of the S5 verification gate (network-semantics vs
+// physical-copper consistency), alongside layout-lint and check/drc. Read-only:
+// it reports each problem tree's wire ids / flag ids / touched pins so the fix
+// can be driven by hand (sch prim-delete + sch connect) or a later --repair
+// pass. BRIDGE findings drive a non-zero exit so it can gate a workflow.
+
+type bridgeTree struct {
+	Kind    string   `json:"kind"` // BRIDGE | ORPHAN
+	WireIds []string `json:"wireIds"`
+	FlagIds []string `json:"flagIds"`
+	Pins    []string `json:"pins"` // designator:pin
+	Nets    []string `json:"nets"`
+}
+
+type bridgeSummary struct {
+	Trees          int `json:"trees"`
+	Bridges        int `json:"bridges"`
+	Orphans        int `json:"orphans"`
+	WireTreesTotal int `json:"wireTreesTotal"`
+}
+
+type bridgeReport struct {
+	Passed  bool          `json:"passed"`
+	Summary bridgeSummary `json:"summary"`
+	Trees   []bridgeTree  `json:"trees"`
+}
+
+// runSchBridgeCheck runs the read-only tree-granularity bridge/orphan detection,
+// renders it, and returns a non-zero exit when a BRIDGE (real short) exists so it
+// can gate a workflow. ORPHAN findings are WARN and do not gate on their own.
+func runSchBridgeCheck(cfg *appConfig, window string, allPages, asJSON bool, stdout, stderr io.Writer) error {
+	payload := map[string]any{}
+	if allPages {
+		payload["allPages"] = true
+	}
+	res, err := requestAction(cfg, "schematic.bridgeCheck", window, payload)
+	if err != nil {
+		return err
+	}
+
+	rep, perr := parseBridgeReport(res.Result)
+	if perr != nil {
+		if b, mErr := json.MarshalIndent(res.Result, "", "  "); mErr == nil {
+			_, _ = stdout.Write(b)
+			fmt.Fprintln(stdout)
+		}
+		return perr
+	}
+
+	if asJSON {
+		if err := encodeResultEnvelope(res, rep, stdout); err != nil {
+			return err
+		}
+	} else {
+		renderBridgeReport(rep, stdout)
+	}
+
+	if rep.Summary.Bridges > 0 {
+		return fmt.Errorf("sch bridge-check: %d bridge(s) — real short(s) (net-vs-copper mismatch)", rep.Summary.Bridges)
+	}
+	return nil
+}
+
+func parseBridgeReport(result map[string]any) (bridgeReport, error) {
+	var rep bridgeReport
+	if result == nil {
+		return rep, fmt.Errorf("empty bridge-check result")
+	}
+	b, err := json.Marshal(result)
+	if err != nil {
+		return rep, err
+	}
+	if err := json.Unmarshal(b, &rep); err != nil {
+		return rep, fmt.Errorf("unexpected bridge-check result shape: %w", err)
+	}
+	return rep, nil
+}
+
+func renderBridgeReport(rep bridgeReport, w io.Writer) {
+	s := rep.Summary
+	fmt.Fprintf(w, "sch bridge-check: %d problem tree(s) — %d bridge(s) (real short), %d orphan(s) (dangling stub) across %d wire tree(s)\n",
+		s.Trees, s.Bridges, s.Orphans, s.WireTreesTotal)
+
+	for _, t := range rep.Trees {
+		tag := "WARN"
+		if t.Kind == "BRIDGE" {
+			tag = "ERROR"
+		}
+		line := fmt.Sprintf("  %-5s  %-7s", tag, t.Kind)
+		if len(t.Nets) > 0 {
+			line += "  nets=[" + strings.Join(t.Nets, ",") + "]"
+		}
+		if len(t.Pins) > 0 {
+			line += "  pins=[" + strings.Join(t.Pins, ",") + "]"
+		}
+		fmt.Fprintln(w, line)
+		if len(t.WireIds) > 0 {
+			fmt.Fprintf(w, "          wires: %s\n", strings.Join(t.WireIds, ", "))
+		}
+		if len(t.FlagIds) > 0 {
+			fmt.Fprintf(w, "          flags: %s\n", strings.Join(t.FlagIds, ", "))
+		}
+	}
+
+	if rep.Passed {
+		fmt.Fprintln(w, "✓ no bridges or orphans")
+		return
+	}
+	if s.Bridges > 0 {
+		fmt.Fprintln(w, "→ bridge (共线合并短路): delete the whole tree (sch prim-delete <wireIds+flagIds>), then re-connect each pin to its own net (sch connect)")
+	}
+	if s.Orphans > 0 {
+		fmt.Fprintln(w, "→ orphan (孤儿桩): the tree touches pins but carries no net flag/port — wire it to a real net or clear the stray stub (sch disconnect / prim-delete)")
+	}
+}

--- a/internal/app/cmd_sch_bridge_check_test.go
+++ b/internal/app/cmd_sch_bridge_check_test.go
@@ -1,0 +1,104 @@
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// The connector shape: one BRIDGE tree (共线合并短路) — a wire tree spanning two
+// wires whose anchored flags carry two DIFFERENT net names, plus one ORPHAN tree
+// (a stub touching a pin with no net flag).
+func TestParseAndRenderBridge_BridgeAndOrphan(t *testing.T) {
+	result := map[string]any{
+		"passed": false,
+		"summary": map[string]any{
+			"trees":          float64(2),
+			"bridges":        float64(1),
+			"orphans":        float64(1),
+			"wireTreesTotal": float64(9),
+		},
+		"trees": []any{
+			map[string]any{
+				"kind":    "BRIDGE",
+				"wireIds": []any{"w1", "w2"},
+				"flagIds": []any{"f1", "f2"},
+				"pins":    []any{"U1:5", "R3:1"},
+				"nets":    []any{"GND", "VCC"},
+			},
+			map[string]any{
+				"kind":    "ORPHAN",
+				"wireIds": []any{"w7"},
+				"flagIds": []any{},
+				"pins":    []any{"C2:2"},
+				"nets":    []any{},
+			},
+		},
+	}
+	rep, err := parseBridgeReport(result)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if rep.Passed {
+		t.Error("expected passed=false")
+	}
+	if rep.Summary.Bridges != 1 || rep.Summary.Orphans != 1 || len(rep.Trees) != 2 {
+		t.Errorf("unexpected summary/trees: %+v", rep)
+	}
+
+	var buf bytes.Buffer
+	renderBridgeReport(rep, &buf)
+	out := buf.String()
+	for _, want := range []string{"ERROR", "BRIDGE", "nets=[GND,VCC]", "pins=[U1:5,R3:1]", "w1, w2", "WARN", "ORPHAN", "C2:2", "bridge", "orphan"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("render missing %q\n--- output ---\n%s", want, out)
+		}
+	}
+}
+
+// Clean board: no problem trees → passed, and the "no bridges or orphans" line.
+func TestRenderBridge_Clean(t *testing.T) {
+	rep := bridgeReport{Passed: true, Summary: bridgeSummary{WireTreesTotal: 12}}
+	var buf bytes.Buffer
+	renderBridgeReport(rep, &buf)
+	if !strings.Contains(buf.String(), "no bridges or orphans") {
+		t.Errorf("expected clean line, got:\n%s", buf.String())
+	}
+}
+
+// --json output must be wrapped in the {id,type,version,ok,result} envelope, so a
+// uniform-envelope parser reading result.trees works consistently with sch check.
+func TestEncodeResultEnvelope_BridgeReport(t *testing.T) {
+	rep := bridgeReport{
+		Passed:  false,
+		Summary: bridgeSummary{Trees: 1, Bridges: 1},
+		Trees: []bridgeTree{
+			{Kind: "BRIDGE", WireIds: []string{"w1", "w2"}, Nets: []string{"GND", "VCC"}, Pins: []string{"U1:5"}},
+		},
+	}
+	res := &actionResult{ID: "req-9", Type: "response", Version: "1", OK: true}
+
+	var buf bytes.Buffer
+	if err := encodeResultEnvelope(res, rep, &buf); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	var env struct {
+		ID     string `json:"id"`
+		OK     bool   `json:"ok"`
+		Result struct {
+			Passed bool         `json:"passed"`
+			Trees  []bridgeTree `json:"trees"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal envelope: %v\n%s", err, buf.String())
+	}
+	if env.ID != "req-9" || !env.OK {
+		t.Errorf("envelope metadata lost: %+v", env)
+	}
+	if len(env.Result.Trees) != 1 || env.Result.Trees[0].Kind != "BRIDGE" || len(env.Result.Trees[0].Nets) != 2 {
+		t.Errorf("result.trees not reachable via envelope: %+v", env.Result)
+	}
+}


### PR DESCRIPTION
Fixes #73

## 做了什么
新增只读 typed 子命令 `easyeda sch bridge-check`——S5 校验门的第三根柱子(网络语义 vs 物理铜线一致性),补上 `sch check` 单线视角看不全的盲区。

- **连接器侧 (`extension/src/actions.ts`)** — 新增 `schematic.bridgeCheck` handler:复用 `collectWireSegments` 收 wire 段,并查集(共享顶点)分树,聚合每棵树上 netflag/netport 的网名集合与触及引脚。`len(set(nets))>1` → BRIDGE;空网名且触脚 → ORPHAN。注册进 ACTIONS 表。
- **Go CLI (`cmd_sch_bridge_check.go`)** — 仿 `runSchCheck` 结构:typed report + `--json` 走 `encodeResultEnvelope`,渲染对齐 `renderCheckReport`;存在 BRIDGE 时非零退出可当门禁。`--all-pages` / `--json` flags,注册在 `cmd_sch.go` check 块附近。
- **文档** — `docs/FEATURES.md` Verify 段 + README 命令说明。

## 范围说明(重要)
评估评论建议将本 feature 拆成两个 PR(先只读检测门,再修复)。本 PR **只实现只读检测半段**,`--repair`(整树删除 + 占用感知重连 + 循环收敛)留待后续 PR——因为修复段的多个判定边界(占用集/路径干净判定复用度、整树删除误伤面、收敛与幂等边界、门控语义)在 issue 里仍留白,不宜猜测实现。

## 测试
- `go test ./...` 全绿;新增 `cmd_sch_bridge_check_test.go`(BRIDGE+ORPHAN 解析/渲染、clean、envelope 三例)。
- 扩展 `npm run typecheck` + `npm test`(45 passed)。
- `go vet ./...` clean;CLI `sch bridge-check --help` 正常。
- **未做运行时验证**:检测逻辑依赖真实 EasyEDA 画布(需连接器 + 打开工程),本地无该运行环境,建议在实机 box-v2 板上跑一遍确认与实战 `repair_bridges.py` 检测结果一致。