### PR TITLE
fix(connector): 自定义属性写入适配 otherProperty

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -163,6 +163,10 @@ follow [SemVer](https://semver.org/).
 ## [0.14.1] - 2026-07-19
 
 ### Fixed
+- **`schematic.component.modify` 自定义属性静默 no-op**:CLI 文档使用
+  `customAttributes`,但 EasyEDA SDK 实际只接受 `otherProperty`,导致命令返回成功却不更新
+  `Value` 等属性。连接器现在将兼容别名转换为 SDK 字段、与现有属性合并后写入,并用新器件
+  句柄逐字段回读验证;平台再次静默忽略时会明确报错,不再假报成功。
 - **`schematic.pin.set_no_connect` 真正生成非连接 X 标识(订正 0.5.14 的平台 no-op 误诊)**:
   真机复现确认 `setState_NoConnected(...)` 只修改当前 pin 句柄的待提交状态,必须再
   `await pin.done()` 才会写回画布;此前 handler 漏掉 `done()`,fresh readback 因而恢复

--- a/extension/src/actions.test.ts
+++ b/extension/src/actions.test.ts
@@ -84,7 +84,7 @@ test('normalizeDeviceRef: non-string uuid/libraryUuid coerced to empty', () => {
 	assert.deepEqual(ref, { libraryUuid: '', uuid: '', name: 'X' });
 });
 
-import { schematicComponentPlace, schematicPinSetNoConnect } from './actions';
+import { schematicComponentModify, schematicComponentPlace, schematicPinSetNoConnect } from './actions';
 
 /** Install a fake `eda.sch_PrimitiveComponent` on the global for one test.
  *  create() returns a placeholder-designator component; modify() records its
@@ -123,6 +123,73 @@ test('place without designator: no modify call, keeps placeholder (issue #68)', 
 	});
 	assert.equal(calls.modify.length, 0);
 	assert.equal((res.result.component as any).designator, 'C?');
+	delete (globalThis as any).eda;
+});
+
+// ─── schematic.component.modify 自定义属性兼容与回读校验 ───────────────
+
+function installComponentModifyStub(options: { apply?: boolean } = {}) {
+	let otherProperty: Record<string, string | number | boolean> = {
+		Description: 'keep me',
+		Value: '',
+	};
+	const calls: Array<{ id: string; patch: Record<string, unknown> }> = [];
+	const current = () => mockComponent({
+		PrimitiveId: 'r2-pid',
+		Designator: 'R2',
+		OtherProperty: { ...otherProperty },
+	});
+	(globalThis as any).eda = {
+		sch_PrimitiveComponent: {
+			get: async (id: string) => id === 'r2-pid' ? current() : undefined,
+			modify: async (id: string, patch: Record<string, unknown>) => {
+				calls.push({ id, patch });
+				if (options.apply !== false && patch.otherProperty) {
+					otherProperty = { ...(patch.otherProperty as Record<string, string | number | boolean>) };
+				}
+				return current();
+			},
+		},
+	};
+	return { calls, getOtherProperty: () => ({ ...otherProperty }) };
+}
+
+test('modify: maps customAttributes to SDK otherProperty and preserves existing fields', async () => {
+	const fx = installComponentModifyStub();
+	const res: any = await schematicComponentModify({
+		primitiveId: 'r2-pid',
+		patch: { customAttributes: { Value: '10kΩ' } },
+	});
+
+	assert.deepEqual(fx.calls[0], {
+		id: 'r2-pid',
+		patch: { otherProperty: { Description: 'keep me', Value: '10kΩ' } },
+	});
+	assert.deepEqual(fx.getOtherProperty(), { Description: 'keep me', Value: '10kΩ' });
+	assert.equal(res.result.component.otherProperty.Value, '10kΩ');
+	delete (globalThis as any).eda;
+});
+
+test('modify: partial otherProperty also merges instead of clearing metadata', async () => {
+	const fx = installComponentModifyStub();
+	await schematicComponentModify({
+		primitiveId: 'r2-pid',
+		patch: { otherProperty: { Value: '4.7kΩ' } },
+	});
+
+	assert.deepEqual(fx.getOtherProperty(), { Description: 'keep me', Value: '4.7kΩ' });
+	delete (globalThis as any).eda;
+});
+
+test('modify: rejects SDK success when requested properties were silently ignored', async () => {
+	installComponentModifyStub({ apply: false });
+	await assert.rejects(
+		() => schematicComponentModify({
+			primitiveId: 'r2-pid',
+			patch: { customAttributes: { Value: '10kΩ' } },
+		}),
+		/returned success but did not apply properties: Value/,
+	);
 	delete (globalThis as any).eda;
 });
 

--- a/extension/src/actions.ts
+++ b/extension/src/actions.ts
@@ -769,18 +769,71 @@ export const schematicComponentPlace: Handler = async (payload) => {
 	};
 };
 
-const schematicComponentModify: Handler = async (payload) => {
+type SchematicPropertyValue = string | number | boolean;
+
+/**
+ * 校验原理图器件自定义属性补丁，避免 SDK 静默忽略不支持的嵌套值。
+ */
+function requireSchematicPropertyPatch(
+	value: unknown,
+	field: 'customAttributes' | 'otherProperty',
+): Record<string, SchematicPropertyValue> {
+	if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+		throw new ActionError(
+			ErrorCodes.MISSING_PAYLOAD_FIELD,
+			`Component patch field "${field}" must be an object.`,
+		);
+	}
+	const out: Record<string, SchematicPropertyValue> = {};
+	for (const [key, item] of Object.entries(value)) {
+		if (typeof item !== 'string' && typeof item !== 'number' && typeof item !== 'boolean') {
+			throw new ActionError(
+				ErrorCodes.MISSING_PAYLOAD_FIELD,
+				`Component property "${field}.${key}" must be a string, number, or boolean.`,
+			);
+		}
+		out[key] = item;
+	}
+	return out;
+}
+
+export const schematicComponentModify: Handler = async (payload) => {
 	const primitiveId = requireString(payload, 'primitiveId');
 	const patch = payload.patch;
-	if (typeof patch !== 'object' || patch === null) {
+	if (typeof patch !== 'object' || patch === null || Array.isArray(patch)) {
 		throw new ActionError(ErrorCodes.MISSING_PAYLOAD_FIELD, 'Missing required object field "patch".');
+	}
+
+	const normalizedPatch = { ...(patch as Record<string, unknown>) };
+	const hasCustomAttributes = Object.prototype.hasOwnProperty.call(normalizedPatch, 'customAttributes');
+	const hasOtherProperty = Object.prototype.hasOwnProperty.call(normalizedPatch, 'otherProperty');
+	if (hasCustomAttributes && hasOtherProperty) {
+		throw new ActionError(
+			ErrorCodes.MISSING_PAYLOAD_FIELD,
+			'Use either "customAttributes" or "otherProperty" in one component patch, not both.',
+		);
+	}
+
+	let expectedProperties: Record<string, SchematicPropertyValue> | undefined;
+	if (hasCustomAttributes || hasOtherProperty) {
+		const field = hasCustomAttributes ? 'customAttributes' : 'otherProperty';
+		expectedProperties = requireSchematicPropertyPatch(normalizedPatch[field], field);
+
+		// EasyEDA SDK 只接受 otherProperty，而且会整体替换该对象；先合并现有值，
+		// 使 CLI 文档中的 customAttributes 别名可用，同时避免修改 Value 时清空其他属性。
+		const current = await getComponentOrThrow(primitiveId);
+		const existing = cleanOtherProperty(
+			current.getState_OtherProperty() as Record<string, unknown> | undefined,
+		) ?? {};
+		normalizedPatch.otherProperty = { ...existing, ...expectedProperties };
+		delete normalizedPatch.customAttributes;
 	}
 
 	let component;
 	try {
 		component = await eda.sch_PrimitiveComponent.modify(
 			primitiveId,
-			patch as Parameters<typeof eda.sch_PrimitiveComponent.modify>[1],
+			normalizedPatch as Parameters<typeof eda.sch_PrimitiveComponent.modify>[1],
 		);
 	}
 	catch (err) {
@@ -788,6 +841,24 @@ const schematicComponentModify: Handler = async (payload) => {
 	}
 	if (!component) {
 		throw new ActionError(ErrorCodes.EDA_CALL_FAILED, `Failed to modify component "${primitiveId}".`);
+	}
+
+	if (expectedProperties) {
+		// SDK 某些未知字段会返回成功但静默 no-op；必须用新句柄回读实际画布状态。
+		const fresh = await getComponentOrThrow(primitiveId);
+		const actual = cleanOtherProperty(
+			fresh.getState_OtherProperty() as Record<string, unknown> | undefined,
+		) ?? {};
+		const notApplied = Object.entries(expectedProperties)
+			.filter(([key, value]) => actual[key] !== value)
+			.map(([key]) => key);
+		if (notApplied.length > 0) {
+			throw new ActionError(
+				ErrorCodes.EDA_CALL_FAILED,
+				`Component "${primitiveId}" modify returned success but did not apply properties: ${notApplied.join(', ')}.`,
+			);
+		}
+		component = fresh;
 	}
 	return { result: { component: serializeComponent(component) } };
 };

--- a/internal/protocol/actions.go
+++ b/internal/protocol/actions.go
@@ -240,7 +240,7 @@ func AllActions() []ActionSpec {
 			Phase:       1,
 			Mutates:     true,
 			NeedsWindow: true,
-			Description: "Modify component position, designator, name, BOM flags, or custom properties.",
+			Description: "Modify component position, designator, name, BOM flags, or custom properties. customAttributes is a compatibility alias for the EasyEDA SDK otherProperty field; property patches are merged with existing values and verified by readback so SDK success/no-op is reported as an error.",
 			Inputs:      []string{"primitiveId", "patch"},
 			Outputs:     []string{"component state"},
 			VerifyWith:  []string{"schematic.component.get"},


### PR DESCRIPTION
## 变更内容

- 将 `schematic.component.modify` 的 `customAttributes` 兼容映射到 EasyEDA SDK 实际支持的 `otherProperty`
- 属性补丁与组件现有属性合并，避免仅修改 `Value` 时清空其他元数据
- 修改后使用新器件句柄逐字段回读；SDK 返回成功但静默未应用时明确报错
- 增加兼容映射、属性保留和静默 no-op 检测测试，并更新动作说明与变更日志

## 根因

CLI 帮助示例使用 `customAttributes`，连接器此前将补丁原样传给 SDK；当前 EasyEDA SDK 实际只接受 `otherProperty`，因此命令返回成功但 `Value` 等属性保持不变。

## 用户影响

以下命令现在会可靠地写入阻值，并保留器件已有属性：

```bash
easyeda sch modify --id <primitiveId> --patch '{"customAttributes":{"Value":"10kΩ"}}'
```

## 验证

- `go test ./...`
- `npm test`（65 项通过）
- `npm run typecheck`
- `npm run compile`
