### PR TITLE
feat(mcp): add stdio adapter and isolate duplicate connector activations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@
 .idea/
 .vscode/
 
+# Node
+node_modules/
+*.tgz
+
 # Python
 __pycache__/
 *.pyc

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help test fmt actions api-index build install dev-build daemon dev eext eext-fresh connector lint-test release publish-skill replay demo-replay replay-sch replay-pcb
+.PHONY: help test mcp-test fmt actions api-index build install dev-build daemon dev eext eext-fresh connector lint-test release publish-skill replay demo-replay replay-sch replay-pcb
 
 DIST := dist
 
@@ -17,6 +17,10 @@ help: ## show this cheatsheet
 
 test: ## go test ./...
 	go test ./...
+
+mcp-test: build ## install MCP deps and run unit + stdio protocol tests
+	npm --prefix mcp ci --ignore-scripts
+	EASYEDA_BIN="$(CURDIR)/bin/easyeda" npm --prefix mcp test
 
 # Rule-trust harness for the schematic linter: orientation-table consistency
 # (orientation.json derives to its frozenTable; matches the connector) +

--- a/README.en.md
+++ b/README.en.md
@@ -145,6 +145,25 @@ clawhub install easyeda-agent
 The old split skills (`easyeda-schematic`, `easyeda-pcb`, `easyeda-design-flow`,
 `easyeda-conventions`) have been merged and removed from the repository.
 
+### Optional: MCP integration
+
+The repository's [`mcp/`](mcp) directory provides a local stdio MCP adapter for
+agents such as Codex. It reuses the existing `easyeda` CLI/daemon and does not
+bypass typed actions, auditing, workflow gates, or the official `eda.*` API. The
+arbitrary-JavaScript `debug.exec_js` domain is intentionally not exposed through
+MCP.
+
+```bash
+npm --prefix mcp ci --ignore-scripts
+codex mcp add easyeda-agent \
+  --env EASYEDA_BIN="$(command -v easyeda)" \
+  -- node "$(pwd)/mcp/src/server.mjs"
+```
+
+Restart the agent client after registration. Other MCP clients can use the same
+stdio command and environment configuration. See [`mcp/README.md`](mcp/README.md)
+for the tool inventory and development checks.
+
 ## Demo Example
 
 A board driven end-to-end through the typed-action + Skill workflow — placed

--- a/README.md
+++ b/README.md
@@ -130,6 +130,23 @@ clawhub install easyeda-agent
 
 > EasyEDA 需开启「**允许外部交互**」,连接器的 WebSocket 才能连到本地 daemon。
 
+### 可选:MCP 接入
+
+仓库内的 [`mcp/`](mcp) 是一个本地 stdio MCP 适配层,方便 Codex 等支持 MCP 的
+agent 直接发现并调用 `easyeda_*` 工具。它复用现有 `easyeda` CLI/daemon,不会绕过
+typed action、审计、workflow gate 或官方 `eda.*` API;任意 JavaScript 的
+`debug.exec_js` 域不会通过 MCP 暴露。
+
+```bash
+npm --prefix mcp ci --ignore-scripts
+codex mcp add easyeda-agent \
+  --env EASYEDA_BIN="$(command -v easyeda)" \
+  -- node "$(pwd)/mcp/src/server.mjs"
+```
+
+重启 agent 客户端后即可使用。其他 MCP 客户端使用同一 stdio command/env 配置;
+详细工具清单与开发验证见 [`mcp/README.md`](mcp/README.md)。
+
 ## 效果演示
 
 > **完整实战案例:[一份需求文档 → AI 全自动画完 ESP32-S3 四层板](docs/showcase-esp32-mini.md)** ——

--- a/docs/connector-contract.md
+++ b/docs/connector-contract.md
@@ -16,7 +16,7 @@ The connector runs inside EasyEDA's webview, which shapes the transport:
 1. For each port in `127.0.0.1:60832-60841` (`0xEDA0`-`0xEDA9`), open a WebSocket to `ws://127.0.0.1:PORT/eda` via `eda.sys_WebSocket.register`.
 2. Wait briefly (~1.5s) for the daemon to send a `handshake` frame. Verify `service === "easyeda-agent"`.
 3. On a valid handshake, generate a `windowId` and send `register`, then `context`.
-4. Start a `ping`/`pong` heartbeat; on a missed pong or socket error, re-scan and reconnect.
+4. Start a `ping`/`pong` heartbeat; on consecutive missed pongs or a socket error, re-scan and reconnect.
 
 ## Required Messages
 
@@ -58,7 +58,7 @@ Sent by the daemon immediately on connect so the connector can confirm it reache
 
 ### ping / pong (heartbeat)
 
-The connector sends `ping` periodically; the daemon answers `pong` echoing the `id`. A missed pong triggers reconnect.
+The connector sends `ping` periodically; the daemon answers `pong` echoing the `id`. Consecutive missed pongs trigger reconnect. Each extension activation uses a distinct host WebSocket id because EasyEDA 3.2.175 can activate one extension more than once in a window; sharing a fixed id would make those activations close each other's connection.
 
 ```json
 { "type": "ping", "id": "hb-1" }

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -68,6 +68,22 @@ daemon 会在端口段 `60832-60841`(`0xEDA0`-`0xEDA9`)监听,连接器会自动
 /easyeda-agent          # 原理图 + PCB 全流程
 ```
 
+支持 MCP 的客户端还可以选择注册仓库内的 stdio 适配层。MCP 是**可选调用入口**,
+不是替代 CLI/daemon 或 Skill 的第五套状态;它仍经过同一套 typed action、审计和
+workflow gate。
+
+```bash
+git clone https://github.com/zhoushoujianwork/easyeda-agent.git
+cd easyeda-agent
+npm --prefix mcp ci --ignore-scripts
+codex mcp add easyeda-agent \
+  --env EASYEDA_BIN="$(command -v easyeda)" \
+  -- node "$(pwd)/mcp/src/server.mjs"
+```
+
+注册后重启 AI 客户端。可用工具包括连接健康、action 发现、7 个安全 action domain、
+电路块和 guarded workflow;MCP 不暴露任意 JavaScript 的 `debug.exec_js`。
+
 ---
 
 ## 验证四件套是否对齐

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -6,6 +6,19 @@ follow [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **新增本地 stdio MCP 适配层**:`mcp/` 将现有 `easyeda` CLI/daemon 的连接健康、action
+  发现、7 个安全 action domain、电路块和 guarded workflow 暴露为 `easyeda_*` tools。
+  MCP 不直连 EasyEDA、不绕过 typed action/审计/workflow gate,并明确不暴露任意
+  JavaScript 的 `debug.exec_js`;mutation 仍要求同时提供 project 与 doc。
+
+### Fixed
+- **修复 EasyEDA Pro 3.2.175 重复激活同一扩展时的永久重连风暴**:旧连接器的所有激活
+  实例共用固定 host WebSocket id,会互相 close/register 同一 socket,表现为交错 heartbeat、
+  windowId 持续变化、`AMBIGUOUS_PROJECT` 和 action response 丢失。现在每次激活生成独立
+  socket id;daemon 仅在 project/document/type/tab 四项完整且完全相同时把连接视为 transport
+  duplicate,并路由到最新连接。真实不同 tab 或身份不完整仍保持 ambiguous,不会静默误路由。
+
 ## [0.18.3] - 2026-08-01
 
 ### Added

--- a/extension/src/transport-identity.test.ts
+++ b/extension/src/transport-identity.test.ts
@@ -1,0 +1,10 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createWebSocketId } from './transport-identity';
+
+test('WebSocket ids are activation-scoped and keep the diagnostic prefix', () => {
+	const ids = ['activation-a', 'activation-b'].map((id) => createWebSocketId(() => id));
+	assert.deepEqual(ids, ['easyeda-agent-activation-a', 'easyeda-agent-activation-b']);
+	assert.notEqual(ids[0], ids[1]);
+});

--- a/extension/src/transport-identity.ts
+++ b/extension/src/transport-identity.ts
@@ -1,0 +1,18 @@
+const SOCKET_ID_PREFIX = 'easyeda-agent-';
+
+function randomActivationToken(): string {
+	if (typeof globalThis.crypto?.randomUUID === 'function') {
+		return globalThis.crypto.randomUUID();
+	}
+	if (typeof globalThis.crypto?.getRandomValues === 'function') {
+		const values = new Uint32Array(4);
+		globalThis.crypto.getRandomValues(values);
+		return Array.from(values, (value) => value.toString(16).padStart(8, '0')).join('');
+	}
+	return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+/** Create an activation-scoped id for EasyEDA's host-managed WebSocket table. */
+export function createWebSocketId(randomToken = randomActivationToken): string {
+	return `${SOCKET_ID_PREFIX}${randomToken()}`;
+}

--- a/extension/src/transport.ts
+++ b/extension/src/transport.ts
@@ -19,6 +19,7 @@
 
 import { buildContextFrame, readEasyEdaVersion } from './eda-context';
 import { runAction } from './actions';
+import { createWebSocketId } from './transport-identity';
 import {
 	ActionError,
 	CAPABILITIES,
@@ -35,7 +36,12 @@ import {
 
 // ─── Configuration ───────────────────────────────────────────────────
 
-const WS_ID = 'easyeda-agent';
+// EasyEDA 3.2.175 can activate the same extension more than once in one app
+// window. eda.sys_WebSocket is shared across those activations, so a fixed id
+// makes each activation close/re-register the other's socket forever. Give each
+// activation its own host-managed socket; the daemon coalesces registrations
+// that report the same project/document/tab when routing an action.
+const WS_ID = createWebSocketId();
 const PORT_START = 0xeda0; // 60832 — "EDA0" in hex; own range, no official-gateway conflict
 const PORT_END = 0xeda9; // 60841
 const RETRY_DELAY_MS = 3000;
@@ -52,9 +58,8 @@ const MAX_RETRIES = 5;
 const HEARTBEAT_INTERVAL_MS = 3000;
 // Liveness is consecutive-miss based, NOT a single round-trip deadline. The
 // daemon never idle-closes, and EasyEDA's webview can lag pong delivery under
-// load (canvas redraw, GC). Tearing the socket down on ONE missed pong tore down
-// perfectly healthy connections every ~5s — the reconnect storm. Only give up
-// after this many pings go unanswered in a row (~9s of true silence).
+// load (canvas redraw, GC). Only give up after this many pings go unanswered in
+// a row (~9s of true silence).
 const MAX_MISSED_PONGS = 3;
 const CONNECTION_TIMEOUT_MS = 1500;
 // A full 10-port scan (each up to CONNECTION_TIMEOUT_MS + REGISTER_DELAY_MS) settles
@@ -228,7 +233,7 @@ async function scanAndConnect(): Promise<void> {
 			if (found) {
 				currentPort = port;
 				retryCount = 0;
-				startHeartbeat(sessionId);
+				startHeartbeat();
 				return;
 			}
 		}
@@ -442,11 +447,7 @@ function diag(msg: string): void {
 
 // ─── Heartbeat ────────────────────────────────────────────────────────
 
-// startHeartbeat just (re)arms the liveness state on a fresh connection — the
-// actual pinging is driven by the watchdog ticker (see startWatchdog), which is
-// worker-backed so it keeps firing even when EasyEDA's window is backgrounded and
-// the main thread's setInterval is frozen (the old nudge-to-reconnect bug).
-function startHeartbeat(_sessionId: number): void {
+function startHeartbeat(): void {
 	heartbeatPending = false;
 	missedPongs = 0;
 }
@@ -456,9 +457,9 @@ function stopHeartbeat(): void {
 	missedPongs = 0;
 }
 
-// heartbeatTick runs one liveness round on the live connection: count a miss if
-// the previous ping is still unanswered, reconnect after MAX_MISSED_PONGS, else
-// send the next ping (+ piggyback a context refresh). Called by the watchdog.
+// heartbeatTick runs one liveness round on this activation's socket: count a
+// miss if the previous ping is still unanswered, reconnect after
+// MAX_MISSED_PONGS, else send the next ping (+ context refresh).
 function heartbeatTick(): void {
 	if (!handshakeVerified) {
 		return;
@@ -469,8 +470,6 @@ function heartbeatTick(): void {
 		void scanAndConnect();
 	};
 
-	// Liveness check BEFORE sending the next ping: a still-pending ping is a miss.
-	// Only reconnect after MAX_MISSED_PONGS in a row — one lagged pong isn't death.
 	if (heartbeatPending) {
 		missedPongs += 1;
 		if (missedPongs >= MAX_MISSED_PONGS) {

--- a/internal/daemon/hub.go
+++ b/internal/daemon/hub.go
@@ -224,11 +224,15 @@ func (h *hub) target(windowID string) (*conn, bool) {
 	}
 	h.mu.RLock()
 	defer h.mu.RUnlock()
-	if len(h.windows) != 1 {
-		return nil, false
-	}
+	var matches []Window
 	for _, c := range h.windows {
-		return c, true
+		matches = append(matches, c.snapshot())
+	}
+	if len(matches) == 1 {
+		return h.windows[matches[0].WindowID], true
+	}
+	if newest, ok := newestExactDocumentDuplicate(matches); ok {
+		return h.windows[newest.WindowID], true
 	}
 	return nil, false
 }
@@ -259,7 +263,7 @@ func (h *hub) windowForProject(project, preferDoc string) (id string, found bool
 	case 1:
 		return matches[0].WindowID, true, false
 	}
-	// Multiple windows for this project — narrow to the one whose active
+	// Multiple windows for this project — narrow to the ones whose active
 	// document matches the action's domain.
 	if preferDoc != "" {
 		var narrowed []Window
@@ -271,8 +275,45 @@ func (h *hub) windowForProject(project, preferDoc string) (id string, found bool
 		if len(narrowed) == 1 {
 			return narrowed[0].WindowID, true, false
 		}
+		if len(narrowed) > 1 {
+			matches = narrowed
+		}
+	}
+
+	// A connector reconnect briefly leaves the old and new registrations alive
+	// together. EasyEDA 3.2.175 can also activate one extension twice. If every
+	// candidate points at the exact same document tab, they are transport
+	// duplicates rather than distinct user windows; route to the newest one.
+	if newest, ok := newestExactDocumentDuplicate(matches); ok {
+		return newest.WindowID, true, false
 	}
 	return "", false, true
+}
+
+func newestExactDocumentDuplicate(matches []Window) (Window, bool) {
+	if len(matches) < 2 {
+		return Window{}, false
+	}
+	first := matches[0]
+	if first.Context.ProjectUUID == "" ||
+		first.Context.DocumentUUID == "" ||
+		first.Context.DocumentType == "" ||
+		first.Context.TabID == "" {
+		return Window{}, false
+	}
+	newest := first
+	for _, w := range matches[1:] {
+		if w.Context.ProjectUUID != first.Context.ProjectUUID ||
+			w.Context.DocumentUUID != first.Context.DocumentUUID ||
+			w.Context.DocumentType != first.Context.DocumentType ||
+			w.Context.TabID != first.Context.TabID {
+			return Window{}, false
+		}
+		if w.ConnectedAt.After(newest.ConnectedAt) {
+			newest = w
+		}
+	}
+	return newest, true
 }
 
 // listAnnotated returns the window list with each window's ConnectorVersionOK

--- a/internal/daemon/hub_test.go
+++ b/internal/daemon/hub_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/zhoushoujianwork/easyeda-agent/internal/protocol"
 )
@@ -47,6 +48,94 @@ func TestWindowForProject(t *testing.T) {
 					tc.project, tc.preferDoc, id, found, ambig, tc.wantID, tc.wantFound, tc.wantAmbig)
 			}
 		})
+	}
+}
+
+func TestWindowForProjectReconnectDuplicateUsesNewest(t *testing.T) {
+	old := connWith("old", "motobox", "pcb")
+	old.connectedAt = time.Unix(10, 0)
+	old.ctx.ProjectUUID = "project-1"
+	old.ctx.DocumentUUID = "pcb-1"
+	old.ctx.TabID = "tab-1"
+
+	newer := connWith("new", "motobox", "pcb")
+	newer.connectedAt = time.Unix(20, 0)
+	newer.ctx.ProjectUUID = "project-1"
+	newer.ctx.DocumentUUID = "pcb-1"
+	newer.ctx.TabID = "tab-1"
+
+	h := &hub{windows: map[string]*conn{"old": old, "new": newer}}
+	id, found, ambiguous := h.windowForProject("motobox", "pcb")
+	if id != "new" || !found || ambiguous {
+		t.Fatalf("windowForProject duplicate reconnect = (%q,%v,%v), want (new,true,false)", id, found, ambiguous)
+	}
+}
+
+func TestWindowForProjectDistinctTabsRemainAmbiguous(t *testing.T) {
+	first := connWith("w1", "motobox", "pcb")
+	first.ctx.ProjectUUID = "project-1"
+	first.ctx.DocumentUUID = "pcb-1"
+	first.ctx.TabID = "tab-1"
+	second := connWith("w2", "motobox", "pcb")
+	second.ctx.ProjectUUID = "project-1"
+	second.ctx.DocumentUUID = "pcb-1"
+	second.ctx.TabID = "tab-2"
+
+	h := &hub{windows: map[string]*conn{"w1": first, "w2": second}}
+	id, found, ambiguous := h.windowForProject("motobox", "pcb")
+	if id != "" || found || !ambiguous {
+		t.Fatalf("windowForProject distinct tabs = (%q,%v,%v), want (\"\",false,true)", id, found, ambiguous)
+	}
+}
+
+func TestWindowForProjectIncompleteDuplicateIdentityRemainsAmbiguous(t *testing.T) {
+	first := connWith("w1", "motobox", "pcb")
+	first.ctx.DocumentUUID = "pcb-1"
+	first.ctx.TabID = "tab-1"
+	second := connWith("w2", "motobox", "pcb")
+	second.ctx.DocumentUUID = "pcb-1"
+	second.ctx.TabID = "tab-1"
+
+	h := &hub{windows: map[string]*conn{"w1": first, "w2": second}}
+	id, found, ambiguous := h.windowForProject("motobox", "pcb")
+	if id != "" || found || !ambiguous {
+		t.Fatalf("windowForProject incomplete identity = (%q,%v,%v), want (\"\",false,true)", id, found, ambiguous)
+	}
+}
+
+func TestWindowForProjectDistinctDocumentsRemainAmbiguous(t *testing.T) {
+	first := connWith("w1", "motobox", "pcb")
+	first.ctx.ProjectUUID = "project-1"
+	first.ctx.DocumentUUID = "pcb-1"
+	first.ctx.TabID = "tab-1"
+	second := connWith("w2", "motobox", "pcb")
+	second.ctx.ProjectUUID = "project-1"
+	second.ctx.DocumentUUID = "pcb-2"
+	second.ctx.TabID = "tab-1"
+
+	h := &hub{windows: map[string]*conn{"w1": first, "w2": second}}
+	id, found, ambiguous := h.windowForProject("motobox", "pcb")
+	if id != "" || found || !ambiguous {
+		t.Fatalf("windowForProject distinct documents = (%q,%v,%v), want (\"\",false,true)", id, found, ambiguous)
+	}
+}
+
+func TestTargetReconnectDuplicateUsesNewest(t *testing.T) {
+	old := connWith("old", "motobox", "pcb")
+	old.connectedAt = time.Unix(10, 0)
+	old.ctx.ProjectUUID = "project-1"
+	old.ctx.DocumentUUID = "pcb-1"
+	old.ctx.TabID = "tab-1"
+	newer := connWith("new", "motobox", "pcb")
+	newer.connectedAt = time.Unix(20, 0)
+	newer.ctx.ProjectUUID = "project-1"
+	newer.ctx.DocumentUUID = "pcb-1"
+	newer.ctx.TabID = "tab-1"
+
+	h := &hub{windows: map[string]*conn{"old": old, "new": newer}}
+	got, ok := h.target("")
+	if !ok || got != newer {
+		t.Fatalf("target duplicate reconnect = (%p,%v), want (%p,true)", got, ok, newer)
 	}
 }
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,31 @@
+# easyeda-agent MCP
+
+Local stdio MCP adapter over the existing `easyeda` CLI/daemon. It exposes 11
+tools: connection health, action discovery, one tool for each of the seven safe
+action domains, circuit blocks, and the guarded workflow state machine. The
+arbitrary-JavaScript debug domain is deliberately not exposed.
+
+```bash
+npm ci --ignore-scripts
+EASYEDA_BIN=/absolute/path/to/easyeda npm test
+EASYEDA_BIN=/absolute/path/to/easyeda npm start
+```
+
+Codex registration:
+
+```bash
+codex mcp add easyeda-agent \
+  --env EASYEDA_BIN=/absolute/path/to/easyeda \
+  -- node /absolute/path/to/mcp/src/server.mjs
+```
+
+The MCP process does not access EasyEDA directly. Mutations still pass through
+the Go daemon, connector, workflow gates, audit log, and official `eda.*` API.
+Mutating typed actions require both `project` and `doc`; use `easyeda_actions`
+before calling a domain tool to inspect its typed payload. Workflow operations
+use structured MCP fields instead of accepting arbitrary CLI options.
+
+After registration, restart the MCP client so it discovers the new server. Run
+`easyeda_health` first, then use `easyeda_actions` to select the exact typed
+action. The Skill's inspect-before-mutate, save, reload, DRC, and workflow-gate
+rules continue to apply to MCP calls.

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,0 +1,1184 @@
+{
+  "name": "easyeda-agent-mcp",
+  "version": "0.18.3",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "easyeda-agent-mcp",
+      "version": "0.18.3",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "1.30.0"
+      },
+      "bin": {
+        "easyeda-agent-mcp": "src/server.mjs"
+      },
+      "engines": {
+        "node": ">=20.17.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.1.tgz",
+      "integrity": "sha512-0D493aP61w0TJ2A0wy27riRsO7FMQ7FK+KUHOKCSfPvYo0R55aiC6emCVgFUeShH0fq0ICPVzNcgoS+BsbXQCA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.33",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.33.tgz",
+      "integrity": "sha512-+SwvkaiJtxsiPjhy9LivY/1m7UsNqCJetM1BrZl9A5DkQhlbHQDU730mMiDPWjnoCYOM8Chf3WrCJw27kNTPFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.7",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.7.tgz",
+      "integrity": "sha512-hq1OB1bALKfydZNoViyg6hPVGV4i93ny9Op+n4zP5RSf7SCZEXa/TsG2O3IEr7+WlHRTPnpqDmHfMH6qXAD60w==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "easyeda-agent-mcp",
+  "version": "0.18.3",
+  "private": true,
+  "type": "module",
+  "description": "Local stdio MCP adapter for easyeda-agent",
+  "bin": {
+    "easyeda-agent-mcp": "src/server.mjs"
+  },
+  "scripts": {
+    "start": "node src/server.mjs",
+    "test": "node --test test/*.test.mjs"
+  },
+  "engines": {
+    "node": ">=20.17.0"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "1.30.0"
+  }
+}

--- a/mcp/src/core.mjs
+++ b/mcp/src/core.mjs
@@ -1,0 +1,144 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+export const DOMAIN_NAMES = [
+  'artifact',
+  'board',
+  'document',
+  'pcb',
+  'project',
+  'schematic',
+  'system',
+];
+
+export function easyedaBinary() {
+  return process.env.EASYEDA_BIN || 'easyeda';
+}
+
+export async function runEasyeda(args, timeoutMs = 300_000) {
+  try {
+    const { stdout, stderr } = await execFileAsync(easyedaBinary(), args, {
+      encoding: 'utf8',
+      maxBuffer: 32 * 1024 * 1024,
+      timeout: timeoutMs,
+    });
+    return {
+      ok: true,
+      result: parseOutput(stdout),
+      stderr: stderr.trim() || undefined,
+    };
+  }
+  catch (error) {
+    return {
+      ok: false,
+      error: {
+        message: error.message,
+        code: error.code ?? null,
+        stdout: parseOutput(error.stdout || ''),
+        stderr: String(error.stderr || '').trim() || undefined,
+      },
+    };
+  }
+}
+
+export function parseOutput(stdout) {
+  const text = String(stdout).trim();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  }
+  catch {
+    return text;
+  }
+}
+
+export function filterActions(actions, { domain, search, mutates } = {}) {
+  const needle = String(search || '').trim().toLowerCase();
+  return actions.filter((action) => {
+    if (domain && action.domain !== domain) return false;
+    if (typeof mutates === 'boolean' && action.mutates !== mutates) return false;
+    if (!needle) return true;
+    return [action.name, action.description, ...(action.inputs || [])]
+      .join(' ')
+      .toLowerCase()
+      .includes(needle);
+  });
+}
+
+export function buildCallArgs(action, input = {}) {
+  const args = [];
+  if (input.project) args.push('--project', input.project);
+  if (input.doc) args.push('--doc', input.doc);
+  args.push('call', action);
+  if (input.payload && Object.keys(input.payload).length > 0) {
+    args.push('--payload', JSON.stringify(input.payload));
+  }
+  if (input.window) args.push('--window', input.window);
+  return args;
+}
+
+export function buildWorkflowArgs(input) {
+  if (!input.project) throw new Error('project is required for workflow operations');
+  const args = ['--project', input.project];
+  if (input.doc) args.push('--doc', input.doc);
+  args.push('workflow', input.operation);
+  switch (input.operation) {
+    case 'init':
+      break;
+    case 'status':
+      args.push('--json');
+      if (input.reconcile) args.push('--reconcile');
+      break;
+    case 'advance':
+      if (Number.isInteger(input.minScore)) args.push('--min-score', String(input.minScore));
+      if (Number.isInteger(input.maxCrossings)) args.push('--max-crossings', String(input.maxCrossings));
+      break;
+    case 'confirm':
+      if (!['layout', 'outline'].includes(input.confirmation)) {
+        throw new Error('confirmation must be layout or outline');
+      }
+      args.push(input.confirmation);
+      if (input.note) args.push('--note', input.note);
+      break;
+    case 'reset':
+      if (input.resetAll === true) args.push('--all');
+      else if (input.resetFrom) args.push('--from', input.resetFrom);
+      else throw new Error('reset requires resetAll=true or resetFrom');
+      break;
+    default:
+      throw new Error(`unsupported workflow operation: ${input.operation}`);
+  }
+  return args;
+}
+
+export function buildBlocksArgs(input) {
+  switch (input.operation) {
+    case 'list':
+      return ['blocks', 'ls'];
+    case 'search':
+      if (!input.query) throw new Error('query is required for blocks search');
+      return ['blocks', 'search', input.query];
+    case 'show':
+      if (!input.id) throw new Error('id is required for blocks show');
+      return ['blocks', 'show', input.id];
+    default:
+      throw new Error(`unsupported blocks operation: ${input.operation}`);
+  }
+}
+
+export function toMcpResult(execution) {
+  const rawValue = execution.ok ? execution.result : execution.error;
+  const value = execution.ok && execution.stderr
+    ? { result: rawValue, warnings: execution.stderr }
+    : rawValue;
+  const result = {
+    content: [{ type: 'text', text: JSON.stringify(value, null, 2) }],
+    isError: !execution.ok,
+  };
+  if (execution.ok && value && typeof value === 'object' && !Array.isArray(value)) {
+    result.structuredContent = value;
+  }
+  return result;
+}

--- a/mcp/src/server.mjs
+++ b/mcp/src/server.mjs
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import {
+  buildBlocksArgs,
+  buildCallArgs,
+  buildWorkflowArgs,
+  DOMAIN_NAMES,
+  filterActions,
+  runEasyeda,
+  toMcpResult,
+} from './core.mjs';
+
+const catalogExecution = await runEasyeda(['actions'], 30_000);
+if (!catalogExecution.ok || !Array.isArray(catalogExecution.result)) {
+  process.stderr.write(`easyeda-agent-mcp: cannot load action catalog: ${JSON.stringify(catalogExecution)}\n`);
+  process.exit(1);
+}
+const actions = catalogExecution.result.filter((action) => DOMAIN_NAMES.includes(action.domain));
+const byName = new Map(actions.map((action) => [action.name, action]));
+
+const server = new Server(
+  { name: 'easyeda-agent-mcp', version: '0.18.3' },
+  {
+    capabilities: { tools: {} },
+    instructions: [
+      'Control EasyEDA Pro through easyeda-agent.',
+      'For mutations, always provide project and doc.',
+      'Inspect before editing and run schematic/PCB checks plus native DRC after editing.',
+      'Do not bypass workflow gates or use force-unsafe in real projects.',
+    ].join(' '),
+  },
+);
+
+const commonRouteProperties = {
+  project: {
+    type: 'string',
+    description: 'EasyEDA project name or UUID. Required for normal project work.',
+  },
+  doc: {
+    type: 'string',
+    description: 'Target schematic page or PCB name/UUID. Required for mutations.',
+  },
+  window: {
+    type: 'string',
+    description: 'Explicit connector windowId; use only to resolve genuine multi-window ambiguity.',
+  },
+  payload: {
+    type: 'object',
+    description: 'Typed action payload. Use easyeda_actions to inspect the action inputs.',
+    additionalProperties: true,
+  },
+};
+
+function domainTool(domain) {
+  const domainActions = actions.filter((action) => action.domain === domain);
+  return {
+    name: `easyeda_${domain}`,
+    title: `EasyEDA ${domain}`,
+    description: `Run one typed ${domain} action through easyeda-agent. Use easyeda_actions for input guidance.`,
+    inputSchema: {
+      type: 'object',
+      properties: {
+        action: {
+          type: 'string',
+          enum: domainActions.map((action) => action.name),
+          description: 'Exact typed action name.',
+        },
+        ...commonRouteProperties,
+      },
+      required: ['action'],
+      additionalProperties: false,
+    },
+    annotations: {
+      readOnlyHint: domainActions.every((action) => !action.mutates),
+      destructiveHint: domainActions.some((action) => action.mutates),
+      idempotentHint: false,
+      openWorldHint: false,
+    },
+  };
+}
+
+const tools = [
+  {
+    name: 'easyeda_health',
+    title: 'EasyEDA connection health',
+    description: 'Check the local daemon and connected EasyEDA Pro windows.',
+    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+  },
+  {
+    name: 'easyeda_actions',
+    title: 'Discover EasyEDA actions',
+    description: `Search the ${actions.length} typed EasyEDA actions and inspect inputs, mutation flags, and confirmation requirements.`,
+    inputSchema: {
+      type: 'object',
+      properties: {
+        domain: { type: 'string', enum: DOMAIN_NAMES },
+        search: { type: 'string' },
+        mutates: { type: 'boolean' },
+      },
+      additionalProperties: false,
+    },
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+  },
+  ...DOMAIN_NAMES.map(domainTool),
+  {
+    name: 'easyeda_blocks',
+    title: 'EasyEDA circuit blocks',
+    description: 'List, search, or show an embedded proven circuit block. Does not require a running daemon.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        operation: { type: 'string', enum: ['list', 'search', 'show'] },
+        query: { type: 'string', description: 'Required for search.' },
+        id: { type: 'string', description: 'Required for show.' },
+      },
+      required: ['operation'],
+      additionalProperties: false,
+    },
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+  },
+  {
+    name: 'easyeda_workflow',
+    title: 'EasyEDA guarded workflow',
+    description: 'Inspect or advance the persisted project design-flow state machine.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        operation: { type: 'string', enum: ['init', 'status', 'advance', 'confirm', 'reset'] },
+        project: { type: 'string' },
+        doc: { type: 'string' },
+        reconcile: { type: 'boolean', description: 'For status: reconcile persisted state with the live document.' },
+        minScore: { type: 'integer', minimum: 0, maximum: 100, description: 'For advance: minimum routability score.' },
+        maxCrossings: { type: 'integer', minimum: -1, description: 'For advance: maximum ratline crossings; -1 is unlimited.' },
+        confirmation: { type: 'string', enum: ['layout', 'outline'], description: 'Required for confirm.' },
+        note: { type: 'string', description: 'Human review note recorded by confirm.' },
+        resetAll: { type: 'boolean', description: 'For reset: clear every confirmation.' },
+        resetFrom: { type: 'string', description: 'For reset: first stage to clear, inclusive.' },
+      },
+      required: ['operation', 'project'],
+      additionalProperties: false,
+    },
+    annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: false },
+  },
+];
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools }));
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const { name, arguments: input = {} } = request.params;
+  try {
+    if (name === 'easyeda_health') {
+      return toMcpResult(await runEasyeda(['daemon', 'health'], 30_000));
+    }
+    if (name === 'easyeda_actions') {
+      const filtered = filterActions(actions, input);
+      return toMcpResult({ ok: true, result: { count: filtered.length, actions: filtered } });
+    }
+    if (name === 'easyeda_blocks') {
+      return toMcpResult(await runEasyeda(buildBlocksArgs(input), 30_000));
+    }
+    if (name === 'easyeda_workflow') {
+      return toMcpResult(await runEasyeda(buildWorkflowArgs(input)));
+    }
+    if (name.startsWith('easyeda_')) {
+      const domain = name.slice('easyeda_'.length);
+      if (!DOMAIN_NAMES.includes(domain)) throw new Error(`unknown EasyEDA domain tool: ${name}`);
+      const action = byName.get(input.action);
+      if (!action || action.domain !== domain) {
+        throw new Error(`action ${input.action || '(missing)'} does not belong to domain ${domain}`);
+      }
+      if (action.mutates && (!input.project || !input.doc)) {
+        throw new Error(`mutating action ${action.name} requires both project and doc`);
+      }
+      return toMcpResult(await runEasyeda(buildCallArgs(action.name, input)));
+    }
+    throw new Error(`unknown tool: ${name}`);
+  }
+  catch (error) {
+    return toMcpResult({ ok: false, error: { message: error.message } });
+  }
+});
+
+await server.connect(new StdioServerTransport());

--- a/mcp/test/core.test.mjs
+++ b/mcp/test/core.test.mjs
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildBlocksArgs,
+  buildCallArgs,
+  buildWorkflowArgs,
+  filterActions,
+  parseOutput,
+  toMcpResult,
+} from '../src/core.mjs';
+
+test('buildCallArgs pins project/doc and keeps payload structured', () => {
+  assert.deepEqual(
+    buildCallArgs('pcb.drc.run', {
+      project: 'Motor',
+      doc: 'PCB1',
+      window: 'win-1',
+      payload: { rebuild: true },
+    }),
+    ['--project', 'Motor', '--doc', 'PCB1', 'call', 'pcb.drc.run', '--payload', '{"rebuild":true}', '--window', 'win-1'],
+  );
+});
+
+test('filterActions applies domain, mutation, and text filters', () => {
+  const actions = [
+    { name: 'pcb.drc.run', domain: 'pcb', mutates: false, description: 'native check', inputs: [] },
+    { name: 'pcb.track.create', domain: 'pcb', mutates: true, description: 'route copper', inputs: ['net'] },
+    { name: 'schematic.check', domain: 'schematic', mutates: false, description: 'lint', inputs: [] },
+  ];
+  assert.deepEqual(filterActions(actions, { domain: 'pcb', mutates: true, search: 'copper' }), [actions[1]]);
+});
+
+test('workflow and blocks arguments are shell-free arrays', () => {
+  assert.deepEqual(buildWorkflowArgs({ project: 'P', doc: 'PCB1', operation: 'status', reconcile: true }),
+    ['--project', 'P', '--doc', 'PCB1', 'workflow', 'status', '--json', '--reconcile']);
+  assert.deepEqual(buildWorkflowArgs({ project: 'P', operation: 'confirm', confirmation: 'layout', note: 'reviewed' }),
+    ['--project', 'P', 'workflow', 'confirm', 'layout', '--note', 'reviewed']);
+  assert.throws(() => buildWorkflowArgs({ project: 'P', operation: 'reset' }), /reset requires/);
+  assert.deepEqual(buildBlocksArgs({ operation: 'search', query: 'usb serial' }), ['blocks', 'search', 'usb serial']);
+});
+
+test('parseOutput and MCP result preserve structured JSON', () => {
+  assert.deepEqual(parseOutput('{"ok":true}'), { ok: true });
+  assert.equal(parseOutput('plain'), 'plain');
+  const result = toMcpResult({ ok: true, result: { passed: true } });
+  assert.deepEqual(result.structuredContent, { passed: true });
+  assert.equal(result.isError, false);
+
+  const warned = toMcpResult({ ok: true, result: { passed: true }, stderr: 'staleRisk' });
+  assert.deepEqual(warned.structuredContent, { result: { passed: true }, warnings: 'staleRisk' });
+});

--- a/mcp/test/integration.test.mjs
+++ b/mcp/test/integration.test.mjs
@@ -1,0 +1,59 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+const packageDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const serverPath = process.env.EASYEDA_MCP_SERVER || path.join(packageDir, 'src', 'server.mjs');
+
+test('stdio MCP initializes, lists tools, and invokes offline discovery', async () => {
+  assert.ok(process.env.EASYEDA_BIN, 'EASYEDA_BIN must point to the local CLI for integration tests');
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [serverPath],
+    cwd: packageDir,
+    env: { ...process.env, EASYEDA_BIN: process.env.EASYEDA_BIN },
+  });
+  const client = new Client({ name: 'easyeda-agent-mcp-test', version: '1.0.0' });
+
+  try {
+    await client.connect(transport);
+    const listed = await client.listTools();
+    assert.equal(listed.tools.length, 11);
+    assert.ok(listed.tools.some((tool) => tool.name === 'easyeda_pcb'));
+    assert.ok(!listed.tools.some((tool) => tool.name === 'easyeda_debug'));
+
+    const allActions = await client.callTool({
+      name: 'easyeda_actions',
+      arguments: {},
+    });
+    assert.equal(allActions.isError, false);
+    assert.ok(!allActions.structuredContent.actions.some((action) => action.domain === 'debug'));
+
+    const discovered = await client.callTool({
+      name: 'easyeda_actions',
+      arguments: { domain: 'schematic', search: 'check', mutates: false },
+    });
+    assert.equal(discovered.isError, false);
+    assert.ok(Array.isArray(discovered.structuredContent.actions));
+    assert.ok(discovered.structuredContent.actions.some((action) => action.name === 'schematic.check'));
+
+    const rejectedMutation = await client.callTool({
+      name: 'easyeda_schematic',
+      arguments: { action: 'schematic.page.create', payload: { name: 'Unsafe' } },
+    });
+    assert.equal(rejectedMutation.isError, true);
+    assert.match(rejectedMutation.content[0].text, /requires both project and doc/);
+
+    const blocks = await client.callTool({
+      name: 'easyeda_blocks',
+      arguments: { operation: 'search', query: 'led' },
+    });
+    assert.equal(blocks.isError, false);
+  }
+  finally {
+    await client.close();
+  }
+});

--- a/skills/easyeda-agent/SKILL.md
+++ b/skills/easyeda-agent/SKILL.md
@@ -13,6 +13,10 @@ EasyEDA tooling.
 > **Source & docs:** https://github.com/zhoushoujianwork/easyeda-agent · Connector
 > 已上架[立创EDA官方插件市场](https://jlc-ext.com/item/zhoushoujian/easyeda-agent-connector)(一键装、平台可原地自动更新,但市场版本可能**滞后** CLI 若干 minor —— 四件套严格同版仍以 **GitHub Release 的 `.eext`** 为准)。Install the CLI + connector per the repo README.
 
+> **MCP 可选入口:**若当前 agent 暴露 `easyeda_*` MCP tools,可优先用它们完成 health、
+> action discovery、typed calls、blocks 和 workflow 操作。MCP 只是同一 CLI/daemon 的
+> stdio 适配层;下方全部铁律、inspect-before-mutate、阶段门和存盘要求保持不变。
+
 > **本 SKILL.md 顶部是「抗遗忘扫读区」——执行任何板级任务前先扫这几屏,别凭记忆走。**
 > 顺序:① **铁律**(不可违反)→ ② **流程停点 / 档位默认 / 块地图** 三张速查 → ③ **顺序硬约束**。
 > 具体细节**不堆在这里**——按下方 **What To Read** 的加载触发表按需读 reference(渐进式披露)。


### PR DESCRIPTION
## Problem

This PR addresses two related gaps in agent-driven EasyEDA workflows:

1. EasyEDA Pro 3.2.175 can activate the same connector extension more than once in one app window. Every activation previously registered the fixed host WebSocket id `easyeda-agent`, so the activations repeatedly closed and replaced each other's socket.
2. Agent clients that speak MCP had no structured local entry point and had to shell out to the CLI themselves.

In the live failure, connector logs showed repeated register/context/disconnect cycles, interleaved heartbeat sequences, `liveness lost: 3 pings unanswered`, continuously changing `windowId` values, `AMBIGUOUS_PROJECT`, and dropped action responses.

## Root cause

`eda.sys_WebSocket` keeps a host-managed socket table keyed by id. That table is shared by duplicate activations in the same EasyEDA window. A process-wide-looking constant was therefore not activation-safe: each activation's close/register sequence invalidated the other activation's transport.

At the daemon side, reconnect overlap and duplicate activations could temporarily produce multiple registrations for one real document tab. Treating every multiple registration as a genuine multi-window ambiguity made stable project routing impossible during that overlap.

## Fix

### Connector and routing

- Generate an activation-scoped WebSocket id, with `crypto.randomUUID`, `getRandomValues`, and legacy fallback paths.
- Preserve the existing consecutive-missed-pong heartbeat behavior.
- Coalesce registrations only when all candidates have complete, identical project UUID, document UUID, document type, and tab ID values.
- Route transport duplicates to the most recently connected registration.
- Keep genuinely different tabs/documents and incomplete identities ambiguous, so routing remains fail-closed.

### Local stdio MCP adapter

- Add an MCP server that reuses the existing `easyeda` binary and daemon.
- Expose 11 tools: health, action discovery, seven safe typed-action domains, circuit blocks, and guarded workflow operations.
- Keep payloads and workflow arguments structured and execute the CLI through shell-free argument arrays.
- Require both `project` and `doc` before a mutating typed action can reach the daemon.
- Preserve successful CLI stderr warnings in MCP results.
- Deliberately exclude the arbitrary-JavaScript `debug.exec_js` domain.

The MCP process does not connect to EasyEDA directly and does not bypass typed actions, audit logs, workflow gates, connector routing, or the official `eda.*` API.

## Tests

Passed on macOS arm64 with Node.js 24 and Go 1.24 toolchain:

- `go test ./...`
- `go vet ./...`
- `npm --prefix extension run typecheck`
- `npm --prefix extension test` (78/78)
- `make mcp-test` (5/5, including SDK stdio initialization, 11-tool discovery, offline action/block calls, and pre-daemon mutation rejection)
- `npm --prefix mcp audit --omit=dev` (0 vulnerabilities)
- `make lint-test`
- `npm --prefix extension run build` (produced an importable v0.18.3 `.eext`)
- `npm pack --dry-run` from `mcp/`
- `git diff --check`

The original reconnect storm was observed in a real EasyEDA Pro 3.2.175 process. For the final committed build, the daemon health endpoint was verified, but the already-running EasyEDA window did not register a connector without a full application restart. I did not force that restart because it could discard unrelated unsaved editor state, so post-fix live soak testing is intentionally not claimed here.

## Compatibility and migration

- No protocol frame changes are required.
- Existing CLI and Skill workflows continue to work unchanged.
- MCP is optional and uses stdio; clients must restart after registration to discover it.
- The connector must be rebuilt/reimported and EasyEDA fully restarted for the activation-scoped socket id to take effect.
