### PR TITLE
feat(blocks): pmos_highside_softstart —— P-MOS 高侧负载开关+软启动(电源域门控标准单元)

### DIFF
--- a/internal/blocks/data/pmos_highside_softstart.json
+++ b/internal/blocks/data/pmos_highside_softstart.json
@@ -1,0 +1,90 @@
+{
+  "id": "block.pmos_highside_softstart",
+  "desc": "P-MOS 高侧负载开关(GPIO 高有效)+ RC 软启动:门控 GNSS/传感器/外设电源域,防硬开机冲垮主轨 brownout;深睡 hold 低=断电省电",
+  "category": "power",
+  "author": "@zhoushoujianwork",
+  "contributors": [],
+  "added": "v0.11.0",
+  "updated": "v0.11.0",
+  "source": "datasheet:SI2301 (Vishay — P 沟道 -20V/-2.3A 低 Vgs(th) 高侧开关典型用法) ; 软启动 RC 参数经 motobox 车机V2 二轮复核推导(硬开机冲 10µF 下游电容会把 3.3V 主轨拉垮 ~0.7V 触发 ESP32 brownout,τ=R_SLEW×C_GS≈1ms 斜坡消除)后在 车机V2-fable P3 整板落网(LC29H GNSS 电源域门控)",
+  "validated": "车机V2-fable 2026-07-09 by @zhoushoujianwork: 整板 place→autoconnect→sch check(0 桥接)→bridge-check 收敛→sch drc(0 fatal/0 error),spec↔sch read 逐网对账 0 差异。诚实: 随整板 netport 落网验证,非孤立块单放;未实板 bring-up(软启动斜坡为计算值,实测波形待 bring-up)。",
+  "parts": {
+    "Q_P": {
+      "part": "pmos.si2301_sot23",
+      "qty": 1,
+      "note": "高侧 P-MOS: S=输入轨, D=被门控输出, G=控制。功能脚(sch read 实测): G/S/D。选低 Vgs(th) 件保证 3.3V 轨全导通(Vgs≈-3.0V)。"
+    },
+    "Q_N": {
+      "part": "bjt.s8050_sot23",
+      "qty": 1,
+      "note": "NPN 拉低 P-MOS 栅极,使控制为『GPIO 高=开』(直连 GPIO 则为低有效且深睡默认态危险)。"
+    },
+    "R_GS": {
+      "part": "res.100k_0402",
+      "qty": 1,
+      "note": "栅-源上拉: 默认关断(上电/复位/深睡 GPIO 悬空时输出无电)。"
+    },
+    "R_SLEW": {
+      "part": "res.10k_0402",
+      "qty": 1,
+      "note": "软启动串阻(Q_N.C→Q_P.G): 与 C_GS 组成 τ≈1ms 栅极斜坡。导通态 V_G≈VIN×R_SLEW/(R_SLEW+R_GS)≈0.3V→Vgs≈-3.0V 充分导通。"
+    },
+    "R_B": {
+      "part": "res.10k_0402",
+      "qty": 1,
+      "note": "Q_N 基极限流。"
+    },
+    "C_GS": {
+      "part": "cap.100nf_0402",
+      "qty": 1,
+      "note": "软启动电容(栅-源): 100nF×10k≈1ms 斜坡,限制下游电容充电涌流。"
+    }
+  },
+  "internal_nets": [
+    ["Q_P.S", "R_GS.1", "C_GS.1", "PORT:VIN"],
+    ["Q_P.G", "R_GS.2", "C_GS.2", "R_SLEW.1"],
+    ["R_SLEW.2", "Q_N.C"],
+    ["Q_N.B", "R_B.1"],
+    ["R_B.2", "PORT:EN"],
+    ["Q_N.E", "PORT:GND"],
+    ["Q_P.D", "PORT:VOUT"]
+  ],
+  "ports": {
+    "VIN": {
+      "dir": "in",
+      "at": "Q_P.S",
+      "desc": "输入电源轨(3.3V/5V 均可;Vgs 导通深度随轨压变化,低于 2.5V 轨需换更低 Vgs(th) 件)",
+      "default_net": "+3V3"
+    },
+    "VOUT": {
+      "dir": "out",
+      "at": "Q_P.D",
+      "desc": "被门控电源域(如 +3V3_GNSS)。下游去耦电容属于负载块,不在本块内",
+      "default_net": "+3V3_SW"
+    },
+    "EN": {
+      "dir": "in",
+      "at": "R_B.2",
+      "desc": "GPIO 控制,高=开。深睡场景: gpio_hold 低电平 = 域断电省电(输出脚不需要 RTC 能力)",
+      "default_net": "PWR_EN"
+    },
+    "GND": {
+      "dir": "bidir",
+      "at": "Q_N.E",
+      "desc": "参考地",
+      "default_net": "GND"
+    }
+  },
+  "schematic_notes": [
+    "为什么要软启动: 硬开栅(<1µs)时下游 10µF+ 电容从主轨电荷共享充电,实测推导会把 3.3V 主轨瞬间拉低 ~0.7V——足以复位主控。R_SLEW+C_GS 把开启拉长到 ~1ms,buck 环路来得及响应。",
+    "为什么加 Q_N 而不是 GPIO 直驱栅极: ① 极性变为高有效(直驱是低有效);② 上电/复位/深睡 GPIO 三态时 R_GS 保证默认关断;③ GPIO 电平与轨压解耦。",
+    "被门控域重新上电≠状态保留: 下游芯片(如 GNSS)断电丢 RAM/星历——需要保持的部分(V_BCKP 类)必须走常开轨,不进本块 VOUT。",
+    "关断后主控侧不得继续驱动通往被门控域的信号线(UART TX/复位等要三态),否则经芯片 IO 钳位二极管反灌供电。",
+    "大电流域(>1A)换更低 Rdson 的 P-MOS 或专用负载开关 IC,拓扑不变。"
+  ],
+  "pcb_layout": [
+    { "rule": "cap-adjacency", "target": "C_GS/R_GS", "constraint": "栅极网络贴 Q_P 栅-源脚,回路最短", "value": "<=3mm", "severity": "should" },
+    { "rule": "trace-width", "target": "VIN→Q_P.S→Q_P.D→VOUT", "constraint": "功率路径按域电流加宽", "value": ">=0.5mm(≤1A)", "severity": "must" }
+  ],
+  "bom_note": "6 件: SI2301 + S8050 + 0402 阻容×4。极低成本的电源域门控标准单元;每个『待机要断电』的外设域(GNSS/传感器/RF)各放一份,配 MCU 一个普通输出脚。"
+}

--- a/skills/easyeda-agent/references/standard-parts.json
+++ b/skills/easyeda-agent/references/standard-parts.json
@@ -234,13 +234,13 @@
     },
     "res.453k_0402": {
       "value": "453k",
-      "mpn": "GR0402F453KTAG00",
-      "lcsc": "C49653416",
-      "deviceUuid": "e3c1e8857b4549ddac2bd93217c56ff0",
+      "mpn": "0402WGF4533TCE",
+      "lcsc": "C27009",
+      "deviceUuid": "377dd2e0e6c44ab88e424bc8f75e5197",
       "package": "0402",
       "class": "res",
       "basic": false,
-      "desc": "auto-added from box-v2 realization 2026-06-26"
+      "desc": "auto-added from box-v2 realization 2026-06-26；lcsc C49653416→C27009(原 C 号 lib by-lcsc 无法解析,2026-07-09 实测)"
     },
     "res.887k_0402": {
       "value": "88.7k",
@@ -254,13 +254,13 @@
     },
     "res.162k_0402": {
       "value": "162k",
-      "mpn": "GR0402F162KTAG00",
-      "lcsc": "C49654427",
-      "deviceUuid": "8280856062f84a9aac732e3406d34fc9",
+      "mpn": "0402WGF1623TCE",
+      "lcsc": "C54068",
+      "deviceUuid": "5709f71aea7e463ba1c8bd6b17afc82f",
       "package": "0402",
       "class": "res",
       "basic": false,
-      "desc": "auto-added from box-v2 realization 2026-06-26"
+      "desc": "auto-added from box-v2 realization 2026-06-26；lcsc C49654427→C54068(原 C 号 lib by-lcsc 无法解析,2026-07-09 实测)"
     },
     "res.47k_0402": {
       "value": "4.7k",
@@ -849,6 +849,126 @@
       "name": "ESP32-S3-WROOM-1U-N8",
       "package": "WIRELM-SMD_ESP32-S3-WROOM-1U",
       "note": "IPEX 外引天线模组;v0.2 case001 主控;2026-07-09"
+    },
+    "charger.bq24074_qfn16": {
+      "value": "BQ24074",
+      "mpn": "BQ24074RGTR",
+      "lcsc": "C54313",
+      "deviceUuid": "545dcdc0f45c4d469fd830849b0edb06",
+      "package": "QFN-16 3x3 EP",
+      "class": "charger",
+      "basic": false,
+      "desc": "锂电充电+power-path(车电↔电池无缝切换);TS 接电芯 NTC,ILIM/ISET 外阻编程。auto-added from 车机V2-fable realization 2026-07-09 (box-v2 评审修正版)"
+    },
+    "buck.tps54360_so8": {
+      "value": "TPS54360B",
+      "mpn": "TPS54360BQDDARQ1",
+      "lcsc": "C2687968",
+      "deviceUuid": "a8b859b29703466aa9edb1fbede5e5d0",
+      "package": "SO-8 EP",
+      "class": "buck",
+      "basic": false,
+      "desc": "60V/3.5A 车规宽压 buck(65V load-dump);非同步需外置续流管。auto-added from 车机V2-fable realization 2026-07-09 (box-v2 评审修正版)"
+    },
+    "pmos.si2301_sot23": {
+      "value": "SI2301",
+      "mpn": "SI2301CDS-T1-GE3",
+      "lcsc": "C10487",
+      "deviceUuid": "f04890a5733d46f3af20c86c64fc9097",
+      "package": "SOT-23",
+      "class": "pmos",
+      "basic": false,
+      "desc": "小信号 P-MOS 高侧开关(-20V/-2.3A,低 Vgs(th));配 NPN 驱动做 GPIO 高有效门控。auto-added from 车机V2-fable realization 2026-07-09 (box-v2 评审修正版)"
+    },
+    "diode.b360a_sma": {
+      "value": "B360A 60V/3A",
+      "mpn": "B360A 60V/3A",
+      "lcsc": "C94193",
+      "deviceUuid": null,
+      "package": "SMA",
+      "class": "diode",
+      "basic": false,
+      "desc": "60V 肖特基续流/OR(符号带 A/K 名);40V 件在 33V TVS 钳位系统会击穿——选它。auto-added from 车机V2-fable realization 2026-07-09 (box-v2 评审修正版)"
+    },
+    "zener.bzt52c12_sod123": {
+      "value": "BZT52C12 12V",
+      "mpn": "BZT52C12-E3-08",
+      "lcsc": "C467524",
+      "deviceUuid": "f92f86f5b0f847aa8d274cf3ca5d0087",
+      "package": "SOD-123",
+      "class": "zener",
+      "basic": false,
+      "desc": "12V 稳压;反接保护 P-MOS 的栅-源钳位标配。auto-added from 车机V2-fable realization 2026-07-09 (box-v2 评审修正版)"
+    },
+    "opto.ltv817s_smd4": {
+      "value": "LTV-817S",
+      "mpn": "LTV-817S-TA1-C",
+      "lcsc": "C109227",
+      "deviceUuid": "94b92fd4314c44a989f28fa11fba3d03",
+      "package": "OPTO-SMD-4",
+      "class": "opto",
+      "basic": false,
+      "desc": "光耦(PC817 兼容,SMD);符号脚为数字 1=A/2=K/3=E/4=C。auto-added from 车机V2-fable realization 2026-07-09 (box-v2 评审修正版)"
+    },
+    "fuse.ptc_1206_500ma": {
+      "value": "0.5A PTC",
+      "mpn": "MF-MSMF050-2500MA",
+      "lcsc": "C3040235",
+      "deviceUuid": "53eb2806e6b54783b60a819d4f1c3e69",
+      "package": "F1206",
+      "class": "fuse",
+      "basic": false,
+      "desc": "自恢复保险(信号/ACC 线过流)。auto-added from 车机V2-fable realization 2026-07-09 (box-v2 评审修正版)"
+    },
+    "conn.ph2_3p_ra": {
+      "value": "PH-3AW",
+      "mpn": "PH-3AW",
+      "lcsc": "C2904959",
+      "deviceUuid": "65400ffaec834789b2a4a29411b0e433",
+      "package": "PH2.0-3P 弯针",
+      "class": "conn",
+      "basic": false,
+      "desc": "带 NTC 第三线的电池座(低温禁充必需)。auto-added from 车机V2-fable realization 2026-07-09 (box-v2 评审修正版)"
+    },
+    "res.1k07_0402": {
+      "value": "1.07k",
+      "mpn": "0402WGF1071TCE",
+      "lcsc": "C26260",
+      "deviceUuid": "9a3dd8c47ab4474084a736e30745138a",
+      "package": "0402",
+      "class": "res",
+      "basic": false,
+      "desc": "E96;BQ24074 ILIM≈1.45A(KILIM=1550)。auto-added from 车机V2-fable realization 2026-07-09 (box-v2 评审修正版)"
+    },
+    "res.10k_0805": {
+      "value": "10k",
+      "mpn": "0805W8F1002T5E",
+      "lcsc": "C17414",
+      "deviceUuid": "e9c34dedae26495c91dced1a655b8614",
+      "package": "0805",
+      "class": "res",
+      "basic": false,
+      "desc": "功耗档 10k(24V 光耦限流 52mW 在额定内)。auto-added from 车机V2-fable realization 2026-07-09 (box-v2 评审修正版)"
+    },
+    "res.470r_0402": {
+      "value": "470Ω",
+      "mpn": "0402WGF4700TCE",
+      "lcsc": "C25117",
+      "deviceUuid": "c404d253ad9e4b6483067cf76635c0e8",
+      "package": "0402",
+      "class": "res",
+      "basic": false,
+      "desc": "GPIO 串阻/滤波。auto-added from 车机V2-fable realization 2026-07-09 (box-v2 评审修正版)"
+    },
+    "res.1m_0402": {
+      "value": "1M",
+      "mpn": "0402WGF1004TCE",
+      "lcsc": "C26083",
+      "deviceUuid": "512988296f6244ad86a0777e419ee0f1",
+      "package": "0402",
+      "class": "res",
+      "basic": false,
+      "desc": "低漏电分压(电池采样 1M/1M=1.9µA)。auto-added from 车机V2-fable realization 2026-07-09 (box-v2 评审修正版)"
     }
   }
 }


### PR DESCRIPTION
GPIO 高有效、默认关断、τ≈1ms RC 软启动（硬开栅冲下游电容会把主轨拉垮 ~0.7V brownout——计算依据在 notes）。适用一切『待机要断电』的外设域(GNSS/传感器/RF)。依赖 #79（器件先入库）。来源：motobox 车机V2 两轮设计评审修正后的拓扑，validated 于 车机V2-fable 139 件整板落网（place→autoconnect→sch check 0 桥接→bridge-check 收敛→DRC 0 fatal + spec↔sch read 逐网对账 0 差异）；诚实标注：随整板验证非孤立单放、未实板 bring-up。go test ./internal/blocks/ 通过（四块同测）。