### PR TITLE
fix: auto-place 保留 2D floorplan 并跳过边缘连接器

### DIFF
--- a/internal/app/cmd_pcb.go
+++ b/internal/app/cmd_pcb.go
@@ -1799,7 +1799,11 @@ nothing overlaps:
   • decoupling caps land by their power pin (3V3/VCC), resistors by their signal pin
   • an LED chains next to its series resistor (shared signal net)
 With 2+ main chips, any that overlap / sit closer than --multi-gap are spread into a
-row (leftmost stays put) before satellites are placed; --multi-gap 0 disables that.
+row (leftmost stays put) before satellites are placed. Use --multi-gap 0 to PRESERVE
+a pre-anchored layout untouched; spreading is also auto-skipped when the chips already
+form a 2D floorplan (≥2 columns with vertical stacking) so a hand-anchored grid is not
+flattened into a row. Board-edge connectors (J*/CN*/USB*/… designators, low pin count,
+large footprint) are skipped and left for 'pcb place-constrained'.
 This is a SEED, not a final layout — verify with 'pcb drc'.
 
   easyeda pcb auto-place --project ceshi --dry-run   # print the plan, move nothing

--- a/internal/app/pcb_autoplace.go
+++ b/internal/app/pcb_autoplace.go
@@ -121,6 +121,52 @@ func isGlobalNet(net string) bool {
 	return reGlobalNet1.MatchString(n) || reGlobalNet2.MatchString(n)
 }
 
+// connectorDesRe matches board-edge connector designators (J1, CN2, CON3, USB1,
+// SIM1, BAT1…) so the planner can leave them for `place-constrained` instead of
+// dragging them toward a chip by their global GND pad. Prefixes are the EDA-wide
+// convention for connectors/plugs; USB/SIM/BAT cover the common edge parts.
+var connectorDesRe = regexp.MustCompile(`(?i)^(?:J|CN|CON|USB|SIM|BAT)\d`)
+
+// edgeConnectorMinDim is the min bbox extent (mil) for the "relatively large
+// footprint" half of the connector heuristic — real board-edge connectors dwarf a
+// decoupling cap/resistor (which top out ~180mil), so 200mil safely separates them.
+const edgeConnectorMinDim = 200.0
+
+// isEdgeConnector flags a low-pin, connector-designated, relatively large part
+// (e.g. a 3P J_VEH power terminal) that belongs on the board edge — auto-place
+// must NOT pull it toward a chip by its global GND pad; `place-constrained` owns
+// it. mainPins-or-more-pin parts are chips (handled elsewhere) and never match.
+func isEdgeConnector(c apComp, mainPins int) bool {
+	if !connectorDesRe.MatchString(strings.TrimSpace(c.designator)) {
+		return false
+	}
+	if c.distinctPins() >= mainPins {
+		return false
+	}
+	return math.Max(c.width(), c.height()) >= edgeConnectorMinDim
+}
+
+// mainsAre2D reports whether the anchored main chips already form an intentional
+// 2D floorplan (≥2 columns with vertical stacking) rather than a single row. It
+// looks for a pair whose X-projections overlap (spaceMains would judge them "too
+// close" and push one right) yet whose Y-projections do NOT overlap (they are
+// stacked, not colliding). Flattening such a layout into a row is exactly the bug
+// in #91, so when detected the caller preserves the anchors.
+func mainsAre2D(comps []apComp, mains []int) bool {
+	for i := 0; i < len(mains); i++ {
+		a := comps[mains[i]]
+		for j := i + 1; j < len(mains); j++ {
+			b := comps[mains[j]]
+			xOverlap := a.minX < b.maxX && b.minX < a.maxX
+			yOverlap := a.minY < b.maxY && b.minY < a.maxY
+			if xOverlap && !yOverlap {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 type apEdge int
 
 const (
@@ -195,18 +241,24 @@ type assignment struct {
 // Returns the moves plus diagnostics for anything left unplaced.
 func planAutoPlace(comps []apComp, opt apOptions) ([]apMove, []apDiag) {
 	var mains, sats []int
+	var diags []apDiag
 	for i, c := range comps {
 		if !c.hasBBox {
 			continue
 		}
 		if c.distinctPins() >= opt.mainPins {
 			mains = append(mains, i)
-		} else if !c.locked {
+		} else if c.locked {
+			continue
+		} else if isEdgeConnector(c, opt.mainPins) {
+			// Board-edge connector (J*/CN*/…): leave it where the user (or
+			// place-constrained) put it — don't drag it toward a chip by its GND pad.
+			diags = append(diags, apDiag{c.designator, "board-edge connector — skipped, use `place-constrained` to seat it on the edge"})
+		} else {
 			sats = append(sats, i)
 		}
 	}
 
-	var diags []apDiag
 	if len(mains) == 0 {
 		for _, s := range sats {
 			diags = append(diags, apDiag{comps[s].designator, "no main chip on board (>= mainPins distinct pins) to anchor against"})
@@ -221,7 +273,7 @@ func planAutoPlace(comps []apComp, opt apOptions) ([]apMove, []apDiag) {
 	// then placed against the chips' NEW positions, so we run the rest of the
 	// planner on a working copy whose mains are shifted, and emit a move per shifted
 	// main. Single-chip boards (and multiGap=0) skip this entirely → unchanged v1.1.
-	if opt.multiGap > 0 && len(mains) > 1 {
+	if opt.multiGap > 0 && len(mains) > 1 && !mainsAre2D(comps, mains) {
 		shifts := spaceMains(comps, mains, opt.multiGap)
 		work := make([]apComp, len(comps))
 		copy(work, comps)

--- a/internal/app/pcb_autoplace_test.go
+++ b/internal/app/pcb_autoplace_test.go
@@ -248,3 +248,88 @@ func TestPlanAutoPlace_MultiChipSpacing(t *testing.T) {
 		}
 	}
 }
+
+// A pre-anchored 2D floorplan (#91): two columns of 8-pin chips, each column
+// stacked vertically. spaceMains would judge the columns' X-projections as
+// "overlapping / too close" and flatten them into a row; the 2D guard must
+// preserve the anchors so no chip-spacing move is emitted.
+func floorplan2DBoard() []apComp {
+	mk8 := func(id, des string, cx, cy float64) apComp {
+		pads := []apPad{
+			p("1", "", cx, cy), p("2", "", cx, cy), p("3", "", cx, cy), p("4", "", cx, cy),
+			p("5", "", cx, cy), p("6", "", cx, cy), p("7", "", cx, cy), p("8", "", cx, cy),
+		}
+		return mkComp(id, des, cx, cy, 400, 400, pads)
+	}
+	// Column A at x≈0, column B at x≈100 (X-projections overlap → 1D would spread),
+	// but each column has two vertically stacked chips (Y-projections disjoint).
+	return []apComp{
+		mk8("u1", "U1", 0, 0),      // col A, lower
+		mk8("u2", "U2", 0, 600),    // col A, upper (stacked over U1)
+		mk8("u3", "U3", 100, 0),    // col B, lower
+		mk8("u4", "U4", 100, 600),  // col B, upper
+	}
+}
+
+func TestPlanAutoPlace_Preserve2DFloorplan(t *testing.T) {
+	opt := defaultApOptions() // multiGap = 150
+	moves, _ := planAutoPlace(floorplan2DBoard(), opt)
+	for _, m := range moves {
+		if m.Via == "chip-spacing" {
+			t.Errorf("2D floorplan must be preserved, got chip-spacing move: %+v", m)
+		}
+	}
+}
+
+// A low-pin, large-bbox connector on the board edge (#91): J_VEH shares GND with
+// the chip but must NOT be dragged toward it — it's skipped with a diag so
+// place-constrained can seat it on the edge.
+func TestPlanAutoPlace_SkipsEdgeConnector(t *testing.T) {
+	comps := ceshiBoard()
+	// 3-pin power terminal on the left edge, GND tied to the global net.
+	jveh := mkComp("jveh", "J1", -500, -1855, 300, 250, []apPad{
+		p("1", "VEH_12V", 0, 0), p("2", "GND", 0, 0), p("3", "GND", 0, 0),
+	})
+	comps = append(comps, jveh)
+
+	moves, diags := planAutoPlace(comps, defaultApOptions())
+	for _, m := range moves {
+		if m.Designator == "J1" {
+			t.Errorf("edge connector J1 should not be moved, got %+v", m)
+		}
+	}
+	found := false
+	for _, d := range diags {
+		if d.Designator == "J1" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a skip diag for edge connector J1, got diags: %+v", diags)
+	}
+}
+
+// isEdgeConnector guards on all three signals: designator prefix, low pin count,
+// and a relatively large footprint. A small J* (a 2-pin test point) or a chip-like
+// connector must not be treated as a board-edge connector.
+func TestIsEdgeConnector(t *testing.T) {
+	big := mkComp("j", "J1", 0, 0, 300, 250, []apPad{p("1", "A", 0, 0), p("2", "GND", 0, 0)})
+	if !isEdgeConnector(big, 8) {
+		t.Error("large low-pin J1 should be an edge connector")
+	}
+	small := mkComp("j", "J2", 0, 0, 80, 45, []apPad{p("1", "A", 0, 0), p("2", "GND", 0, 0)})
+	if isEdgeConnector(small, 8) {
+		t.Error("small J2 (below size floor) should NOT be an edge connector")
+	}
+	notConn := mkComp("r", "R9", 0, 0, 300, 250, []apPad{p("1", "A", 0, 0), p("2", "GND", 0, 0)})
+	if isEdgeConnector(notConn, 8) {
+		t.Error("R9 (non-connector designator) should NOT be an edge connector")
+	}
+	bigChip := mkComp("j", "J3", 0, 0, 300, 250, []apPad{
+		p("1", "", 0, 0), p("2", "", 0, 0), p("3", "", 0, 0), p("4", "", 0, 0),
+		p("5", "", 0, 0), p("6", "", 0, 0), p("7", "", 0, 0), p("8", "", 0, 0),
+	})
+	if isEdgeConnector(bigChip, 8) {
+		t.Error("8-pin J3 (chip-like) should NOT be classed as an edge connector")
+	}
+}


### PR DESCRIPTION
Fixes #91

## 问题
1. `--multi-gap` 默认 150 让 spaceMains 把预锚定的 2D floorplan 沿 x 轴摊平成一行。
2. 低引脚大 bbox 的边缘连接器(如 J_VEH)被当卫星按最近 GND 焊盘拉向芯片,与芯片重叠。

## 改动
- pcb_autoplace.go: 新增 mainsAre2D 检测——当主芯片已构成 2D 分布(≥2 列 + 纵向堆叠,即 X 投影重叠但 Y 投影不重叠)时跳过 spaceMains,保留锚点。
- pcb_autoplace.go: 新增 isEdgeConnector 启发式(designator J/CN/CON/USB/SIM/BAT 前缀 + 引脚数 < mainPins + bbox 最大边 ≥ 200mil),分类阶段将其排除出 sats 并给出 diag,交给 place-constrained。
- cmd_pcb.go: --help 长说明显著标注 --multi-gap 0=保留预布局、2D 自动跳过、边缘连接器跳过。

## 测试
- 新增 TestPlanAutoPlace_Preserve2DFloorplan:两列纵向堆叠芯片不产生 chip-spacing move。
- 新增 TestPlanAutoPlace_SkipsEdgeConnector:J1 不被移动且产生 skip diag。
- 新增 TestIsEdgeConnector:三信号(前缀/引脚/尺寸)守卫的边界用例。
- go build ./... 通过;go test ./internal/app/ 全绿。

## 未覆盖
纯启发式单元测试,未在真实 EasyEDA 车机 V2 板上做端到端 runtime 验证。