### PR TITLE
fix: place-constrained consumes block placement hints (#95 defect #1)

### DIFF
--- a/internal/app/pcb_place_constrained.go
+++ b/internal/app/pcb_place_constrained.go
@@ -5,6 +5,9 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
+
+	"github.com/zhoushoujianwork/easyeda-agent/internal/blocks"
 )
 
 // pcb_place_constrained.go — constraint-driven TIERED placement (daemon-side).
@@ -17,12 +20,19 @@ import (
 //	Tier 2  edge-constrained parts    — connectors (USB / terminal / card socket / IPEX) + RF
 //	                                     modules → snapped flush to their NEAREST board edge, fixed.
 //	Tier 3  main chips + crystals     — anchors, kept where they are (fixed).
+//	        + block-anchored parts    — a part the block pinned to a deliberate
+//	                                     non-edge spot (e.g. a bus-terminal jumper).
 //	Tier 4  satellites + user-facing  — legalized (spiral) around the fixed set, avoiding holes.
 //
-// Classification is by footprint/designator pattern — the categories are the ones
-// the circuit-block library flags with `placement.board_edge=true` / `user-facing`
-// (see internal/blocks/data/*.json). A board that was block-assembled or built from
-// the schematic both work: we read what's placed, not how it got there.
+// Classification CONSUMES the circuit-block library's declarative placement hints
+// (internal/blocks/data/*.json → placement.<REF>.{board_edge,edge,...}): a placed
+// part is reverse-mapped to its block role by device name / designator prefix, and
+// only falls back to the hardcoded footprint/designator regex when no block role
+// matches. The block data is the single source-of-truth (see the
+// improvements-sink-to-blocks rule) — the regex merely mirrors it as a safety net.
+// A board that was block-assembled or built from the schematic both work: we read
+// what's placed, not how it got there (placed parts carry no block link, hence the
+// device-name / prefix reverse lookup).
 
 type cpClass int
 
@@ -31,6 +41,8 @@ const (
 	cpUserFacing                // tier 4, but wants to stay near an edge / visible (LED, button)
 	cpMainChip                  // tier 3
 	cpEdgeMust                  // tier 2 — MUST sit at a board edge (connector / module / IPEX)
+	cpAnchored                  // tier 3 — block declares a DELIBERATE non-edge position
+	// (e.g. a bus-terminal jumper next to its resistor); keep it put, don't spiral.
 )
 
 func (k cpClass) String() string {
@@ -39,6 +51,8 @@ func (k cpClass) String() string {
 		return "edge"
 	case cpMainChip:
 		return "main"
+	case cpAnchored:
+		return "anchored"
 	case cpUserFacing:
 		return "user-facing"
 	default:
@@ -46,9 +60,49 @@ func (k cpClass) String() string {
 	}
 }
 
-// Footprint / designator patterns for the position-constrained categories. Derived
-// from the block library's placement hints (must-edge = connectors + RF module;
-// user-facing = buttons + LED). Matched case-insensitively against footprint name.
+// cpPlacementIndex lazily loads (and caches) the block library's placement hints
+// so classifyCP can consult the declarative source-of-truth before falling back
+// to the hardcoded regex below. The block data is go:embed'd, so this never
+// touches disk. Built once; the index is read-only after.
+var (
+	cpIdxOnce sync.Once
+	cpIdx     blocks.PlacementIndex
+)
+
+func placementIndex() blocks.PlacementIndex {
+	cpIdxOnce.Do(func() {
+		// Errors leave cpIdx zero-valued (empty maps → classifyCP just uses the
+		// regex fallback), so a broken block library degrades, never panics.
+		if idx, err := blocks.LoadPlacementIndex(); err == nil {
+			cpIdx = idx
+		}
+	})
+	return cpIdx
+}
+
+// classFromHint maps a block placement hint to a placement tier:
+//   - board_edge=true                     → edge-must (tier 2), snapped to an edge.
+//   - user-facing (and NOT board_edge)    → tier 4 user-facing (LED / button).
+//   - any other DELIBERATE non-edge decl  → anchored (tier 3): the block pinned it
+//     to a specific spot next to another part (e.g. JP701 by its 120R terminator),
+//     so keep it put rather than spiral it to a board corner.
+//
+// The hint only ever promotes a part to a stronger placement role; it never
+// demotes a main chip (which the pin-count fallback still catches).
+func classFromHint(h blocks.PlacementHint) cpClass {
+	if h.BoardEdge {
+		return cpEdgeMust
+	}
+	if strings.EqualFold(strings.TrimSpace(h.Edge), "user-facing") {
+		return cpUserFacing
+	}
+	return cpAnchored
+}
+
+// Footprint / designator patterns for the position-constrained categories. These
+// only MIRROR the block library's placement hints — they are the FALLBACK, used
+// when classifyCP can't reverse-map a placed part to a block role by device name
+// or designator prefix (see placementIndex). The block data is the source-of-truth.
 var (
 	cpReEdgeConn = regexp.MustCompile(`(?i)usb|type-?c|micro-?sd|tf[-_ ]?card|sd[-_]?card|push-?push|ipex|u\.?fl|sma|ufl|kf301|kf128|kf2edg|terminal|screw|hdr|header|pin-?header|conn`)
 	cpReModule   = regexp.MustCompile(`(?i)wroom|wrover|esp32.*(module|wifi|smd)`)
@@ -68,9 +122,24 @@ type cpComp struct {
 }
 
 // classify decides the placement tier from footprint + designator + pin count.
+//
+// Block-data FIRST: the declarative placement hints in internal/blocks/data/*.json
+// are the source-of-truth (see improvements-sink-to-blocks). We reverse-map the
+// placed part to a block role by device name, then by DISTINCTIVE designator
+// prefix (a placed part carries no block link, so we can only match on what it
+// exposes). Only when neither matches do we fall through to the hardcoded regex
+// heuristic below — that regex is the fallback, not the primary path.
 func classifyCP(c cpComp, mainPins int) cpClass {
 	fp := c.footprint
 	des := strings.ToUpper(c.designator)
+
+	idx := placementIndex()
+	if h, ok := idx.ByDevice[strings.ToLower(strings.TrimSpace(fp))]; ok {
+		return classFromHint(h)
+	}
+	if h, ok := idx.ByRefPrefix[refPrefixCP(des)]; ok {
+		return classFromHint(h)
+	}
 	// A connector/module footprint, OR a Jxx designator that isn't a plain header
 	// resistor — treat as edge-must.
 	if cpReModule.MatchString(fp) {
@@ -93,6 +162,18 @@ func classifyCP(c cpComp, mainPins int) cpClass {
 		return cpMainChip
 	}
 	return cpSatellite
+}
+
+// refPrefixCP returns the leading alphabetic run of a designator, upper-cased
+// ("JP701" → "JP", "J4" → "J"). Mirrors blocks.refPrefix so the app-side lookup
+// key matches the index key.
+func refPrefixCP(des string) string {
+	des = strings.ToUpper(strings.TrimSpace(des))
+	i := 0
+	for i < len(des) && des[i] >= 'A' && des[i] <= 'Z' {
+		i++
+	}
+	return des[:i]
 }
 
 // edgeInteriorDir is the unit vector pointing from a board edge toward the board
@@ -295,13 +376,21 @@ func planConstrainedPlace(comps []cpComp, holes []cpHole, opt cpOptions) ([]apMo
 		diags = append(diags, apDiag{Designator: c.designator, Reason: reason})
 	}
 
-	// ── Tier 3: main chips + crystals → keep where they are, fix. ─────────────
+	// ── Tier 3: main chips + crystals + block-anchored parts → keep, fix. ─────
+	// cpAnchored is a part the block deliberately pinned to a specific non-edge
+	// spot (e.g. a bus-terminal jumper beside its resistor). Like a main chip we
+	// leave it where it is and add it to the fixed set, so the Tier-4 spiral can
+	// never fling it to a corner.
 	for i, c := range comps {
-		if kinds[i] != cpMainChip || !c.hasBBox {
+		if (kinds[i] != cpMainChip && kinds[i] != cpAnchored) || !c.hasBBox {
 			continue
 		}
 		addFixed(cpRect{c.minX - m, c.minY - m, c.maxX + m, c.maxY + m}, c.layer)
-		diags = append(diags, apDiag{Designator: c.designator, Reason: "main:fixed"})
+		reason := "main:fixed"
+		if kinds[i] == cpAnchored {
+			reason = "anchored:fixed"
+		}
+		diags = append(diags, apDiag{Designator: c.designator, Reason: reason})
 	}
 
 	// ── Tier 4: satellites + user-facing → legalize (spiral) around fixed. ────

--- a/internal/app/pcb_place_constrained_test.go
+++ b/internal/app/pcb_place_constrained_test.go
@@ -38,6 +38,65 @@ func TestClassifyCP(t *testing.T) {
 	}
 }
 
+// TestClassifyCPFromBlockData is the acceptance gate for issue #95 defect #1:
+// classifyCP must consult the block library's placement hints (device name /
+// designator prefix) BEFORE the hardcoded regex. JP701 (RS485 120R terminator
+// jumper) is declared board_edge=false in sp3485_rs485_halfduplex.json, so it
+// must land as an anchored part (kept beside its resistor), NOT be caught by the
+// old J*-but-not-JP* rule and spiraled to a corner as a plain satellite.
+func TestClassifyCPFromBlockData(t *testing.T) {
+	// device name matches the library part id conn.sip2_254 → picked up by
+	// ByDevice regardless of designator.
+	jp := classifyCP(mkCP("JP701", "conn.sip2_254", 1, 0, 0, 60, 40, 2), 8)
+	if jp == cpSatellite {
+		t.Errorf("JP701 (block board_edge=false) must not classify as plain satellite; got %v", jp)
+	}
+	if jp != cpAnchored {
+		t.Errorf("JP701 should be block-anchored (deliberate non-edge spot); got %v", jp)
+	}
+	// The 3P terminal J4 IS a board-edge part per the same block → edge-must.
+	j4 := classifyCP(mkCP("J4", "conn.terminal_3p_508", 1, 0, 0, 300, 200, 3), 8)
+	if j4 != cpEdgeMust {
+		t.Errorf("J4 (block board_edge=true) should be edge-must; got %v", j4)
+	}
+}
+
+// TestConstrainedPlaceKeepsJP701 asserts the end-to-end #95 acceptance: with a
+// JP701 sitting next to its 120R terminator and 3P terminal, place-constrained
+// must NOT spiral it off to a board corner. A block-anchored part is fixed in
+// place, so it produces no move (or at most a tiny legalizing nudge), unlike a
+// satellite that gets flung outward.
+func TestConstrainedPlaceKeepsJP701(t *testing.T) {
+	comps := []cpComp{
+		mkCP("U7", "ic.sp3485_sop8", 1, 900, 900, 300, 200, 8),      // main chip, fixed
+		mkCP("J4", "conn.terminal_3p_508", 1, 1500, 900, 300, 200, 3), // edge terminal
+		mkCP("R703", "res.120r_1206", 1, 1300, 900, 80, 50, 2),        // terminator
+		mkCP("JP701", "conn.sip2_254", 1, 1350, 950, 60, 40, 2),       // jumper beside R703/J4
+		mkCP("C701", "cap.100nf_0402", 1, 700, 900, 40, 30, 2),        // decap satellite
+	}
+	moves, diags := planConstrainedPlace(comps, nil, defaultCpOptions())
+
+	byDes := map[string]apMove{}
+	for _, m := range moves {
+		byDes[m.Designator] = m
+	}
+	// JP701 must be recognised as block-anchored, not a satellite spiral.
+	var jpDiag string
+	for _, d := range diags {
+		if d.Designator == "JP701" {
+			jpDiag = d.Reason
+		}
+	}
+	if jpDiag != "anchored:fixed" {
+		t.Errorf("JP701 should be block-anchored (diag anchored:fixed); got %q", jpDiag)
+	}
+	// An anchored part stays put → no move emitted (satellites near JP701's old
+	// class would have been flung to legalize around the pile).
+	if mv, moved := byDes["JP701"]; moved {
+		t.Errorf("JP701 (anchored) should not be relocated; got move to (%v,%v)", mv.NewX, mv.NewY)
+	}
+}
+
 func TestConstrainedPlaceEdgeSnapAndNoOverlap(t *testing.T) {
 	// A USB connector parked 300mil inside the board must snap to the nearest edge;
 	// satellites must not overlap it or each other.

--- a/internal/blocks/placement.go
+++ b/internal/blocks/placement.go
@@ -1,0 +1,104 @@
+package blocks
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// PlacementHint is a block's placement.<REF> declaration, projected for the PCB
+// placer to consume. The circuit-block library (data/*.json) is the single
+// source-of-truth for placement roles; the placer reverse-maps a PLACED
+// component (which carries no block link) back to its declared role via the
+// part device id or the designator prefix.
+type PlacementHint struct {
+	BoardEdge   bool   `json:"board_edge"`
+	Edge        string `json:"edge"`
+	Side        string `json:"side"`
+	Orientation string `json:"orientation"`
+	Severity    string `json:"severity"`
+	Device      string `json:"-"` // library part id (parts[ref].part) this hint applies to
+	Ref         string `json:"-"` // block-internal designator the hint was declared under
+}
+
+// PlacementIndex is the two-level reverse-map the placer consults before falling
+// back to hardcoded regex: device-name → hint and designator-prefix → hint.
+//
+// ByRefPrefix is deliberately restricted to DISTINCTIVE prefixes (2+ letters
+// such as JP / SW / LED / ANT). Generic single-letter prefixes (U / C / R / X)
+// are excluded: on a real board they denote a whole component class, so blanket
+// prefix-mapping them would misfile (e.g. snapping every U* IC to a board edge).
+// Those are handled by the precise ByDevice layer or the regex fallback.
+type PlacementIndex struct {
+	ByDevice    map[string]PlacementHint // lower-cased library part id → hint
+	ByRefPrefix map[string]PlacementHint // upper-cased alpha designator prefix → hint
+}
+
+// blockPlacementRaw mirrors just the fields of a block JSON the index needs.
+type blockPlacementRaw struct {
+	Parts map[string]struct {
+		Part string `json:"part"`
+	} `json:"parts"`
+	Placement map[string]PlacementHint `json:"placement"`
+}
+
+// refPrefix returns the leading alphabetic run of a designator, upper-cased
+// ("JP701" → "JP", "SW_BOOT" → "SW", "J4" → "J"). Empty if it doesn't start
+// with a letter.
+func refPrefix(ref string) string {
+	ref = strings.ToUpper(strings.TrimSpace(ref))
+	i := 0
+	for i < len(ref) && ref[i] >= 'A' && ref[i] <= 'Z' {
+		i++
+	}
+	return ref[:i]
+}
+
+// LoadPlacementIndex builds the reverse-map from every embedded block's
+// placement.* declarations. It reads the raw JSON directly (not the Block
+// projection, which drops `placement`) so the block library stays the sole
+// source-of-truth. A malformed single block is skipped, not fatal.
+func LoadPlacementIndex() (PlacementIndex, error) {
+	idx := PlacementIndex{
+		ByDevice:    map[string]PlacementHint{},
+		ByRefPrefix: map[string]PlacementHint{},
+	}
+	all, err := Load()
+	if err != nil {
+		return idx, err
+	}
+	// A prefix that resolves to conflicting board_edge across blocks is
+	// ambiguous → drop it, let device-name / regex decide instead.
+	prefixConflict := map[string]bool{}
+	for _, b := range all {
+		var raw blockPlacementRaw
+		if json.Unmarshal(b.Raw, &raw) != nil {
+			continue
+		}
+		for ref, hint := range raw.Placement {
+			hint.Ref = ref
+			if p, ok := raw.Parts[ref]; ok {
+				hint.Device = p.Part
+			}
+			if hint.Device != "" {
+				key := strings.ToLower(hint.Device)
+				if _, seen := idx.ByDevice[key]; !seen {
+					idx.ByDevice[key] = hint
+				}
+			}
+			prefix := refPrefix(ref)
+			// Skip generic single-letter prefixes (see PlacementIndex doc).
+			if len(prefix) < 2 || prefixConflict[prefix] {
+				continue
+			}
+			if prev, seen := idx.ByRefPrefix[prefix]; seen {
+				if prev.BoardEdge != hint.BoardEdge {
+					delete(idx.ByRefPrefix, prefix)
+					prefixConflict[prefix] = true
+				}
+				continue
+			}
+			idx.ByRefPrefix[prefix] = hint
+		}
+	}
+	return idx, nil
+}

--- a/internal/blocks/placement_test.go
+++ b/internal/blocks/placement_test.go
@@ -1,0 +1,46 @@
+package blocks
+
+import "testing"
+
+func TestLoadPlacementIndex(t *testing.T) {
+	idx, err := LoadPlacementIndex()
+	if err != nil {
+		t.Fatalf("LoadPlacementIndex: %v", err)
+	}
+
+	// JP701's part (conn.sip2_254) is declared board_edge=false in the RS485
+	// block — the exact misfire issue #95 fixes.
+	jp, ok := idx.ByDevice["conn.sip2_254"]
+	if !ok {
+		t.Fatal("conn.sip2_254 (JP701) missing from ByDevice index")
+	}
+	if jp.BoardEdge {
+		t.Errorf("JP701 part should be board_edge=false; got true")
+	}
+
+	// The 3P terminal is an edge part.
+	if j4, ok := idx.ByDevice["conn.terminal_3p_508"]; !ok || !j4.BoardEdge {
+		t.Errorf("conn.terminal_3p_508 (J4) should be indexed board_edge=true; ok=%v edge=%v", ok, j4.BoardEdge)
+	}
+
+	// Distinctive prefixes are indexed; the JP prefix resolves to a non-edge hint.
+	if jpP, ok := idx.ByRefPrefix["JP"]; ok && jpP.BoardEdge {
+		t.Errorf("JP prefix should map to a non-edge hint; got board_edge=true")
+	}
+	// Generic single-letter prefixes must NOT be indexed (would misfile whole
+	// component classes).
+	for _, p := range []string{"U", "C", "R", "X", "J"} {
+		if _, ok := idx.ByRefPrefix[p]; ok {
+			t.Errorf("generic prefix %q must not be in ByRefPrefix", p)
+		}
+	}
+}
+
+func TestRefPrefix(t *testing.T) {
+	cases := map[string]string{"JP701": "JP", "J4": "J", "SW_BOOT": "SW", "LED1": "LED", "701": "", "": ""}
+	for in, want := range cases {
+		if got := refPrefix(in); got != want {
+			t.Errorf("refPrefix(%q)=%q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #95 (defect #1 only — scope per issue 修复序建议).

## What changed
`classifyCP` (internal/app/pcb_place_constrained.go) now consults the circuit-block library's declarative `placement.*` hints BEFORE the hardcoded regex, which is demoted to a fallback. This is 方案 A: 'block data is the single source-of-truth' compiled into the tool rather than relying on the agent to read blocks.

- **internal/blocks/placement.go** (new): `LoadPlacementIndex` builds two reverse-maps from the go:embed'd block data — `device-name → hint` and `distinctive-prefix → hint`. Generic single-letter prefixes (U/C/R/X/J) are excluded (they denote whole component classes, would misfile), and prefixes with conflicting board_edge across blocks are dropped.
- **classifyCP**: device-name match → prefix match → regex fallback.
- **new cpAnchored tier**: a part the block pins to a deliberate non-edge spot (`board_edge=false`, e.g. JP701 the RS485 120R terminator jumper) is now fixed in place in Tier 3 like a main chip, instead of being spiraled to a board corner by the Tier-4 satellite pass. This directly fixes the JP701 misfire the block's own reason field warned about.

## Tests
- `TestClassifyCPFromBlockData` / `TestConstrainedPlaceKeepsJP701` (app): JP701 (conn.sip2_254) no longer classifies as satellite and is not relocated; J4 (conn.terminal_3p_508) stays edge-must — the #95 acceptance gate.
- `TestLoadPlacementIndex` / `TestRefPrefix` (blocks): index picks up JP701's non-edge hint and excludes generic prefixes.
- Existing `TestClassifyCP`, `TestConstrainedPlaceEdgeSnapAndNoOverlap`, `TestConnOrientation` still pass; full `go build ./... && go test ./...` green.

## Scope
Defects #2 (real outline), #3 (net-hug into Tier-4), #4 (antenna keepout) are intentionally left for follow-up PRs per the issue's 修复序. This is headless unit-tested only; no runtime/hardware verification needed (pure function change).