### PR TITLE
feat(blocks): opto_acc_ign_detect —— 车载 ACC/点火光耦检测前端

### DIFF
--- a/internal/blocks/data/opto_acc_ign_detect.json
+++ b/internal/blocks/data/opto_acc_ign_detect.json
@@ -1,0 +1,96 @@
+{
+  "id": "block.opto_acc_ign_detect",
+  "desc": "车载 ACC/点火检测前端(PTC+TVS+限流+光耦隔离+RC 硬化): 12-24V 点火线安全进 MCU GPIO,低有效;strapping 脚可用",
+  "category": "sensing",
+  "author": "@zhoushoujianwork",
+  "contributors": [],
+  "added": "v0.11.0",
+  "updated": "v0.11.0",
+  "source": "datasheet:LTV-817 (Liteon — 光耦 CTR 特性/IF 工作点) + motobox IGNITION_DETECT_INPUT_DESIGN(项目级隔离硬化设计文档: PTC/TVS/RC 要求) ; 限流值经车机V2 二轮复核推导(22k 在 12V 下 IF 仅 0.49mA,无 CTR 分档不保拉低;10k/0805 兼顾 12V 1.08mA 与 24V 52mW)后在 车机V2-fable P4 整板落网",
+  "validated": "车机V2-fable 2026-07-09 by @zhoushoujianwork: 整板 place→autoconnect→sch check(0 桥接)→bridge-check 收敛→sch drc(0 fatal/0 error),spec↔sch read 逐网对账 0 差异。诚实: 随整板 netport 落网验证,非孤立块单放;未实板 bring-up(光耦 CTR 温度裕度待实测)。",
+  "parts": {
+    "F_ACC": {
+      "part": "fuse.ptc_1206_500ma",
+      "qty": 1,
+      "note": "ACC 线自恢复保险(线束短路/搭铁保护)。"
+    },
+    "D_ACC": {
+      "part": "diode.smbj33a_smb",
+      "qty": 1,
+      "note": "ACC 线浪涌 TVS(点火线毛刺/负载突降): K→信号, A→GND。"
+    },
+    "R_LIM": {
+      "part": "res.10k_0805",
+      "qty": 1,
+      "note": "光耦 LED 限流: 12V 时 IF≈1.08mA(无 CTR 分档件也保得住拉低), 24V 时 52mW 在 0805 额定内。⚠不要用 22k——12V 下只有 0.49mA,输出可能拉不到 VIL(评审二轮实证);也不要 0402 小封装——24V 下超额定。"
+    },
+    "U_OPT": {
+      "part": "opto.ltv817s_smd4",
+      "qty": 1,
+      "note": "光耦隔离(车身电气域↔MCU 域)。符号脚为数字(sch read 实测): 1=阳极A, 2=阴极K, 3=发射极E, 4=集电极C(PC817 标准脚序)。"
+    },
+    "R_PU": {
+      "part": "res.10k_0402",
+      "qty": 1,
+      "note": "集电极上拉到 MCU 域 3.3V。"
+    },
+    "R_S": {
+      "part": "res.470r_0402",
+      "qty": 1,
+      "note": "GPIO 串阻(与 C_F 组成输出 RC,τ≈47µs 毛刺滤除;strapping 脚要求)。"
+    },
+    "C_F": {
+      "part": "cap.100nf_0402",
+      "qty": 1,
+      "note": "GPIO 端滤波电容(贴 MCU 脚)。"
+    }
+  },
+  "internal_nets": [
+    ["PORT:IGN_12V", "F_ACC.1"],
+    ["F_ACC.2", "R_LIM.1", "D_ACC.K"],
+    ["R_LIM.2", "U_OPT.1"],
+    ["U_OPT.4", "R_PU.1", "R_S.1"],
+    ["R_PU.2", "PORT:VPULL"],
+    ["R_S.2", "C_F.1", "PORT:IGN_DETECT"],
+    ["U_OPT.2", "U_OPT.3", "D_ACC.A", "C_F.2", "PORT:GND"]
+  ],
+  "ports": {
+    "IGN_12V": {
+      "dir": "in",
+      "at": "F_ACC.1",
+      "desc": "车辆 ACC/点火线(12-24V,经线束端子进板;配 block.vehicle_input_tps54360_5v 的 IGN_12V 透传口)",
+      "default_net": "IGN_12V"
+    },
+    "IGN_DETECT": {
+      "dir": "out",
+      "at": "R_S.2",
+      "desc": "MCU GPIO,低有效(ACC 通→光耦导通→拉低)。RC 硬化后可安全用在 strapping 脚(如 ESP32-S3 IO3——但该板永不烧 STRAP_JTAG_SEL eFuse);RTC 脚上可做 ext1 ANY_LOW 深睡唤醒(点火即醒)",
+      "default_net": "IGN_DETECT"
+    },
+    "VPULL": {
+      "dir": "in",
+      "at": "R_PU.2",
+      "desc": "输出上拉电源(MCU 域 3.3V)",
+      "default_net": "+3V3"
+    },
+    "GND": {
+      "dir": "bidir",
+      "at": "U_OPT.3",
+      "desc": "地。注意本块光耦两侧共地(隔离的是电压域与瞬态,不是地隔离);需要真地隔离时输入侧回线单独走",
+      "default_net": "GND"
+    }
+  },
+  "schematic_notes": [
+    "低有效语义: ACC 通电→LED 亮→晶体管导通→IGN_DETECT 拉低;固件按 level==0 判『点火开』。",
+    "限流值是本块的核心工程点: 必须同时满足 12V 最小 IF(CTR 无分档件的拉低裕度)与 24V 功耗(封装额定)。10k/0805 是两约束的交集;改值前先算两端。",
+    "输出 RC(R_S+C_F)不可省: ① 点火线毛刺滤除;② IGN_DETECT 常落在 strapping 脚,复位窗口内的电平抖动会改启动模式。",
+    "PTC+TVS 保护的是『点火线』而非主电源输入——主输入的保险/TVS 在电源入口块,两者不互相替代。",
+    "U_OPT 符号脚为数字 1-4,映射见 part note(1=A/2=K/3=E/4=C);块内网表已按此写死,复用时零改号。"
+  ],
+  "pcb_layout": [
+    { "rule": "cap-adjacency", "target": "C_F", "constraint": "滤波电容贴 MCU GPIO 脚(不是贴光耦)", "value": "<=3mm", "severity": "must" },
+    { "rule": "domain-separation", "target": "F_ACC/D_ACC/R_LIM/U_OPT 输入侧", "constraint": "车身电气域器件靠端子聚集,与 MCU 域隔开;光耦跨在两域边界", "value": ">=3mm 域间距", "severity": "should" },
+    { "rule": "trace-clearance", "target": "IGN_12V 走线", "constraint": "24V 线与低压信号保持间距", "value": ">=0.5mm", "severity": "must" }
+  ],
+  "bom_note": "7 件: PTC+TVS+10k0805+光耦+上拉+串阻+滤波电容。车载/摩托设备的 ACC 检测标准前端;输出直接喂 MCU(可深睡唤醒)。"
+}

--- a/skills/easyeda-agent/references/standard-parts.json
+++ b/skills/easyeda-agent/references/standard-parts.json
@@ -234,13 +234,13 @@
     },
     "res.453k_0402": {
       "value": "453k",
-      "mpn": "GR0402F453KTAG00",
-      "lcsc": "C49653416",
-      "deviceUuid": "e3c1e8857b4549ddac2bd93217c56ff0",
+      "mpn": "0402WGF4533TCE",
+      "lcsc": "C27009",
+      "deviceUuid": "377dd2e0e6c44ab88e424bc8f75e5197",
       "package": "0402",
       "class": "res",
       "basic": false,
-      "desc": "auto-added from box-v2 realization 2026-06-26"
+      "desc": "auto-added from box-v2 realization 2026-06-26；lcsc C49653416→C27009(原 C 号 lib by-lcsc 无法解析,2026-07-09 实测)"
     },
     "res.887k_0402": {
       "value": "88.7k",
@@ -254,13 +254,13 @@
     },
     "res.162k_0402": {
       "value": "162k",
-      "mpn": "GR0402F162KTAG00",
-      "lcsc": "C49654427",
-      "deviceUuid": "8280856062f84a9aac732e3406d34fc9",
+      "mpn": "0402WGF1623TCE",
+      "lcsc": "C54068",
+      "deviceUuid": "5709f71aea7e463ba1c8bd6b17afc82f",
       "package": "0402",
       "class": "res",
       "basic": false,
-      "desc": "auto-added from box-v2 realization 2026-06-26"
+      "desc": "auto-added from box-v2 realization 2026-06-26；lcsc C49654427→C54068(原 C 号 lib by-lcsc 无法解析,2026-07-09 实测)"
     },
     "res.47k_0402": {
       "value": "4.7k",
@@ -849,6 +849,126 @@
       "name": "ESP32-S3-WROOM-1U-N8",
       "package": "WIRELM-SMD_ESP32-S3-WROOM-1U",
       "note": "IPEX 外引天线模组;v0.2 case001 主控;2026-07-09"
+    },
+    "charger.bq24074_qfn16": {
+      "value": "BQ24074",
+      "mpn": "BQ24074RGTR",
+      "lcsc": "C54313",
+      "deviceUuid": "545dcdc0f45c4d469fd830849b0edb06",
+      "package": "QFN-16 3x3 EP",
+      "class": "charger",
+      "basic": false,
+      "desc": "锂电充电+power-path(车电↔电池无缝切换);TS 接电芯 NTC,ILIM/ISET 外阻编程。auto-added from 车机V2-fable realization 2026-07-09 (box-v2 评审修正版)"
+    },
+    "buck.tps54360_so8": {
+      "value": "TPS54360B",
+      "mpn": "TPS54360BQDDARQ1",
+      "lcsc": "C2687968",
+      "deviceUuid": "a8b859b29703466aa9edb1fbede5e5d0",
+      "package": "SO-8 EP",
+      "class": "buck",
+      "basic": false,
+      "desc": "60V/3.5A 车规宽压 buck(65V load-dump);非同步需外置续流管。auto-added from 车机V2-fable realization 2026-07-09 (box-v2 评审修正版)"
+    },
+    "pmos.si2301_sot23": {
+      "value": "SI2301",
+      "mpn": "SI2301CDS-T1-GE3",
+      "lcsc": "C10487",
+      "deviceUuid": "f04890a5733d46f3af20c86c64fc9097",
+      "package": "SOT-23",
+      "class": "pmos",
+      "basic": false,
+      "desc": "小信号 P-MOS 高侧开关(-20V/-2.3A,低 Vgs(th));配 NPN 驱动做 GPIO 高有效门控。auto-added from 车机V2-fable realization 2026-07-09 (box-v2 评审修正版)"
+    },
+    "diode.b360a_sma": {
+      "value": "B360A 60V/3A",
+      "mpn": "B360A 60V/3A",
+      "lcsc": "C94193",
+      "deviceUuid": null,
+      "package": "SMA",
+      "class": "diode",
+      "basic": false,
+      "desc": "60V 肖特基续流/OR(符号带 A/K 名);40V 件在 33V TVS 钳位系统会击穿——选它。auto-added from 车机V2-fable realization 2026-07-09 (box-v2 评审修正版)"
+    },
+    "zener.bzt52c12_sod123": {
+      "value": "BZT52C12 12V",
+      "mpn": "BZT52C12-E3-08",
+      "lcsc": "C467524",
+      "deviceUuid": "f92f86f5b0f847aa8d274cf3ca5d0087",
+      "package": "SOD-123",
+      "class": "zener",
+      "basic": false,
+      "desc": "12V 稳压;反接保护 P-MOS 的栅-源钳位标配。auto-added from 车机V2-fable realization 2026-07-09 (box-v2 评审修正版)"
+    },
+    "opto.ltv817s_smd4": {
+      "value": "LTV-817S",
+      "mpn": "LTV-817S-TA1-C",
+      "lcsc": "C109227",
+      "deviceUuid": "94b92fd4314c44a989f28fa11fba3d03",
+      "package": "OPTO-SMD-4",
+      "class": "opto",
+      "basic": false,
+      "desc": "光耦(PC817 兼容,SMD);符号脚为数字 1=A/2=K/3=E/4=C。auto-added from 车机V2-fable realization 2026-07-09 (box-v2 评审修正版)"
+    },
+    "fuse.ptc_1206_500ma": {
+      "value": "0.5A PTC",
+      "mpn": "MF-MSMF050-2500MA",
+      "lcsc": "C3040235",
+      "deviceUuid": "53eb2806e6b54783b60a819d4f1c3e69",
+      "package": "F1206",
+      "class": "fuse",
+      "basic": false,
+      "desc": "自恢复保险(信号/ACC 线过流)。auto-added from 车机V2-fable realization 2026-07-09 (box-v2 评审修正版)"
+    },
+    "conn.ph2_3p_ra": {
+      "value": "PH-3AW",
+      "mpn": "PH-3AW",
+      "lcsc": "C2904959",
+      "deviceUuid": "65400ffaec834789b2a4a29411b0e433",
+      "package": "PH2.0-3P 弯针",
+      "class": "conn",
+      "basic": false,
+      "desc": "带 NTC 第三线的电池座(低温禁充必需)。auto-added from 车机V2-fable realization 2026-07-09 (box-v2 评审修正版)"
+    },
+    "res.1k07_0402": {
+      "value": "1.07k",
+      "mpn": "0402WGF1071TCE",
+      "lcsc": "C26260",
+      "deviceUuid": "9a3dd8c47ab4474084a736e30745138a",
+      "package": "0402",
+      "class": "res",
+      "basic": false,
+      "desc": "E96;BQ24074 ILIM≈1.45A(KILIM=1550)。auto-added from 车机V2-fable realization 2026-07-09 (box-v2 评审修正版)"
+    },
+    "res.10k_0805": {
+      "value": "10k",
+      "mpn": "0805W8F1002T5E",
+      "lcsc": "C17414",
+      "deviceUuid": "e9c34dedae26495c91dced1a655b8614",
+      "package": "0805",
+      "class": "res",
+      "basic": false,
+      "desc": "功耗档 10k(24V 光耦限流 52mW 在额定内)。auto-added from 车机V2-fable realization 2026-07-09 (box-v2 评审修正版)"
+    },
+    "res.470r_0402": {
+      "value": "470Ω",
+      "mpn": "0402WGF4700TCE",
+      "lcsc": "C25117",
+      "deviceUuid": "c404d253ad9e4b6483067cf76635c0e8",
+      "package": "0402",
+      "class": "res",
+      "basic": false,
+      "desc": "GPIO 串阻/滤波。auto-added from 车机V2-fable realization 2026-07-09 (box-v2 评审修正版)"
+    },
+    "res.1m_0402": {
+      "value": "1M",
+      "mpn": "0402WGF1004TCE",
+      "lcsc": "C26083",
+      "deviceUuid": "512988296f6244ad86a0777e419ee0f1",
+      "package": "0402",
+      "class": "res",
+      "basic": false,
+      "desc": "低漏电分压(电池采样 1M/1M=1.9µA)。auto-added from 车机V2-fable realization 2026-07-09 (box-v2 评审修正版)"
     }
   }
 }


### PR DESCRIPTION
PTC+TVS+10k/0805 限流(12V IF 与 24V 功耗双约束交集,22k 反例已注)+光耦+RC 硬化(strapping 脚可用/可深睡唤醒)。与 vehicle_input 块的 IGN_12V 透传口配套。依赖 #79（器件先入库）。来源：motobox 车机V2 两轮设计评审修正后的拓扑，validated 于 车机V2-fable 139 件整板落网（place→autoconnect→sch check 0 桥接→bridge-check 收敛→DRC 0 fatal + spec↔sch read 逐网对账 0 差异）；诚实标注：随整板验证非孤立单放、未实板 bring-up。go test ./internal/blocks/ 通过（四块同测）。