### PR TITLE
改进多页原理图验收流程并增加确定性验收脚本

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ mcp-test: build ## install MCP deps and run unit + stdio protocol tests
 # fixture goldens (known-good board stays clean, known-bad cases still fire).
 lint-test: ## linter rule-trust harness (orientation + fixtures)
 	python3 skills/easyeda-agent/scripts/tests/run.py
+	python3 -m unittest discover -s skills/easyeda-agent/scripts/tests -p '*_test.py'
 
 blocks-audit: ## check every block pin ref against real symbol pins (offline; --probe to refresh)
 	python3 skills/easyeda-agent/scripts/blocks-pin-audit.py

--- a/skills/easyeda-agent/SKILL.md
+++ b/skills/easyeda-agent/SKILL.md
@@ -2,7 +2,6 @@
 name: easyeda-agent
 description: "Community EasyEDA Agent automation skill for EasyEDA Pro schematic and PCB work through the local easyeda-agent CLI/daemon/connector. Use when designing a board from scratch; inspecting, cleaning up, or safely refactoring an existing wired schematic; arranging multi-page functional modules; drawing page-scoped module frames and text labels; preserving and reconciling pin-to-net topology; placing/wiring real LCSC/JLC library parts; syncing schematic changes into PCB; laying out PCB components; running EasyEDA DRC/check/bridge-check/layout-lint; exporting BOM/netlists/artifacts; querying the embedded circuit-block library (`easyeda blocks ls/show/search`); or applying the bundled EasyEDA design workflows and conventions. 覆盖嘉立创EDA专业版原理图/PCB、混乱原理图整理、多页功能分区、框选文字标注、布线、铺铜、板框与机械门禁。适用于嘉立创EDA(JLC EDA / JLCEDA / LCEDA / EasyEDA Pro)与立创商城(LCSC)元件的电路板设计自动化。"
 license: MIT
-compatibility: "Requires the local easyeda-agent CLI and daemon (macOS/Linux/Windows) plus the EasyEDA Agent Connector extension installed in EasyEDA Pro with 'Allow external interaction' enabled. Bundled scripts need Python 3. Network access is needed only for LCSC part lookup and self-update."
 metadata:
   author: zhoushoujianwork
   version: "1.1.1"
@@ -15,6 +14,10 @@ Use the local `easyeda` CLI and daemon to operate EasyEDA Pro through typed,
 observable actions. This is the community `easyeda-agent` workflow, not an official
 EasyEDA skill; the suffix is intentional so users can distinguish it from upstream
 EasyEDA tooling.
+
+Requires the local `easyeda` CLI and daemon (macOS/Linux/Windows), the EasyEDA Agent
+Connector extension with “Allow external interaction” enabled, and Python 3 for
+bundled scripts. Network access is only needed for LCSC lookup and self-update.
 
 > **本 skill 单独装上没用 —— 它要驱动两个外部件:本机 `easyeda` CLI/daemon + EasyEDA Pro 里的连接器插件。**
 > 源码与文档:https://github.com/zhoushoujianwork/easyeda-agent
@@ -69,6 +72,7 @@ EasyEDA tooling.
 14. **阶段门禁机械强制,不必预读细则** — 布线前、布线后各一道门,未过一律被拒(daemon 在 /action 层也拦,raw 调用绕不过)。撞上去的拒绝消息**自带下一条该跑的命令**,照做即可。切入/恢复会话:`workflow status --reconcile` → `workflow advance`。→ design-flow P6(含 force 分级 #132)/P10
 15. **原理图必须分页分区 + 每模块电路说明,默认必做**(「最小/单页」不是借口)— ①分页(页名=功能名)②`sch zones set`+`zone-draw` 画区框(**单页小板也要画**)③每模块 1~3 行 `sch note`。⚠ 手工 `block-apply`/`sch place` **不自动画框**,必须补 ②③。机械兜底:`sch check` 的 `missing-partition` + `sch gate --strict` 会挡下。→ design-flow S1–S3
 16. **「探出图纸」≠「比图纸还大」** — 前者挪一挪能解;后者(`page-too-small`)挪多少次都没用,必须换手段,且**分页是设计决策 → 停手问用户**(工具不自动分页)。别人肉重试:`--max-attempts`(默认 3)会替你停手。→ design-flow S3
+17. **S0 先于任何放置** — spec 必须在首个 `page-new` / `place` / `block-apply` 前落盘并通过 `easyeda spec validate --strict`;先画后补只能算记录,不能证明设计决策已冻结。→ design-flow S0
 
 ## ② 流程停点 + 档位默认 + 块地图速查
 
@@ -161,8 +165,10 @@ EasyEDA tooling.
 - **Schematic work**:读 `references/schematic.md`。
 - **混乱/已连线原理图整理、多页高质量布局、功能框和文字标注**:同时读
   `references/design-flow.md` 的 S1–S6、`references/auto-layout-sop.md` 的
-  “已连线页安全整理”，以及 `references/schematic.md` 的 “Functional frames +
-  text labels”。先保存 pin→net/NC 黄金表，任何布局重构后必须逐页对账。
+  “已连线页安全整理”、`references/schematic-efficient-flow.md`,以及
+  `references/schematic.md` 的 “Functional frames + text labels”。先保存 pin→net/NC
+  黄金表，任何布局重构后必须逐页对账；多页最终验收走
+  `scripts/schematic-acceptance.py`,不要手工重拼页循环。
 - **PCB work**:读 `references/pcb.md`(顶部有「块的 PCB 约束(先查)」+ 命令目录)。
 - 查任一 typed action 签名、或 >5 步批量操作要用 playbook(`easyeda apply`):读 `references/actions.md`。
 - **DRC / 制造规则地板与 fallback**:读 `references/fab-rules-jlcpcb.json`(live `pcb.drc.rules` 优先,此表作 fallback seed + clamp floors,**永不发出低于 manufacturingMin 的 track/via/gap**)。

--- a/skills/easyeda-agent/references/auto-layout-sop.md
+++ b/skills/easyeda-agent/references/auto-layout-sop.md
@@ -19,17 +19,20 @@ netflag、去耦贴 IC、框和文字按页保存。**
 
 ### 新建或尚未布线的页面
 
-1. `easyeda sch sheet-geometry --json --doc <page>`：必须有真实 sheet bbox。
-2. 按功能拆页并生成 module spec；`easyeda sch zones set --spec <spec>` 持久化
+1. **先落盘并严格校验 S0 spec，再创建/放置页面。** spec 至少冻结器件选型、统一网名、
+   页面集合、模块归属和接口方向；文件时间必须早于首个 placement。不要用 `_NEW` 页面
+   作为容量规划手段。
+2. `easyeda sch sheet-geometry --json --doc <page>`：必须有真实 sheet bbox。
+3. 按功能拆页并生成 module spec；`easyeda sch zones set --spec <spec>` 持久化
    （认领现在**只给布局前的 `sch autolayout` 指定落位格位**；分区框/说明的成员归属
    读的是虚拟组 —— `sch block-apply` 落块时已按功能子群自动归组）
    `modules[].page/zone/parts`。
-3. 放置全部器件并读回真实 bbox/pins。优先 `sch block-apply`；其次在无
+4. 放置全部器件并读回真实 bbox/pins。优先 `sch block-apply`；其次在无
    wire/bus/marker 的页面运行 `sch autolayout --engine template --dry-run`，确认后
    `--apply --doc <page>`。
-4. 每页通过 `sch layout-lint --strict --doc <page>` 后才布线。
-5. 模块内部画短正交线；电源/地/netport 短桩优先用 `sch autoconnect`。
-6. 逐页完成下方“功能框 + 文字标注”和“最终验证门”。
+5. 每页通过 `sch layout-lint --strict --doc <page>` 后才布线。
+6. 模块内部画短正交线；电源/地/netport 短桩优先用 `sch autoconnect`。
+7. 逐页完成下方“功能框 + 文字标注”和“最终验证门”。
 
 ### 已连线、待整理的页面
 
@@ -56,6 +59,19 @@ netflag、去耦贴 IC、框和文字按页保存。**
 5. 每批修改后立即 `sch read` 对照黄金表；任何 pin→net、NC 集合变化都先修复，不带病
    进入下一批。每个通过的批次显式 `sch save`。
 6. 全页完成后运行最终验证门；只有拓扑完全一致才可宣布“只是布局变化”。
+
+### 每页事务与失败预算
+
+每页只走一条状态线：`baseline → mutate → readback → cheap gate → save`。未过的页不进入
+下一页，也不把多页问题混在一次大修里。
+
+- 中间检查只跑 `sch gate --only layout-lint,check,bridge-check --doc <page>`；官方 DRC
+  放到该页完成或最终验收时跑，避免每挪一个标签都重复最慢检查。
+- `connect_pin`、`disconnect`、move、delete 等非幂等动作 fail/partial 后先读回活体；
+  只重试明确失败项一次。第二次同类失败立即停止，保留输入、stderr 和 readback。
+- `zone-arrange`、`destagger` 先 dry-run 一次，apply 最多一次；断言、网表或 bridge 变差
+  时停止，不重放整批。
+- 一个页面若需要第二次整体迁移，回到 S0/S1 重算分页，不再追加临时 `_NEW` 页。
 
 ## 功能框 + 文字标注（逐页）
 
@@ -109,13 +125,27 @@ easyeda sch zone-draw --mode partition --font-size 22 --doc <page> --project <pr
 
 ## 最终验证门（每页）
 
-1. `easyeda sch gate --strict --doc <page>`：**`verdict` 必须是 `pass`**。一条命令按固定顺序
+多页工程优先运行：
+
+```bash
+python3 <skill>/scripts/schematic-acceptance.py \
+  --project <project> --spec <s0.json> --golden <pin-net.json> \
+  --export --artifacts .easyeda/artifacts
+```
+
+脚本只读取一次页表，随后串行显式打开每页，执行 strict gate、权威 `sch read`、全工程
+`sch nets --strict`、黄金 pin→net/NC 对账和可选导出，避免手工循环漏页。
+
+1. `easyeda sch gate --strict --doc <page>`：通常 **`verdict` 必须是 `pass`**。一条命令按固定顺序
    跑完四关(layout-lint 0 overlap/0 pin-coincidence + check 结构与 marker findings 0 +
    bridge-check 0 bridge、orphan 解释或清理 + drc fatal/error 0),报告里带每关的计数;
    DRC 聚合 WARN 仍需审阅并报告。
    - `verdict=blocked` **不是板子的问题**——检查器没跑起来(连接器断/页没打开),
      先 `easyeda health` + `doc switch <page>` 修环境再重跑,别去改电路。
    - 窗口不在前台时先 `--skip drc` 过前三关,DRC 单独补跑。
+   - CLI/connector v1.1.1 若仅被 `missing-titleblock` 阻塞，可在 acceptance 脚本上显式加
+     `--allow-titleblock-gap` 挂账；脚本会拒绝任何其他版本、stage 或 finding。不要执行
+     gate 输出里的 `sch titleblock --data`，该写路径会损坏 sheet 引用。
 2. `easyeda sch read --doc <page>`：与设计 spec 或整理前黄金
    `DESIGNATOR.pin → net`、显式 NC 集合逐项一致。**gate 判「合不合法」,这步判「对不对」**,
    两者都要。

--- a/skills/easyeda-agent/references/design-flow.md
+++ b/skills/easyeda-agent/references/design-flow.md
@@ -54,14 +54,14 @@ S0 设计方案书 → S1 图纸/分页💾 → S2 模块编组 → S3 按组摆
 
 | 步 | 做什么 | 固定命令 | 过门判据(不过不进下一步) |
 |---|---|---|---|
-| S0 | 方案书:选块选型、网名表、分页计划、架构决策 | `blocks ls/search/show` → spec 写盘 → `easyeda spec validate`(落块后位号回填走 `easyeda spec backfill … --write`,或 `block-apply --spec`) | validate 无 ERROR;milestone 档经用户确认 |
+| S0 | 方案书:选块选型、网名表、分页计划、架构决策 | `blocks ls/search/show` → spec 写盘 → `easyeda spec validate --strict`(落块后位号回填走 `easyeda spec backfill … --write`,或 `block-apply --spec`) | **首个 page-new/place/block-apply 前** validate 无 ERROR;milestone 档经用户确认 |
 | S1 | 图纸/分页 reconcile 到模块计划 | `sch pages` → `page-rename`/`page-new`/`page-delete` → `sch sheet-geometry --json` | 页集合=模块计划;每页有 A4 sheet 💾 |
 | S2 | 分区规划(只规划不落子) | 块路径读虚拟组;手工页 `sch zones set` → `sch zone-plan --json` | 六项 validation 全 0 **且 `labelScopeDegraded=false`**(降级=判据验不了,不是"没问题") |
 | S3 | 按组摆放(块优先;命中块 S3+S4 一条命令) | `sch block-apply <id> --bind 端口=网名 --spec <s0.json>`(`--spec` 顺手回填位号)/ `sch autolayout --engine template` / `sch place`+`modify` | `sch gate --only layout-lint,clusters` 无 ERROR 💾。⛔ 报 `page-too-small` = **停手问用户**(独立成页/继续分页/收小组),工具不自动分页;人肉重试由 `--max-attempts`(默认 3)机械叫停 |
 | S3′ | **分区收敛(按需)**:分区拥挤 / `partitionOverlap`>0 / 重整已放置页 | `sch zone-arrange`(纯规划,唯一解;phase B = 边归属+多层货架+回溯)→ `--apply`(断言①②+假失败清创+分级回滚+**断言③落地复判**) | verdict=pass 且断言①②③绿(③ = 落地实测框 vs 规划框偏差 ≤ gutter、区框零重叠、**无成员探出图纸**、**retain 区几何未被改动**、**无自由落点 pin**)。**断言③红时不要「多跑几遍」** —— 桩线伸展已统一为一把尺,再跑一轮只会追尾(真机 4 轮取证:每轮 dry-run pass、落地必重叠);按复判表定位是哪个区胖了。**这条现在有机械兜底**:`block-apply`/`destagger`/`group-move` 的 `--max-attempts`(默认 3,跨调用失败签名台账)会在同一个结果第 3 次出现时**停手并给结论**,画布零改动;而一旦读到 `page-too-small` 就**别再做任何几何微调**,直接进拆页决策(见 S3 停点)。注意「规划框 = 落地框上界」**只在模型内成立**(同一份 pin 坐标+桩长),真机 MCU_IO 六区实测偏差 +141/+126/+82/+56/+26/+10,断言③ 的职责就是把不成立的那几次报出来。报「N 只 pin 走了自由落点」= 计划根本没覆盖那几只脚,它们的方向/桩长不在规划里,先看是不是有 pin 靠普通导线/netlabel 连着。`blocked` 时先看 phase A 那一栏收敛了没(**排不下的是形状不是面积**)——phase A 现在会**域感知选形**(候选先比可排布档位、再比「本页有几条通道装得下」,平局才回到原有紧凑序),所以 `zones[].mode` 尾巴会直说它选了什么形态、为什么;读到「没有一个装得进任何通道」就是真的要拆(**别去调纸张/带高**),再考虑 `page-new` 拆页 —— A4-only,不换纸。phase A 行首的 `↩` = **「不得变差」门回退了这一区**(收敛会让它在本页**更难排**,于是保留原形;理由在 `zones[].retainWhy`)—— 那是保护不是故障,**别去改 A4 尺寸/带高绕开它**,要么把该区拆小要么拆页;门比的是**三档可排布性**(`2` 有落点 / `1` 只被图签挡 / `0` 连可用域都装不下),掉档才回退 —— 所以「原形也排不下」不等于放行,`1 → 0` 照样拦(2026-08-20 第二轮真机 `449×737 → 244×863` 就是从首版那个单布尔判据里漏掉的);两个形状都是 `0` 档时门不拦,phase B 报「纸面放不下」= 真的要拆。`↩` 区在 `--apply` 里受**刚体不变式**硬门保护(逐 pin 比对方向/桩长/类型,不一致就拒绝整页、画布零改动) |
 | S4 | 通道布线(块外的连线) | `sch autoconnect`(电源/地/netport)/ `sch wire`(信号) | 无穿件压线 💾 |
-| S5 | 校验门(机械真值) | 逐页 `sch gate --strict --doc <页>` + 全工程 `sch nets --strict` + `sch reconcile` | 每页 verdict=pass;无网名变体/单引脚网;意图对账无差异 |
-| S6 | 调整闭环 | 照 gate 报告「下一步」修 → 重跑 gate | verdict=pass → `sch save` 确认 `saved:true` 💾 |
+| S5 | 校验门(机械真值) | 多页统一运行 `scripts/schematic-acceptance.py`(内部逐页 strict gate + 全工程 nets + 黄金对账) | 每页 verdict=pass;或仅显式挂账 v1.1.1 `missing-titleblock`;无网名变体/单引脚网;意图对账无差异 |
+| S6 | 调整闭环 | 按页修一个 finding 类别 → 先跑便宜门 → 最终只重跑一次 acceptance | acceptance 通过 → `sch save` 确认 `saved:true` 💾 |
 | S6′ | 交付三件套(默认必做) | `sch zone-draw --mode partition` + `sch note --zone <模块>` + ~~`sch titleblock`~~(⚠图签写入当前禁用:写路径损毁 sheet 引用→重启丢图框,见 actions.md;留白如实报) | `sch check` 无 missing-partition/note(titleblock 挂账) |
 
 > `blocked` ≠ `fail`(检查器没跑成,先修环境别改电路);判状态看数据不看截图;每过门显式 save。
@@ -75,6 +75,9 @@ imported/placement_ready 打成实心圆,而那块 PCB 上一个器件都没有�
 S6 平台不暴露脏标记(只能显式 `sch save` 并确认 `saved:true`)。
 
 ### S0 — 设计方案书(Design Proposal)
+- **时序门**:S0 spec 必须在首个 `page-new`、`place` 或 `block-apply` 前落盘并通过
+  `easyeda spec validate --strict`。先画后补 spec 只能算事后记录,不能阻止选型、分页和
+  统一网名返工；不要靠创建 `*_NEW` 临时页代替容量规划。
 - **做什么**:读懂设计——器件清单、电源树、功能模块划分、目标幅面;**并在放置第一个元件之前**,把覆盖原理图 + PCB 全程的架构决策一次性定下来,而不是让它们在 S2/P4/P8 执行到才被想起(实测最贵的返工正是决策后置:天线 keepout 后置逼已布线的模块重绕,地策略选错要重铺)。
 - **怎么做(轻量摸底)**:见 conventions 的 `design-pre-analysis.md`(器件清单、电源树、功能分组、幅面估算)。`easyeda health` 确认已连接。
 - **怎么做(架构决策)**:查 [`design-decisions.md`](./design-decisions.md) 里的决策点清单——叠层与层数、地策略(单 GND PLANE vs 分区 pour + 桥地)、接口取向(如 USB 单/双取向)、器件选型成本档位等。**每一条都要把该文件里的选项、已知坑、推荐方案摊开给用户看,由用户拍板,不能替用户默认选**——这是设计方案书阶段的核心产出,不是可选步骤。RF/天线 keepout 范围**不在**这份决策清单里——它是唯一正确答案的 guardrail(必须覆盖全层),不摊开选项;S0 只需把 RF 器件位号和 `"all"` 层范围写进 spec 的 `rf` 字段供 P4 直接读取执行。
@@ -356,6 +359,8 @@ S6 平台不暴露脏标记(只能显式 `sch save` 并确认 `saved:true`)。
 
 **逐页跑 `easyeda sch gate --strict --doc <page>`,再做一次设计意图对账。** 不要用
 `--all-pages` 的浅数据冒充逐页证明(`--strict` 与 `--all-pages` 不兼容,多页就循环 `--doc`)。
+多页工程优先运行 `scripts/schematic-acceptance.py`,由它统一核对页集合、逐页 gate、全工程
+nets、pin→net/NC 黄金表和最终导出,避免漏页或重复执行同一组慢检查。
 
 1. **机械门(一条命令)** `easyeda sch gate --strict --doc <page>`
 
@@ -395,6 +400,12 @@ S6 平台不暴露脏标记(只能显式 `sch save` 并确认 `saved:true`)。
    `--json` 带每个 stage 的完整原生报告(`stages[].detail`),是四个单命令 JSON 的超集,不用重跑。
    局部复查仍可直接用 `sch layout-lint` / `sch check` / `sch bridge-check` / `sch drc` 单命令
    (它们原样保留),但**交付门走 gate**。窗口不在前台时 `--skip drc` 先过前三关。
+
+   **v1.1.1 标题栏例外(精确 allowlist,不是通用忽略 WARN):**`sch titleblock --data`
+   会损坏 sheet 引用,而 strict gate 同时会报 `missing-titleblock` 并建议该危险命令。
+   只有 CLI 与 connector 都是 1.1.1、失败 stage 仅为 `check`、finding 仅含
+   `missing-titleblock`、其余 stage 全 pass 时,才可给 acceptance 脚本显式传
+   `--allow-titleblock-gap` 挂账。任何其他版本、stage 或 finding 仍失败。
 
 2. **跨页网名门(逐页命令看不见的那半)** `easyeda sch nets --strict`
 

--- a/skills/easyeda-agent/references/schematic-efficient-flow.md
+++ b/skills/easyeda-agent/references/schematic-efficient-flow.md
@@ -1,0 +1,99 @@
+# 多页原理图高效收敛流程
+
+用于新建多页原理图、已连线页面重排和跨 agent 接力。目标不是减少必要验证，而是把验证
+安排在能最早发现问题、又不重复付费的位置。
+
+## 1. S0 冻结门
+
+首个 `page-new`、`place` 或 `block-apply` 之前，必须有一份已落盘并通过
+`easyeda spec validate --strict` 的 S0 spec。至少包含：
+
+- 已确认的器件和封装；
+- 全工程统一网名；
+- 页面集合、模块归属和页面职责；
+- 接口朝向、板框、层数、天线方案等会影响后续布局的决策。
+
+spec 文件时间应早于首个 placement。若先画后补，它只是事后记录，不能阻止返工。容量
+判断先用真实 sheet、器件 bbox 和 `zone-plan` 六项 validation；不能确认可读性时先拆页，
+不要创建 `*_NEW` 页面搬家后再删旧页。
+
+## 2. 一页一个事务
+
+每页按固定顺序收敛：
+
+1. `sch read --page <uuid> --stay` 保存 pin→net 和 NC 基线。
+2. 只修改这一页；所有 mutation 显式 `--doc <uuid>`。
+3. `sch read --page <uuid> --stay --no-check` 对照基线或黄金表。
+4. 跑便宜门：`sch gate --only layout-lint,check,bridge-check --doc <uuid>`。
+5. 通过后 `sch save --doc <uuid>`，再进入下一页。
+
+官方 DRC 放在该页完成时或最终验收时跑。不要在每次移动标签后重复跑全 gate。
+
+## 3. 批量操作停止条件
+
+`connect_pin`、`disconnect`、move、delete 和 autoconnect 不是可盲目重放的事务：
+
+- fail/partial 后先 `sch read`，区分成功项、失败项和附带断开的引脚；
+- 只重试明确失败项一次；
+- 同类失败第二次立即停止，保存输入、stderr、活体 read 和 bridge 报告；
+- 不把整个 spec 再提交一遍，否则可能叠加 marker、合并线树或制造短路。
+
+`zone-arrange` 和 `destagger` 都执行 `dry-run 一次 → apply 最多一次`。任何落地断言、黄金
+网表或 bridge 变差都停止。重复运行相同变换器不是收敛策略。
+
+## 4. 多页读取和交付
+
+非活动页的 `--all-pages` 数据可能缺 pins/bbox，不能用于严格证明。逐页用
+`sch read --page <uuid> --stay`；导出前显式 `sch open --page <uuid>`。页面清单命令默认
+已输出 JSON envelope，`sch pages` 没有 `--json` flag。
+
+最终使用：
+
+```bash
+python3 <skill>/scripts/schematic-acceptance.py \
+  --project <project> \
+  --spec .easyeda/s0-project.json \
+  --golden .easyeda/pin-net-golden.json \
+  --export --artifacts .easyeda/artifacts
+```
+
+该脚本一次完成：页集合对账、逐页 strict gate、全工程 `nets --strict`、黄金 pin→net/NC
+对账和最终图片导出。失败报告已包含 stage 详情，不要为查看同一 finding 再跑四个单命令。
+
+## 5. v1.1.1 已知缺陷
+
+### 标题栏不可达门
+
+CLI/connector v1.1.1 同时存在三个矛盾行为：
+
+- `sch titleblock --data` 会损坏 sheet 符号引用，保存重启后可能丢图框；
+- strict gate 对空标题栏报 `missing-titleblock`，并建议执行上述危险命令；
+- `check.summary.missingPartitions` 会把这个 finding 错计为 1。
+
+默认仍将 strict gate 失败视为失败。只有失败 stage 仅为 `check`、finding 仅含
+`missing-titleblock`、其余 stage 全 pass，并显式传入 `--allow-titleblock-gap` 时才允许
+挂账。这不是忽略其他 WARN 的通用开关，且脚本会核对 CLI 和 connector 都是 1.1.1。
+
+### 容量布尔值误报
+
+若 `zone-plan.capacity.fits` 与 `needW/haveW`、`needH/haveH` 自相矛盾，不要围绕单个布尔值
+反复搬动。以六项 validation、实际 bbox、区框重叠和图纸越界为门，并保留矛盾 JSON。
+
+### 审计证据不完整
+
+daemon audit 的失败记录可能只有 action/errorCode，没有输入和错误正文；playbook journal
+也只记录顶层 step，可能看不到内部 action 失败。复盘时同时保留 CLI stderr、journal、最终
+`sch read` 和 gate JSON，不把 journal 全绿当作电路全绿。
+
+## 6. 跨 agent 接力包
+
+交给另一个 agent 前只提供以下稳定材料：
+
+- 当前页表及 UUID；
+- S0 spec、器件 manifest、黄金 pin→net/NC；
+- 每页最近一次 gate JSON 和最终导出图；
+- 禁止动作与已知挂账；
+- 明确的单页 ownership。
+
+接手 agent 首先运行 acceptance 的只读部分。未对齐黄金表前不得修改；修改后只交回该页
+的差异和验收结果。

--- a/skills/easyeda-agent/scripts/schematic-acceptance.py
+++ b/skills/easyeda-agent/scripts/schematic-acceptance.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3
+"""Run one deterministic acceptance pass for a multi-page schematic."""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+FULL_GATE_STAGES = {"layout-lint", "clusters", "check", "bridge-check", "drc"}
+
+
+class AcceptanceError(RuntimeError):
+    pass
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--project", help="EasyEDA project name or UUID")
+    parser.add_argument("--spec", type=Path, help="S0 design spec with pages[]")
+    parser.add_argument("--golden", type=Path, help="Golden nets[].members and nc[] JSON")
+    parser.add_argument("--artifacts", type=Path, default=Path(".easyeda/artifacts"))
+    parser.add_argument("--report-out", type=Path, help="Write the JSON report to this path")
+    parser.add_argument("--export", action="store_true", help="Export PAGE-final.png for each page")
+    parser.add_argument("--skip-gate", action="store_true", help="Skip per-page strict gate")
+    parser.add_argument(
+        "--allow-titleblock-gap",
+        action="store_true",
+        help="Allow only the exact v1.1.1 missing-titleblock gate failure",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit a JSON report")
+    parser.add_argument("--easyeda", default="easyeda", help="Path to the easyeda CLI")
+    return parser.parse_args(argv)
+
+
+def run_command(base, args, allow_failure=False, expect_json=True):
+    command = [base] + list(args)
+    completed = subprocess.run(command, text=True, capture_output=True, check=False)
+    payload = None
+    if expect_json:
+        try:
+            payload = json.loads(completed.stdout)
+        except json.JSONDecodeError as exc:
+            raise AcceptanceError(
+                f"invalid JSON from {' '.join(command)}: {exc}; "
+                f"stderr={completed.stderr.strip()}"
+            ) from exc
+    if completed.returncode and not allow_failure:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise AcceptanceError(
+            f"command failed ({completed.returncode}): {' '.join(command)}: {detail}"
+        )
+    return completed.returncode, payload, completed.stderr.strip()
+
+
+def with_project(args, project):
+    values = list(args)
+    if project:
+        values.extend(["--project", project])
+    return values
+
+
+def unwrap_result(payload):
+    if isinstance(payload, dict) and isinstance(payload.get("result"), dict):
+        return payload["result"]
+    return payload
+
+
+def load_json(path):
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise AcceptanceError(f"cannot read {path}: {exc}") from exc
+
+
+def find_window(health, project):
+    windows = health.get("found", {}).get("raw", {}).get("windows", [])
+    if not windows:
+        raise AcceptanceError("easyeda health found no connected window")
+    if project:
+        for window in windows:
+            context = window.get("context", {})
+            if project in (context.get("projectName"), context.get("projectUuid")):
+                return window
+        available = [
+            window.get("context", {}).get("projectName") or "<unknown>"
+            for window in windows
+        ]
+        raise AcceptanceError(
+            f"no connected window matches project {project!r}; available={available}"
+        )
+    return windows[0]
+
+
+def compare_page_sets(actual, expected):
+    actual_duplicates = duplicate_values(actual)
+    expected_duplicates = duplicate_values(expected)
+    return {
+        "actual": actual,
+        "expected": expected,
+        "actualDuplicates": actual_duplicates,
+        "expectedDuplicates": expected_duplicates,
+        "matched": not actual_duplicates
+        and not expected_duplicates
+        and set(actual) == set(expected),
+    }
+
+
+def expected_pin_map(golden):
+    records = []
+    for net in golden.get("nets", []):
+        for member in net.get("members", []):
+            records.append((member, net.get("name")))
+    records.extend((pin, None) for pin in golden.get("nc", []))
+    return records
+
+
+def actual_pin_records(read_payload):
+    records = []
+    for component in unwrap_result(read_payload).get("components", []):
+        if component.get("componentType") != "part":
+            continue
+        designator = component.get("designator")
+        for pin in component.get("pins", []):
+            records.append((f"{designator}.{pin.get('number')}", pin.get("net")))
+    return records
+
+
+def duplicate_values(values):
+    counts = {}
+    for value in values:
+        counts[value] = counts.get(value, 0) + 1
+    return sorted(
+        (value for value, count in counts.items() if count > 1), key=lambda value: str(value)
+    )
+
+
+def duplicate_keys(records):
+    return duplicate_values([key for key, _ in records])
+
+
+def compare_pins(actual, expected):
+    actual_map = dict(actual)
+    expected_map = dict(expected)
+    missing = sorted(key for key in expected_map if key not in actual_map)
+    unexpected = sorted(key for key in actual_map if key not in expected_map)
+    mismatched = [
+        {"pin": key, "expected": expected_map[key], "actual": actual_map[key]}
+        for key in sorted(expected_map.keys() & actual_map.keys())
+        if expected_map[key] != actual_map[key]
+    ]
+    actual_duplicates = duplicate_keys(actual)
+    expected_duplicates = duplicate_keys(expected)
+    return {
+        "actualPinCount": len(actual),
+        "expectedPinCount": len(expected),
+        "actualNC": sum(1 for _, net in actual if net is None),
+        "expectedNC": sum(1 for _, net in expected if net is None),
+        "missingPins": missing,
+        "unexpectedPins": unexpected,
+        "mismatchedNets": mismatched,
+        "actualDuplicatePins": actual_duplicates,
+        "expectedDuplicatePins": expected_duplicates,
+        "matched": not (
+            missing or unexpected or mismatched or actual_duplicates or expected_duplicates
+        ),
+    }
+
+
+def titleblock_only_failure(gate):
+    gate = unwrap_result(gate)
+    if gate.get("verdict") != "fail":
+        return False
+    stages = gate.get("stages", [])
+    if {stage.get("name") for stage in stages} != FULL_GATE_STAGES:
+        return False
+    check = next(stage for stage in stages if stage.get("name") == "check")
+    if check.get("status") != "fail":
+        return False
+    if any(stage.get("status") != "pass" for stage in stages if stage is not check):
+        return False
+    detail = unwrap_result(check.get("detail") or {})
+    findings = detail.get("findings") or []
+    return bool(findings) and all(
+        item.get("type") == "missing-titleblock" for item in findings
+    )
+
+
+def safe_page_name(name):
+    cleaned = re.sub(r"[^A-Za-z0-9_.-]+", "_", name).strip("._")
+    return cleaned or "PAGE"
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    errors = []
+    report = {
+        "ok": False,
+        "pages": [],
+        "pageSet": {},
+        "nets": {},
+        "pins": None,
+        "exports": [],
+        "errors": errors,
+    }
+
+    _, health, _ = run_command(args.easyeda, ["health"])
+    window = find_window(health, args.project)
+    if not window.get("connectorVersionOk"):
+        raise AcceptanceError("connector version does not match the CLI")
+    raw_health = health.get("found", {}).get("raw", {})
+    if args.allow_titleblock_gap and (
+        raw_health.get("version") != "v1.1.1"
+        or window.get("connectorVersion") != "1.1.1"
+    ):
+        raise AcceptanceError(
+            "--allow-titleblock-gap is scoped to CLI/connector v1.1.1; "
+            "rerun without it"
+        )
+    context = window.get("context", {})
+    original_page = (
+        context.get("documentUuid") if context.get("documentType") == "schematic" else None
+    )
+
+    try:
+        _, pages_payload, _ = run_command(
+            args.easyeda, with_project(["sch", "pages"], args.project)
+        )
+        pages = unwrap_result(pages_payload).get("pages", [])
+        if not pages:
+            raise AcceptanceError("project has no schematic pages")
+
+        actual_names = [page.get("name") for page in pages]
+        if args.spec:
+            run_command(
+                args.easyeda,
+                ["spec", "validate", str(args.spec), "--strict"],
+                expect_json=False,
+            )
+            spec = load_json(args.spec)
+            expected_names = [page.get("name") for page in spec.get("pages", [])]
+            report["pageSet"] = compare_page_sets(actual_names, expected_names)
+            if not report["pageSet"]["matched"]:
+                errors.append({"type": "page-set-mismatch", "detail": report["pageSet"]})
+        else:
+            report["pageSet"] = {
+                "actual": actual_names,
+                "expected": None,
+                "actualDuplicates": duplicate_values(actual_names),
+                "expectedDuplicates": [],
+                "matched": not duplicate_values(actual_names),
+            }
+            if not report["pageSet"]["matched"]:
+                errors.append({"type": "duplicate-pages", "detail": report["pageSet"]})
+
+        nets_rc, nets_payload, nets_stderr = run_command(
+            args.easyeda,
+            with_project(["sch", "nets", "--all", "--strict", "--json"], args.project),
+            allow_failure=True,
+        )
+        nets = unwrap_result(nets_payload)
+        report["nets"] = {
+            "ok": nets_rc == 0 and bool(nets.get("ok")),
+            "totalNets": nets.get("totalNets"),
+            "stderr": nets_stderr or None,
+        }
+        if not report["nets"]["ok"]:
+            errors.append({"type": "project-nets-failed", "detail": nets_payload})
+
+        all_actual_pins = []
+        if args.export:
+            args.artifacts.mkdir(parents=True, exist_ok=True)
+
+        for page in pages:
+            name = page.get("name")
+            uuid = page.get("uuid")
+            page_report = {"name": name, "uuid": uuid, "gate": "skipped"}
+
+            run_command(
+                args.easyeda,
+                with_project(["sch", "open", "--page", uuid], args.project),
+            )
+
+            if not args.skip_gate:
+                _, gate_payload, gate_stderr = run_command(
+                    args.easyeda,
+                    with_project(
+                        ["sch", "gate", "--strict", "--doc", uuid, "--json"],
+                        args.project,
+                    ),
+                    allow_failure=True,
+                )
+                gate = unwrap_result(gate_payload)
+                if gate.get("verdict") == "pass":
+                    page_report["gate"] = "pass"
+                elif args.allow_titleblock_gap and titleblock_only_failure(gate):
+                    page_report["gate"] = "known-titleblock-gap"
+                else:
+                    page_report["gate"] = gate.get("verdict", "invalid")
+                    page_report["blockers"] = gate.get("blockers", [])
+                    page_report["gateStderr"] = gate_stderr or None
+                    errors.append({"type": "page-gate-failed", "page": name, "gate": gate})
+
+            _, read_payload, _ = run_command(
+                args.easyeda,
+                with_project(
+                    ["sch", "read", "--page", uuid, "--stay", "--no-check"],
+                    args.project,
+                ),
+            )
+            page_pins = actual_pin_records(read_payload)
+            all_actual_pins.extend(page_pins)
+            page_report["partPins"] = len(page_pins)
+
+            if args.export:
+                output = args.artifacts / f"{safe_page_name(name)}-final.png"
+                run_command(
+                    args.easyeda,
+                    with_project(
+                        [
+                            "sch",
+                            "export-image",
+                            "--scope",
+                            "page",
+                            "--format",
+                            "png",
+                            "--theme",
+                            "Black on White",
+                            "--out",
+                            str(output),
+                        ],
+                        args.project,
+                    ),
+                    expect_json=False,
+                )
+                if not output.is_file() or output.stat().st_size == 0:
+                    errors.append(
+                        {"type": "empty-export", "page": name, "path": str(output)}
+                    )
+                else:
+                    report["exports"].append(
+                        {
+                            "page": name,
+                            "path": str(output.resolve()),
+                            "bytes": output.stat().st_size,
+                        }
+                    )
+
+            report["pages"].append(page_report)
+
+        if args.golden:
+            golden = load_json(args.golden)
+            report["pins"] = compare_pins(all_actual_pins, expected_pin_map(golden))
+            if not report["pins"]["matched"]:
+                errors.append({"type": "golden-pin-net-mismatch", "detail": report["pins"]})
+
+        report["ok"] = not errors
+    finally:
+        if original_page:
+            run_command(
+                args.easyeda,
+                with_project(["sch", "open", "--page", original_page], args.project),
+                allow_failure=True,
+            )
+
+    rendered_report = json.dumps(report, ensure_ascii=False, indent=2)
+    if args.report_out:
+        args.report_out.parent.mkdir(parents=True, exist_ok=True)
+        args.report_out.write_text(rendered_report + "\n", encoding="utf-8")
+
+    if args.json:
+        print(rendered_report)
+    else:
+        gate_counts = {}
+        for page in report["pages"]:
+            gate = page["gate"]
+            gate_counts[gate] = gate_counts.get(gate, 0) + 1
+        page_set = "match" if report["pageSet"].get("matched") else "FAIL"
+        print(f"pages: {len(report['pages'])} page-set={page_set}")
+        print(f"gates: {json.dumps(gate_counts, ensure_ascii=False, sort_keys=True)}")
+        nets_status = "pass" if report["nets"].get("ok") else "FAIL"
+        print(f"nets: {report['nets'].get('totalNets')} strict={nets_status}")
+        if report["pins"] is not None:
+            pins = report["pins"]
+            golden_status = "match" if pins["matched"] else "FAIL"
+            print(
+                f"pins: {pins['actualPinCount']}/{pins['expectedPinCount']} "
+                f"nc={pins['actualNC']}/{pins['expectedNC']} golden={golden_status}"
+            )
+        if args.export:
+            print(f"exports: {len(report['exports'])}/{len(report['pages'])}")
+        print("RESULT: PASS" if report["ok"] else f"RESULT: FAIL ({len(errors)} issue(s))")
+        for error in errors:
+            detail = error.get("page") or error.get("detail") or ""
+            print(f"- {error['type']}: {detail}")
+
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except AcceptanceError as exc:
+        print(f"acceptance error: {exc}", file=sys.stderr)
+        sys.exit(2)

--- a/skills/easyeda-agent/scripts/tests/schematic_acceptance_test.py
+++ b/skills/easyeda-agent/scripts/tests/schematic_acceptance_test.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Offline tests for the multi-page schematic acceptance helpers."""
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "schematic-acceptance.py"
+SPEC = importlib.util.spec_from_file_location("schematic_acceptance", SCRIPT)
+ACCEPTANCE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(ACCEPTANCE)
+
+
+def gate_with(check_findings, extra_failure=None):
+    stages = [
+        {"name": "layout-lint", "status": "pass"},
+        {"name": "clusters", "status": "pass"},
+        {
+            "name": "check",
+            "status": "fail",
+            "detail": {"findings": check_findings},
+        },
+        {"name": "bridge-check", "status": "pass"},
+        {"name": "drc", "status": "pass"},
+    ]
+    if extra_failure:
+        next(stage for stage in stages if stage["name"] == extra_failure)["status"] = "fail"
+    return {"verdict": "fail", "stages": stages}
+
+
+class PageSetTests(unittest.TestCase):
+    def test_page_order_is_ignored(self):
+        result = ACCEPTANCE.compare_page_sets(["MCU", "POWER"], ["POWER", "MCU"])
+        self.assertTrue(result["matched"])
+
+    def test_duplicate_pages_are_rejected(self):
+        result = ACCEPTANCE.compare_page_sets(["MCU", "MCU"], ["MCU"])
+        self.assertFalse(result["matched"])
+        self.assertEqual(result["actualDuplicates"], ["MCU"])
+
+
+class WindowSelectionTests(unittest.TestCase):
+    def test_requested_project_never_falls_back_to_another_window(self):
+        health = {
+            "found": {
+                "raw": {
+                    "windows": [{"context": {"projectName": "another-project"}}]
+                }
+            }
+        }
+        with self.assertRaises(ACCEPTANCE.AcceptanceError):
+            ACCEPTANCE.find_window(health, "target-project")
+
+
+class PinComparisonTests(unittest.TestCase):
+    def test_pin_and_nc_mismatches_are_rejected(self):
+        result = ACCEPTANCE.compare_pins(
+            [("U1.1", "3V3"), ("U1.2", "GND")],
+            [("U1.1", "3V3"), ("U1.2", None)],
+        )
+        self.assertFalse(result["matched"])
+        self.assertEqual(result["mismatchedNets"][0]["pin"], "U1.2")
+
+
+class TitleblockAllowlistTests(unittest.TestCase):
+    def test_exact_titleblock_gap_is_allowed(self):
+        gate = gate_with([{"type": "missing-titleblock"}])
+        self.assertTrue(ACCEPTANCE.titleblock_only_failure(gate))
+
+    def test_other_finding_remains_blocking(self):
+        gate = gate_with(
+            [{"type": "missing-titleblock"}, {"type": "floating-pin"}]
+        )
+        self.assertFalse(ACCEPTANCE.titleblock_only_failure(gate))
+
+    def test_other_failed_stage_remains_blocking(self):
+        gate = gate_with([{"type": "missing-titleblock"}], "drc")
+        self.assertFalse(ACCEPTANCE.titleblock_only_failure(gate))
+
+    def test_missing_or_skipped_stage_is_not_a_full_gate(self):
+        gate = gate_with([{"type": "missing-titleblock"}])
+        gate["stages"][-1]["status"] = "skipped"
+        self.assertFalse(ACCEPTANCE.titleblock_only_failure(gate))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 改动概述

本 PR 将多页原理图中需要反复手工拼接的验收步骤固化为一套确定性工作流。

- 修正 SKILL.md 的 Agent Skills 规范兼容问题：移除不受支持的顶层 compatibility 字段，并将环境要求移入正文。
- 明确要求 S0 设计方案书必须在创建页面或放置器件前落盘，并通过严格校验。
- 增加“单页事务”工作方式，以及针对非幂等原理图操作的有限重试和停止条件。
- 新增 scripts/schematic-acceptance.py，统一完成页面集合核对、全工程严格网络检查、逐页打开与 strict gate、权威 pin-to-net/NC 黄金表对账，以及可选的最终图片导出。
- 针对 v1.1.1 已知的 missing-titleblock 死锁增加精确且受版本限制的显式挂账条件。任何其他版本、失败阶段、跳过阶段或其他 finding 仍会阻塞验收。
- 增加离线回归测试，覆盖页面顺序与重复页、错误工程窗口选择、pin/NC 不一致，以及标题栏挂账边界。

## 背景与动机

当前多页验收需要每次重新组合多个命令，容易出现漏页、误信浅层 all-pages 数据、每次小改动后重复运行高成本 DRC，或者在非幂等操作部分成功后盲目重放整批等问题。

v1.1.1 还存在一个已知矛盾：sch titleblock --data 可能损坏 sheet 引用，而 strict gate 又会针对 missing-titleblock 推荐执行该命令。本 PR 不修改 connector 或 gate 的底层实现，只在验收脚本中为已经确认的精确失败形态提供显式、严格受限的临时挂账能力，并在 skill 中记录该限制。

## 验证结果

- npx -y skills-ref@latest validate ./skills/easyeda-agent
- make lint-test
- go test ./...
- git diff --check
- 真实 9 页原理图验收结果：
  - 页面集合：9/9 匹配
  - strict gate：9/9 在显式启用 v1.1.1 标题栏挂账后通过
  - 全工程网络：59 条，strict 检查通过
  - 黄金拓扑：298/298 个引脚、48/48 个 NC 全部匹配
  - 最终导出：9/9 张 PNG 均非空

## 改动边界

本 PR 仅修改 skill、流程文档、辅助脚本和对应测试，不改变 daemon、connector、原理图 action 或 PCB 行为。

标题栏写入、missingPartitions 统计、容量诊断字段矛盾，以及审计日志载荷完整性仍属于上游实现问题，本 PR 不扩大范围处理。