### PR TITLE
fix: stitch stub avoids other-net vias and tracks

### DIFF
--- a/internal/app/pcb_powerplanes_stitch.go
+++ b/internal/app/pcb_powerplanes_stitch.go
@@ -115,10 +115,13 @@ func planStitchViasForNet(net string, padsAll []pcbPadP, tracks []pcbTrack, vias
 		}
 		return true
 	}
-	// The stub is short, but it can still graze an adjacent other-net pad —
-	// reject a candidate whose stub does.
-	stubClear := func(px, py, vx, vy float64) bool {
-		band := ctx.clearance + nominalPadHalf + ctx.stubW/2
+	// The stub is short, but it can still graze an adjacent other-net pad, an
+	// other-net via (through-hole → clashes on the stub's layer), or an other-net
+	// track on the same layer — reject a candidate whose stub does. layer is the
+	// stub's copper layer (the pad's layer); track checks are layer-scoped, while
+	// pads/vias are treated as present on every layer (conservative for shorts).
+	stubClear := func(px, py, vx, vy float64, layer int) bool {
+		padB := ctx.clearance + nominalPadHalf + ctx.stubW/2
 		for _, o := range padsAll {
 			if o.Net == net {
 				continue
@@ -126,7 +129,40 @@ func planStitchViasForNet(net string, padsAll []pcbPadP, tracks []pcbTrack, vias
 			if samePoint(o.X, o.Y, px, py) {
 				continue
 			}
-			if segPtDist(o.X, o.Y, px, py, vx, vy) < band {
+			if segPtDist(o.X, o.Y, px, py, vx, vy) < padB {
+				return false
+			}
+		}
+		// Vias are through-hole: an other-net via clashes with the stub copper on
+		// any layer. The stub's own via endpoint (vx,vy) is same-net, skipped below.
+		viaHit := func(cx, cy, r float64) bool {
+			if samePoint(cx, cy, vx, vy) {
+				return false // the stub's own endpoint via
+			}
+			return segPtDist(cx, cy, px, py, vx, vy) < ctx.clearance+r+ctx.stubW/2
+		}
+		for _, v := range vias {
+			if v.Net == net {
+				continue
+			}
+			if viaHit(v.X, v.Y, v.Dia/2) {
+				return false
+			}
+		}
+		for _, pv := range priorVias {
+			if pv.Net == net {
+				continue
+			}
+			if viaHit(pv.X, pv.Y, viaR) {
+				return false
+			}
+		}
+		// Other-net tracks on the same layer: segment-to-segment distance.
+		for _, t := range tracks {
+			if t.Net == net || t.Layer != layer {
+				continue
+			}
+			if segSegDist(px, py, vx, vy, t.X1, t.Y1, t.X2, t.Y2) < ctx.clearance+t.Width/2+ctx.stubW/2 {
 				return false
 			}
 		}
@@ -145,7 +181,7 @@ func planStitchViasForNet(net string, padsAll []pcbPadP, tracks []pcbTrack, vias
 		// Share: a same-net via already planned (this run) within reach → fan in.
 		shared := false
 		for _, pv := range planned {
-			if math.Hypot(p.X-pv.x, p.Y-pv.y) <= ctx.shareDist && stubClear(p.X, p.Y, pv.x, pv.y) {
+			if math.Hypot(p.X-pv.x, p.Y-pv.y) <= ctx.shareDist && stubClear(p.X, p.Y, pv.x, pv.y, p.Layer) {
 				res.Stubs = append(res.Stubs, rtSeg{Net: net, X1: p.X, Y1: p.Y, X2: pv.x, Y2: pv.y, Layer: p.Layer, Width: ctx.stubW})
 				res.Shared++
 				shared = true
@@ -155,7 +191,7 @@ func planStitchViasForNet(net string, padsAll []pcbPadP, tracks []pcbTrack, vias
 		if !shared {
 			// Or an existing same-net board via (a routing via is through-hole too).
 			for _, v := range vias {
-				if v.Net == net && math.Hypot(p.X-v.X, p.Y-v.Y) <= ctx.shareDist && stubClear(p.X, p.Y, v.X, v.Y) {
+				if v.Net == net && math.Hypot(p.X-v.X, p.Y-v.Y) <= ctx.shareDist && stubClear(p.X, p.Y, v.X, v.Y, p.Layer) {
 					res.Stubs = append(res.Stubs, rtSeg{Net: net, X1: p.X, Y1: p.Y, X2: v.X, Y2: v.Y, Layer: p.Layer, Width: ctx.stubW})
 					res.Shared++
 					shared = true
@@ -171,7 +207,7 @@ func planStitchViasForNet(net string, padsAll []pcbPadP, tracks []pcbTrack, vias
 		for _, off := range ctx.offsets {
 			for _, d := range stitchDirs {
 				vx, vy := p.X+d[0]*off, p.Y+d[1]*off
-				if !viaClear(vx, vy) || !stubClear(p.X, p.Y, vx, vy) {
+				if !viaClear(vx, vy) || !stubClear(p.X, p.Y, vx, vy, p.Layer) {
 					continue
 				}
 				res.Vias = append(res.Vias, rtVia{Net: net, X: vx, Y: vy})

--- a/internal/app/pcb_powerplanes_stitch_test.go
+++ b/internal/app/pcb_powerplanes_stitch_test.go
@@ -91,6 +91,65 @@ func TestStitchAvoidsExistingVias(t *testing.T) {
 	}
 }
 
+// A stub must not graze an other-net via. An other-net via sits between the pad
+// and its first (E, offset 30) candidate via spot; the stub to that spot would
+// run 0mil from it, so the planner must pick a different direction — and the
+// chosen stub must clear the foreign via.
+func TestStitchStubAvoidsOtherNetVia(t *testing.T) {
+	pads := []pcbPadP{{Designator: "C1", Number: "1", Net: "+5V", Layer: 1, X: 0, Y: 0}}
+	// Foreign via just past the pad on the +X axis: the E/offset-50 stub would
+	// pass right over it. viaClear also dodges it, but the stub is the point here.
+	vias := []pcbViaP{{ID: "v1", Net: "GND", X: 40, Y: 0, Dia: 24}}
+	ctx := stitchCtxForTest()
+	res := planStitchViasForNet("+5V", pads, nil, vias, nil, ctx)
+	if len(res.Vias) != 1 {
+		t.Fatalf("want 1 via, got %d", len(res.Vias))
+	}
+	v := res.Vias[0]
+	// The chosen stub (pad→via) must clear the GND via by clearance+viaR+stubW/2.
+	band := ctx.clearance + ctx.viaDia/2 + ctx.stubW/2
+	if d := segPtDist(40, 0, 0, 0, v.X, v.Y); d < band {
+		t.Errorf("stub runs %.1fmil from the GND via — under the %.1f band", d, band)
+	}
+}
+
+// A stub must not run alongside an other-net track on the same layer. A GND
+// track lies along +X just off the pad; the E-direction stub would parallel it
+// under clearance, so the planner picks another direction that clears the track.
+func TestStitchStubAvoidsOtherNetTrack(t *testing.T) {
+	pads := []pcbPadP{{Designator: "C1", Number: "1", Net: "+5V", Layer: 1, X: 0, Y: 0}}
+	tracks := []pcbTrack{{ID: "t1", Net: "GND", Layer: 1, X1: 30, Y1: 6, X2: 70, Y2: 6, Width: 10}}
+	ctx := stitchCtxForTest()
+	res := planStitchViasForNet("+5V", pads, tracks, nil, nil, ctx)
+	if len(res.Vias) != 1 {
+		t.Fatalf("want 1 via, got %d", len(res.Vias))
+	}
+	v := res.Vias[0]
+	band := ctx.clearance + 10.0/2 + ctx.stubW/2
+	if d := segSegDist(0, 0, v.X, v.Y, 30, 6, 70, 6); d < band {
+		t.Errorf("stub runs %.1fmil from the GND track — under the %.1f band", d, band)
+	}
+}
+
+// A stub sharing a via into a same-net board via must still clear a foreign via
+// that sits along the share path — otherwise the share stub itself shorts.
+func TestStitchShareStubAvoidsOtherNetVia(t *testing.T) {
+	pads := []pcbPadP{{Designator: "U1", Number: "1", Net: "GND", Layer: 1, X: 0, Y: 0}}
+	// Same-net board via within shareDist along +X, plus a foreign via right on
+	// the share stub path → the share must be rejected, planner offsets a new via.
+	vias := []pcbViaP{
+		{ID: "g1", Net: "GND", X: 70, Y: 0, Dia: 24},
+		{ID: "f1", Net: "+3V3", X: 35, Y: 0, Dia: 24},
+	}
+	ctx := stitchCtxForTest()
+	res := planStitchViasForNet("GND", pads, nil, vias, nil, ctx)
+	// The share stub (0,0)→(70,0) would run 0mil from the +3V3 via at (35,0), so
+	// it must NOT be taken as a plain shared stub with no new via.
+	if res.Shared != 0 {
+		t.Errorf("share stub grazes a foreign via — must not share, shared=%d", res.Shared)
+	}
+}
+
 // A pad boxed in on all candidates is left unstitched (reported), never violated
 // into place.
 func TestStitchLeavesBoxedInPadUnplaced(t *testing.T) {


### PR DESCRIPTION
Fixes #92

## 问题
`pcb power-planes` 的 per-pad 缝合规划器 `planStitchViasForNet` 中，避让函数 `stubClear` 只遍历异网焊盘中心点，完全没有把 stub 段落对照 via（`vias`/`priorVias`）与异网 `tracks` 做距离检查。稠密板上缝合 stub 因此会紧贴甚至压过异网 via / 走线，落笔后被真实几何 DRC 判为 `track-over-pad` 短路与 `runs 0.0mil from via` 欠 clearance。

## 改动
在 `stubClear` 中补齐两类避让（`internal/app/pcb_powerplanes_stitch.go`）：
- **异网 via**（via 为通孔，任意层都冲突）：对 `vias`（含真实 `Dia/2`）与 `priorVias`（`viaR`）做段-点距离校验，阈值 `clearance + viaR + stubW/2`；stub 自身端点 via 为同网，跳过。
- **同层异网 track**：段-段距离校验，阈值 `clearance + track.Width/2 + stubW/2`。

`stubClear` 新增 `layer` 参数（stub 所在铜层），track 校验按层过滤；三处调用点（share-via / share-board-via / 新 via 候选）均传入 `p.Layer`。冲突候选被否决后，落回现有 `Unplaced` 上报路径，绝不违规硬放。

## 测试
新增 3 个回归用例（`pcb_powerplanes_stitch_test.go`）：stub 压异网 via、stub 贴同层异网 track、share stub 跨异网 via。`go test ./internal/app/` 全量通过，`go build ./...` / `go vet` 无警告。

## 未覆盖
issue 中提到的焊盘尺寸低估（`pcbPadP` 无宽高、规划与 DRC 统一用固定 `nominalPadHalf=12`）属数据模型级改动，及 `--no-stub`/`--via-on-pad` 模式，本 PR 未涉及，建议单开 issue 跟进。稠密板 `pcb check` 端到端归零需真实 EasyEDA 环境验证，本地仅覆盖单元回归。