### PR TITLE
feat(blocks): bq24074_powerpath_charger —— 锂电备份 power-path 充电(断电续报核心)

### DIFF
--- a/internal/blocks/data/bq24074_powerpath_charger.json
+++ b/internal/blocks/data/bq24074_powerpath_charger.json
@@ -1,0 +1,115 @@
+{
+  "id": "block.bq24074_powerpath_charger",
+  "desc": "BQ24074 锂电充电 + power-path(输入↔电池无缝切换,断电续报/防盗类设备核心);电芯 NTC 低温禁充 + ILIM/ISET 外阻编程 + PGOOD 断电检测输出",
+  "category": "power",
+  "author": "@zhoushoujianwork",
+  "contributors": [],
+  "added": "v0.11.0",
+  "updated": "v0.11.0",
+  "source": "datasheet:BQ24074 (TI SLUS810 — power-path 充电器典型应用电路: IN/OUT/BAT 电容、ISET/ILIM 编程电阻、TS 10k NTC、EN1/EN2 输入限流模式真值表) ; 拓扑经 motobox 车机V2 两轮设计评审修正(评审修正项: TS 由轨分压改电芯 NTC、EN strap 落定 ILIM 模式、ILIM 1.07k=1.45A、PGOOD 100k 上拉)后在 车机V2-fable P1 整板落网",
+  "validated": "车机V2-fable 2026-07-09 by @zhoushoujianwork: 整板 place→autoconnect→sch check(0 桥接/0 异名合并)→bridge-check 收敛→sch drc(0 fatal/0 error),spec↔sch read 逐网对账 0 差异(P1 85 rails + 52 ports)。诚实: 随整板 netport 落网验证,非孤立块单放;未实板 bring-up;U.ITERM strap 仍标 datasheet 待核。",
+  "parts": {
+    "U": {
+      "part": "charger.bq24074_qfn16",
+      "qty": 1,
+      "note": "BQ24074 QFN-16。功能脚(sch read 实测): TS/BAT(2,3)/CE#/EN2/EN1/PGOOD#/VSS/CHG#/OUT(10,11)/ILIM/IN/TMR/ITERM/ISET/EP。BAT 与 OUT 各为双脚同名——两脚都要连(漏一脚=悬空)。"
+    },
+    "J_BAT": {
+      "part": "conn.ph2_3p_ra",
+      "qty": 1,
+      "note": "PH2.0-3P 电池座: 1=VBATT, 2=GND, 3=电芯 NTC(103AT 10k,贴/绑电芯)。第三线是低温禁充的前提——两线座+板上固定电阻会删掉温度保护(评审 P1 高危项)。"
+    },
+    "R_ISET": {
+      "part": "res.178k_0402",
+      "qty": 1,
+      "note": "充电电流 Ich=KISET/R≈890/1.78k≈0.5A(500mAh 电芯 1C)。电芯限 0.5C 则改 3.6k。"
+    },
+    "R_ILIM": {
+      "part": "res.1k07_0402",
+      "qty": 1,
+      "note": "输入限流 KILIM/R=1550/1.07k≈1.45A(KILIM 实测典型 1550,非旧文档的 1600)。1.6k 的 1.0A 档会成为系统+充电的总瓶颈(DPPM 长期抢走充电电流)。"
+    },
+    "R_PG1": {
+      "part": "res.100k_0402",
+      "qty": 1,
+      "note": "PGOOD#(开漏)上拉。100k 而非 1M: PGOOD 关断漏电可达 ~1µA,1M 会掉 1V 危及唤醒判读;100k 仅在输入在位时耗 33µA,电池态无电流。"
+    },
+    "R_TS": {
+      "part": "res.10k_0402",
+      "qty": 1,
+      "note": "DNP(bring-up 临时件): 无 NTC 时单电阻 TS→GND 按 datasheet 无-NTC 接法。量产必须用电芯 NTC,此件禁贴。"
+    },
+    "C_IN1": { "part": "cap.1uf_0402", "qty": 1, "note": "IN 高频去耦,贴 U.IN。" },
+    "C_IN2": { "part": "cap.10uf_0805", "qty": 1, "note": "IN 体电容。" },
+    "C_BAT": { "part": "cap.10uf_0805", "qty": 1, "note": "BAT 去耦,贴 U.BAT。" },
+    "C_OUT": { "part": "cap.10uf_0805", "qty": 1, "note": "OUT(VSYS) 体电容。" },
+    "C_OUT_HF": { "part": "cap.100nf_0402", "qty": 1, "note": "OUT 高频。" },
+    "C_TMR": { "part": "cap.100nf_0402", "qty": 1, "note": "安全定时。按 K_TMR 对 DPPM 拉长后的充电时间核 ≥4-5h,或按 datasheet 禁用(终核)。" },
+    "C_TS": { "part": "cap.100nf_0402", "qty": 1, "note": "TS 近端滤波: NTC 走电池辫线,滤 RF/瞬态防充电误挂起(核 datasheet 允许容值)。" }
+  },
+  "internal_nets": [
+    ["U.IN", "C_IN1.1", "C_IN2.1", "PORT:VIN"],
+    ["U.OUT", "C_OUT.1", "C_OUT_HF.1", "U.EN2", "PORT:VSYS"],
+    ["U.BAT", "J_BAT.1", "C_BAT.1", "PORT:VBATT"],
+    ["U.TS", "C_TS.1", "R_TS.1", "J_BAT.3"],
+    ["U.ILIM", "R_ILIM.1"],
+    ["U.ISET", "R_ISET.1"],
+    ["U.TMR", "C_TMR.1"],
+    ["U.PGOOD#", "R_PG1.1", "PORT:CHG_PG"],
+    ["R_PG1.2", "PORT:VPULL"],
+    ["U.VSS", "U.EP", "U.CE#", "U.EN1", "J_BAT.2", "R_ILIM.2", "R_ISET.2", "R_TS.2", "C_TS.2", "C_IN1.2", "C_IN2.2", "C_BAT.2", "C_OUT.2", "C_OUT_HF.2", "PORT:GND"]
+  ],
+  "ports": {
+    "VIN": {
+      "dir": "in",
+      "at": "U.IN",
+      "desc": "输入电源(上游 5V 母线/USB经OR后的 +5V)",
+      "default_net": "+5V"
+    },
+    "VSYS": {
+      "dir": "out",
+      "at": "U.OUT",
+      "desc": "power-path 系统轨: 输入在位≈4.4-5V,断电无缝切电池≈VBATT。下游 buck/buck-boost 从这里取电",
+      "default_net": "VSYS"
+    },
+    "VBATT": {
+      "dir": "bidir",
+      "at": "U.BAT",
+      "desc": "单节锂电(经 J_BAT)。可再分压做电池电压采样",
+      "default_net": "VBATT"
+    },
+    "CHG_PG": {
+      "dir": "out",
+      "at": "U.PGOOD#",
+      "desc": "输入电源在位指示(开漏+上拉): 低=输入好,高=输入丢失。接 RTC 脚(ESP32-S3 GPIO0-21)可做深睡 ext0 高电平唤醒→断电即时报警",
+      "default_net": "CHG_PG"
+    },
+    "VPULL": {
+      "dir": "in",
+      "at": "R_PG1.2",
+      "desc": "CHG_PG 上拉电源——必须接断电后仍存活的常开轨(如 VSYS 派生的 +3V3),否则断电瞬间读数无效",
+      "default_net": "+3V3"
+    },
+    "GND": {
+      "dir": "bidir",
+      "at": "U.VSS",
+      "desc": "参考地(EP 一并)",
+      "default_net": "GND"
+    }
+  },
+  "schematic_notes": [
+    "EN strap(已内联): EN1→GND、EN2→VSYS = ILIM 外阻编程模式。悬空/接错默认落 USB100 模式(输入限 100mA)——系统会静默转吃电池,现象像『充电器坏了』。EN2 不得接 +3V3 之类的晚上电轨。",
+    "TS 必须接电芯 NTC(J_BAT.3): 户外/车载设备冬季 0°C 以下充锂电会析锂。R_TS 仅 bring-up 临时(DNP-for-production)。bq2407x TS 由内部电流源偏置——轨分压接法不被 datasheet 支持且可能落窗外禁充。",
+    "U.ITERM(pin15) 本块悬空,strap 按 datasheet 待核(标 no-connect 在部分 EDA build 是 no-op,悬空告警属预期,文档记录即可)。U.CHG# 可选接充电指示 LED,默认 NC。",
+    "U.BAT 与 U.OUT 均为双脚同名——接线时两脚都要落网(同 AMS1117 散热片脚教训)。",
+    "CHG_PG 唤醒用法(ESP32-S3): PGOOD# 断电时变高,与 IMU/IGN 的 ANY_LOW ext1 组极性相反——用 ext0(高电平)与 ext1 并存,免加反相器;CHG_PG 必须落在 RTC 脚(GPIO0-21)。",
+    "输入限流与充电电流的预算关系: 下游负载(经 VSYS)+充电电流 共享 ILIM 上限,负载重时 DPPM 自动压缩充电——短途使用场景要核『电池能否充得回来』。"
+  ],
+  "pcb_layout": [
+    { "rule": "cap-adjacency", "target": "C_IN1/C_BAT/C_OUT_HF", "constraint": "高频去耦贴对应引脚", "value": "<=2mm", "severity": "must" },
+    { "rule": "thermal-copper", "target": "U.EP", "constraint": "EP 过孔阵列下沉内层/底层地(线性充电损耗散热)", "value": ">=4 过孔", "severity": "must" },
+    { "rule": "trace-width", "target": "VIN/VSYS/VBATT", "constraint": "功率路径走线加宽(1.45A 输入限流+突发)", "value": ">=0.8mm", "severity": "must" },
+    { "rule": "signal-isolation", "target": "U.TS 走线", "constraint": "TS 是模拟窗口比较输入且走电池辫线,远离功率开关节点/RF", "value": ">=2mm 间距", "severity": "should" }
+  ],
+  "bom_note": "13 件: BQ24074 + PH2.0-3P 电池座 + 编程电阻×3(含 DNP) + 上拉 + 电容×7。适用: 车载/户外常电供电、断电需电池续报的设备(防盗器/记录仪/网关)。配套下游: VSYS→buck-boost(4G 3.8V 轨)/buck(3.3V 数字轨)。"
+}

--- a/skills/easyeda-agent/references/standard-parts.json
+++ b/skills/easyeda-agent/references/standard-parts.json
@@ -234,13 +234,13 @@
     },
     "res.453k_0402": {
       "value": "453k",
-      "mpn": "GR0402F453KTAG00",
-      "lcsc": "C49653416",
-      "deviceUuid": "e3c1e8857b4549ddac2bd93217c56ff0",
+      "mpn": "0402WGF4533TCE",
+      "lcsc": "C27009",
+      "deviceUuid": "377dd2e0e6c44ab88e424bc8f75e5197",
       "package": "0402",
       "class": "res",
       "basic": false,
-      "desc": "auto-added from box-v2 realization 2026-06-26"
+      "desc": "auto-added from box-v2 realization 2026-06-26；lcsc C49653416→C27009(原 C 号 lib by-lcsc 无法解析,2026-07-09 实测)"
     },
     "res.887k_0402": {
       "value": "88.7k",
@@ -254,13 +254,13 @@
     },
     "res.162k_0402": {
       "value": "162k",
-      "mpn": "GR0402F162KTAG00",
-      "lcsc": "C49654427",
-      "deviceUuid": "8280856062f84a9aac732e3406d34fc9",
+      "mpn": "0402WGF1623TCE",
+      "lcsc": "C54068",
+      "deviceUuid": "5709f71aea7e463ba1c8bd6b17afc82f",
       "package": "0402",
       "class": "res",
       "basic": false,
-      "desc": "auto-added from box-v2 realization 2026-06-26"
+      "desc": "auto-added from box-v2 realization 2026-06-26；lcsc C49654427→C54068(原 C 号 lib by-lcsc 无法解析,2026-07-09 实测)"
     },
     "res.47k_0402": {
       "value": "4.7k",
@@ -849,6 +849,126 @@
       "name": "ESP32-S3-WROOM-1U-N8",
       "package": "WIRELM-SMD_ESP32-S3-WROOM-1U",
       "note": "IPEX 外引天线模组;v0.2 case001 主控;2026-07-09"
+    },
+    "charger.bq24074_qfn16": {
+      "value": "BQ24074",
+      "mpn": "BQ24074RGTR",
+      "lcsc": "C54313",
+      "deviceUuid": "545dcdc0f45c4d469fd830849b0edb06",
+      "package": "QFN-16 3x3 EP",
+      "class": "charger",
+      "basic": false,
+      "desc": "锂电充电+power-path(车电↔电池无缝切换);TS 接电芯 NTC,ILIM/ISET 外阻编程。auto-added from 车机V2-fable realization 2026-07-09 (box-v2 评审修正版)"
+    },
+    "buck.tps54360_so8": {
+      "value": "TPS54360B",
+      "mpn": "TPS54360BQDDARQ1",
+      "lcsc": "C2687968",
+      "deviceUuid": "a8b859b29703466aa9edb1fbede5e5d0",
+      "package": "SO-8 EP",
+      "class": "buck",
+      "basic": false,
+      "desc": "60V/3.5A 车规宽压 buck(65V load-dump);非同步需外置续流管。auto-added from 车机V2-fable realization 2026-07-09 (box-v2 评审修正版)"
+    },
+    "pmos.si2301_sot23": {
+      "value": "SI2301",
+      "mpn": "SI2301CDS-T1-GE3",
+      "lcsc": "C10487",
+      "deviceUuid": "f04890a5733d46f3af20c86c64fc9097",
+      "package": "SOT-23",
+      "class": "pmos",
+      "basic": false,
+      "desc": "小信号 P-MOS 高侧开关(-20V/-2.3A,低 Vgs(th));配 NPN 驱动做 GPIO 高有效门控。auto-added from 车机V2-fable realization 2026-07-09 (box-v2 评审修正版)"
+    },
+    "diode.b360a_sma": {
+      "value": "B360A 60V/3A",
+      "mpn": "B360A 60V/3A",
+      "lcsc": "C94193",
+      "deviceUuid": null,
+      "package": "SMA",
+      "class": "diode",
+      "basic": false,
+      "desc": "60V 肖特基续流/OR(符号带 A/K 名);40V 件在 33V TVS 钳位系统会击穿——选它。auto-added from 车机V2-fable realization 2026-07-09 (box-v2 评审修正版)"
+    },
+    "zener.bzt52c12_sod123": {
+      "value": "BZT52C12 12V",
+      "mpn": "BZT52C12-E3-08",
+      "lcsc": "C467524",
+      "deviceUuid": "f92f86f5b0f847aa8d274cf3ca5d0087",
+      "package": "SOD-123",
+      "class": "zener",
+      "basic": false,
+      "desc": "12V 稳压;反接保护 P-MOS 的栅-源钳位标配。auto-added from 车机V2-fable realization 2026-07-09 (box-v2 评审修正版)"
+    },
+    "opto.ltv817s_smd4": {
+      "value": "LTV-817S",
+      "mpn": "LTV-817S-TA1-C",
+      "lcsc": "C109227",
+      "deviceUuid": "94b92fd4314c44a989f28fa11fba3d03",
+      "package": "OPTO-SMD-4",
+      "class": "opto",
+      "basic": false,
+      "desc": "光耦(PC817 兼容,SMD);符号脚为数字 1=A/2=K/3=E/4=C。auto-added from 车机V2-fable realization 2026-07-09 (box-v2 评审修正版)"
+    },
+    "fuse.ptc_1206_500ma": {
+      "value": "0.5A PTC",
+      "mpn": "MF-MSMF050-2500MA",
+      "lcsc": "C3040235",
+      "deviceUuid": "53eb2806e6b54783b60a819d4f1c3e69",
+      "package": "F1206",
+      "class": "fuse",
+      "basic": false,
+      "desc": "自恢复保险(信号/ACC 线过流)。auto-added from 车机V2-fable realization 2026-07-09 (box-v2 评审修正版)"
+    },
+    "conn.ph2_3p_ra": {
+      "value": "PH-3AW",
+      "mpn": "PH-3AW",
+      "lcsc": "C2904959",
+      "deviceUuid": "65400ffaec834789b2a4a29411b0e433",
+      "package": "PH2.0-3P 弯针",
+      "class": "conn",
+      "basic": false,
+      "desc": "带 NTC 第三线的电池座(低温禁充必需)。auto-added from 车机V2-fable realization 2026-07-09 (box-v2 评审修正版)"
+    },
+    "res.1k07_0402": {
+      "value": "1.07k",
+      "mpn": "0402WGF1071TCE",
+      "lcsc": "C26260",
+      "deviceUuid": "9a3dd8c47ab4474084a736e30745138a",
+      "package": "0402",
+      "class": "res",
+      "basic": false,
+      "desc": "E96;BQ24074 ILIM≈1.45A(KILIM=1550)。auto-added from 车机V2-fable realization 2026-07-09 (box-v2 评审修正版)"
+    },
+    "res.10k_0805": {
+      "value": "10k",
+      "mpn": "0805W8F1002T5E",
+      "lcsc": "C17414",
+      "deviceUuid": "e9c34dedae26495c91dced1a655b8614",
+      "package": "0805",
+      "class": "res",
+      "basic": false,
+      "desc": "功耗档 10k(24V 光耦限流 52mW 在额定内)。auto-added from 车机V2-fable realization 2026-07-09 (box-v2 评审修正版)"
+    },
+    "res.470r_0402": {
+      "value": "470Ω",
+      "mpn": "0402WGF4700TCE",
+      "lcsc": "C25117",
+      "deviceUuid": "c404d253ad9e4b6483067cf76635c0e8",
+      "package": "0402",
+      "class": "res",
+      "basic": false,
+      "desc": "GPIO 串阻/滤波。auto-added from 车机V2-fable realization 2026-07-09 (box-v2 评审修正版)"
+    },
+    "res.1m_0402": {
+      "value": "1M",
+      "mpn": "0402WGF1004TCE",
+      "lcsc": "C26083",
+      "deviceUuid": "512988296f6244ad86a0777e419ee0f1",
+      "package": "0402",
+      "class": "res",
+      "basic": false,
+      "desc": "低漏电分压(电池采样 1M/1M=1.9µA)。auto-added from 车机V2-fable realization 2026-07-09 (box-v2 评审修正版)"
     }
   }
 }


### PR DESCRIPTION
库内首个 power-path 块：输入↔电池无缝切换、电芯 NTC 低温禁充(3P 电池座)、EN strap ILIM 模式内联(悬空=USB100 静默陷阱)、PGOOD 100k 上拉断电检测(含 ext0 唤醒用法注记)。依赖 #79（器件先入库）。来源：motobox 车机V2 两轮设计评审修正后的拓扑，validated 于 车机V2-fable 139 件整板落网（place→autoconnect→sch check 0 桥接→bridge-check 收敛→DRC 0 fatal + spec↔sch read 逐网对账 0 差异）；诚实标注：随整板验证非孤立单放、未实板 bring-up。go test ./internal/blocks/ 通过（四块同测）。