### PR TITLE
fix(pcb): 只统计已启用铜层；绝不静默改动叠层（T-11）

### DIFF
--- a/internal/app/cmd_pcb.go
+++ b/internal/app/cmd_pcb.go
@@ -3395,7 +3395,7 @@ current stackup with 'pcb layers' (copperLayerCount + each layer's type).`,
 	// ceshi: DRC No-Connection → 0. Core in pcb_powerplanes.go.
 	{
 		var gndLayer, powerLayer int
-		var dryRun, gndPlane bool
+		var dryRun, gndPlane, allowStackupChange bool
 		c := &cobra.Command{
 			Use:   "power-planes",
 			Short: "4-layer power distribution: GND 内电层 + power inner plane + via-stitch (fixes 2-layer pour conflict)",
@@ -3425,13 +3425,17 @@ Validated on ceshi: DRC 31 → 0, No-Connection → 0. Run AFTER auto-place + ou
   easyeda pcb power-planes --gnd-plane=false   # keep GND as a signal-layer pour
   easyeda pcb power-planes --dry-run`,
 			RunE: func(cmd *cobra.Command, args []string) error {
-				return runPowerPlanes(cfg, window, gndLayer, powerLayer, gndPlane, dryRun, stdout, stderr)
+				return runPowerPlanes(cfg, window, gndLayer, powerLayer, gndPlane, dryRun, allowStackupChange, stdout, stderr)
 			},
 		}
 		c.Flags().IntVar(&gndLayer, "gnd-layer", 15, "inner layer id for the GND plane (15=Inner1)")
 		c.Flags().IntVar(&powerLayer, "power-layer", 16, "inner layer id for the power plane (16=Inner2)")
 		c.Flags().BoolVar(&gndPlane, "gnd-plane", true, "flip the GND inner layer to 内电层/PLANE after pouring (customer-stackup correct)")
 		c.Flags().BoolVar(&dryRun, "dry-run", false, "print the plan (nets→layers, pad counts) without mutating")
+		c.Flags().BoolVar(&allowStackupChange, "allow-stackup-change", false,
+			"permit step 1 to CHANGE the board's copper layer count (pcb stackup set --layers 4). "+
+				"Off by default: a board with <4 copper layers is REFUSED, not silently re-stacked "+
+				"(T-11). On a 2-layer board use `pcb power-pour` instead")
 		pcb.AddCommand(c)
 	}
 

--- a/internal/app/pcb_powerplanes.go
+++ b/internal/app/pcb_powerplanes.go
@@ -34,7 +34,11 @@ type ppNet struct {
 // inner-layer ids (15=Inner1, 16=Inner2 on a 4-layer board). gndAsPlane flips the GND
 // inner layer to 内电层/PLANE after pouring (the verified pour-while-SIGNAL → flip →
 // rebuild recipe; DRC stays clean — see the pcb-inner-plane-fill memory).
-func runPowerPlanes(cfg *appConfig, window string, gndLayer, powerLayer int, gndAsPlane, dryRun bool, stdout, stderr io.Writer) error {
+//
+// allowStackupChange gates step 3: without it a board with fewer than 4 copper
+// layers is REFUSED rather than re-stacked (T-11). A board that already has 4+
+// copper layers never triggers the gate, since nothing needs changing.
+func runPowerPlanes(cfg *appConfig, window string, gndLayer, powerLayer int, gndAsPlane, dryRun, allowStackupChange bool, stdout, stderr io.Writer) error {
 	// ADR-0004 Decision 4: dry-run 必须纯计算 —— 机械保证,Mutates 派发直接被拒。
 	if dryRun {
 		defer setDispatchDryRun(true)()
@@ -116,8 +120,26 @@ func runPowerPlanes(cfg *appConfig, window string, gndLayer, powerLayer int, gnd
 		return enc.Encode(map[string]any{"dryRun": true, "plan": plan, "routeAsTracks": routeAsTracks, "warnings": warnings, "pourRect": rect, "gndAsPlane": gndAsPlane, "gndLayer": gndLayer})
 	}
 
-	// 3. Ensure ≥4 copper layers.
-	if _, err := requestAction(cfg, "pcb.stackup.set", window, map[string]any{"count": 4}); err != nil {
+	// 3. Ensure >=4 copper layers — but NEVER silently. Re-stacking a board is
+	//    irreversible in fab terms (a 2-layer board that is already ordered comes
+	//    back as a different part), so a board that is not already 4+ layers is
+	//    only upgraded when the caller said so out loud (T-11: route-critical
+	//    mis-counted a 2-layer board as 4 and this line quietly re-stacked it).
+	if live, _, ok := currentCopperLayerCount(cfg, window); ok && live >= 4 {
+		// Already deep enough — nothing to set, so nothing to guard.
+	} else if !allowStackupChange {
+		have := "unknown"
+		if ok {
+			have = fmt.Sprintf("%d", live)
+		}
+		return fmt.Errorf(
+			"power-planes needs >=4 copper layers but the board has %s — refusing to re-stack it.\n"+
+				"Inner planes only make sense on a 4+ layer board; on a 2-layer board use `pcb power-pour` instead.\n"+
+				"If you really do want this board re-stacked to 4 layers, say so explicitly:\n"+
+				"  easyeda pcb power-planes --allow-stackup-change\n"+
+				"  easyeda pcb stackup set --layers 4        # or do it as its own deliberate step",
+			have)
+	} else if _, err := requestAction(cfg, "pcb.stackup.set", window, map[string]any{"count": 4}); err != nil {
 		return fmt.Errorf("set 4 copper layers: %w", err)
 	}
 

--- a/internal/app/pcb_route_critical.go
+++ b/internal/app/pcb_route_critical.go
@@ -30,11 +30,13 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"os"
 	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/zhoushoujianwork/easyeda-agent/internal/blocks"
+	"github.com/zhoushoujianwork/easyeda-agent/internal/spec"
 )
 
 // ── diff-pair identification ────────────────────────────────────────────────
@@ -295,7 +297,9 @@ func splitCSVList(items []string) []string {
 func newPcbRouteCriticalCmd(cfg *appConfig, window *string, stdout, stderr io.Writer) *cobra.Command {
 	var (
 		skipPower, skipDiff, noLock, dryRun bool
+		allowStackupChange                  bool
 		forceReason, forceUnsafeReason      string
+		specPath                            string
 	)
 	c := &cobra.Command{
 		Use:   "route-critical",
@@ -322,6 +326,22 @@ and identifies without mutating.`,
   easyeda pcb route-critical --project ceshi --skip-power   # pairs only`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// S0 spec 的 stackup.layers(若有)是本次运行的层数**权威**。先读,
+			// 读不动就早死,别等到板子已经被前面的步骤写过。
+			declared := 0
+			if specPath != "" {
+				raw, rerr := os.ReadFile(specPath)
+				if rerr != nil {
+					return fmt.Errorf("read spec: %w", rerr)
+				}
+				s0, perr := spec.Parse(raw)
+				if perr != nil {
+					return perr
+				}
+				if s0.Stackup != nil {
+					declared = s0.Stackup.Layers
+				}
+			}
 			// ADR-0004 Decision 4: dry-run 必须纯计算 —— 机械保证,Mutates 派发直接被拒。
 			if dryRun {
 				defer setDispatchDryRun(true)()
@@ -340,14 +360,30 @@ and identifies without mutating.`,
 			if skipPower {
 				out["power"] = "skipped (--skip-power)"
 			} else {
-				copper := copperLayerCount(cfg, *window, stderr)
+				copper, copperSrc := copperLayerCount(cfg, *window, stderr)
+				out["copperLayerCount"] = copper
+				out["copperLayerCountSource"] = copperSrc
+				// spec 说了算:S0 的 stackup.layers 是**人写下的意图**,活板与它不
+				// 一致时 route-critical 不改板 —— 它是布线命令,不是叠层命令(T-11)。
+				if declared > 0 {
+					out["copperLayerCountDeclared"] = declared
+					if declared != copper {
+						return fmt.Errorf(
+							"stackup conflict: spec declares %d copper layer(s) but the board reads %d (%s).\n"+
+								"route-critical routes, it does not re-stack a board. Fix one of the two first:\n"+
+								"  board  → easyeda pcb stackup set --layers %d   (changes the PCB!)\n"+
+								"  spec   → set stackup.layers to %d in %s",
+							declared, copper, copperSrc, declared, copper, specPath)
+					}
+					copperSrc = "spec (confirmed against " + copperSrc + ")"
+				}
 				if copper >= 4 {
-					out["power"] = "power-planes (4-layer)"
-					if err := runPowerPlanes(cfg, *window, 15, 16, true, dryRun, stderr, stderr); err != nil {
+					out["power"] = fmt.Sprintf("power-planes (%d-layer, from %s)", copper, copperSrc)
+					if err := runPowerPlanes(cfg, *window, 15, 16, true, dryRun, allowStackupChange, stderr, stderr); err != nil {
 						return fmt.Errorf("power step (power-planes): %w", err)
 					}
 				} else {
-					out["power"] = "power-pour (2-layer)"
+					out["power"] = fmt.Sprintf("power-pour (%d-layer, from %s)", copper, copperSrc)
 					if err := runPowerPour(cfg, *window, "both", "pour", railMargin, 0, true, true, dryRun, stderr, stderr); err != nil {
 						return fmt.Errorf("power step (power-pour): %w", err)
 					}
@@ -500,6 +536,11 @@ and identifies without mutating.`,
 	c.Flags().BoolVar(&dryRun, "dry-run", false, "plan + identify without mutating")
 	c.Flags().StringVar(&forceReason, "force", "", "bypass SOFT gate gaps only (audited, per-run) — same tiering as route-short (#132)")
 	c.Flags().StringVar(&forceUnsafeReason, "force-unsafe", "", "bypass EVERYTHING incl. an unconfirmed skeleton (audited, per-run)")
+	c.Flags().StringVar(&specPath, "spec", "", "S0 spec JSON — its stackup.layers is AUTHORITATIVE: when the live board\n"+
+		"disagrees the command refuses instead of re-stacking the board")
+	c.Flags().BoolVar(&allowStackupChange, "allow-stackup-change", false,
+		"permit the power step to CHANGE the board's copper layer count (pcb stackup set).\n"+
+			"Off by default: route-critical routes, it does not re-stack a board (T-11)")
 	return c
 }
 
@@ -517,15 +558,62 @@ func dedupeStrings(in []string) []string {
 	return out
 }
 
-// copperLayerCount counts copper layers from pcb.layers.list (SIGNAL/PLANE
-// types on copper layer ids); falls back to 2 when unreadable.
+// copperLayerTypes 是 pcb.layers.list 里算「铜层」的 type 值。
+//
+// 实测(EasyEDA Pro 3.2.135,2 层板)的 type 取值与 @jlceda/pro-api-types 的
+// EPCB_LayerType 枚举**不一致**:外层不叫 SIGNAL 而是 TOP / BOTTOM,只有内层
+// Inner1..Inner32 才叫 SIGNAL(内电层是 PLANE)。四个值都收下,才既算得到外层、
+// 又不漏掉内层。
+var copperLayerTypes = map[string]bool{"TOP": true, "BOTTOM": true, "SIGNAL": true, "PLANE": true}
+
+// copperLayerCountFromResult 从一份 pcb.layers.list 的 result 里读出**已启用**的
+// 铜层数,并说明这个数字的出处。ok=false 表示这份 result 里没有可信证据。
+//
+// 优先用平台自己的 copperLayerCount 字段(连接器直接转发
+// eda.pcb_Layer.getTheNumberOfCopperLayers()),它就是叠层对话框里的那个数。
+// 读不到时才退回数 layers[]:只数 copperLayerTypes 里的 type,且 layerStatus 必须
+// 不是 0(EPCB_LayerStatus.NOT_USED,即「不使用」)。
+//
+// 这个 layerStatus 过滤是 T-11 的根。实测 2 层板的 pcb.layers.list 回 260 条 layer,
+// 其中 Inner1..Inner32 全是 type=SIGNAL、layerStatus=0(未启用),而真正的两层铜是
+// type=TOP / BOTTOM。老实现只数 SIGNAL|PLANE 又不看 layerStatus,于是**任何**板子
+// 都数出 32 —— 一块 2 层板被判成 >=4 层,走进 power-planes,而 power-planes 头一件
+// 事就是 pcb.stackup.set{count:4},把一块已下单的 2 层板改成了 4 层。
+func copperLayerCountFromResult(result map[string]any) (int, string, bool) {
+	if v, ok := asFloatOK(result["copperLayerCount"]); ok && v >= 2 {
+		return int(v), "pcb.layers.list.copperLayerCount", true
+	}
+	raw, _ := result["layers"].([]any)
+	n := 0
+	for _, ri := range raw {
+		m, ok := ri.(map[string]any)
+		if !ok {
+			continue
+		}
+		if !copperLayerTypes[strings.ToUpper(asString(m["type"]))] {
+			continue
+		}
+		// 缺 layerStatus 时按「启用」算 —— 只有明确的 NOT_USED(0) 才排除。
+		if st, ok := asFloatOK(m["layerStatus"]); ok && st == 0 {
+			continue
+		}
+		n++
+	}
+	if n < 2 {
+		return 0, "", false
+	}
+	return n, "pcb.layers.list.layers[] (enabled copper)", true
+}
+
+// copperLayerCount 读活板的已启用铜层数,返回层数与它的出处(出处进回执,让
+// 「为什么走了这条电源分支」事后可复查);读不到时按 2 层降级。
 //
 // 这个「读不到就当 2 层」的兜底在 STALE_READ 门下变得危险:板子若在本命令开跑前
 // 就脏(上一条命令写完没 reload),这一读会被门拒掉,于是一块 4 层板被静默当成 2
 // 层 —— 走的是 power-pour 而不是 power-planes,两条电源轨挤同一层,正是内电层要
 // 解决的那个冲突。**这一读按设计不放行**(它是命令入口的规划读,不是写后回读),
 // 所以唯一负责任的做法是把兜底说出来,别让分档决策静默走偏。
-func copperLayerCount(cfg *appConfig, window string, stderr io.Writer) int {
+func copperLayerCount(cfg *appConfig, window string, stderr io.Writer) (int, string) {
 	res, err := requestAction(cfg, "pcb.layers.list", window, nil)
 	if err != nil {
 		if isStaleRead(err) {
@@ -534,22 +622,22 @@ func copperLayerCount(cfg *appConfig, window string, stderr io.Writer) int {
 		} else {
 			fmt.Fprintf(stderr, "⚠ route-critical: 读不到叠层(%v)—— 按 2 层降级(将走 power-pour 而不是 power-planes)\n", err)
 		}
-		return 2
+		return 2, "unreadable — fell back to 2"
 	}
-	raw, _ := res.Result["layers"].([]any)
-	n := 0
-	for _, ri := range raw {
-		m, ok := ri.(map[string]any)
-		if !ok {
-			continue
-		}
-		t := strings.ToUpper(asString(m["type"]))
-		if t == "SIGNAL" || t == "PLANE" {
-			n++
-		}
+	n, src, ok := copperLayerCountFromResult(res.Result)
+	if !ok {
+		fmt.Fprintln(stderr, "⚠ route-critical: pcb.layers.list 里没有可信的铜层证据 —— 按 2 层降级(将走 power-pour)")
+		return 2, "no copper evidence — fell back to 2"
 	}
-	if n < 2 {
-		return 2
+	return n, src
+}
+
+// currentCopperLayerCount 是 copperLayerCount 的静默版:同一份证据、同一套判据,
+// 但不写 stderr —— 给「决定要不要改板」这种非入口读用(pcb_powerplanes.go)。
+func currentCopperLayerCount(cfg *appConfig, window string) (int, string, bool) {
+	res, err := requestAction(cfg, "pcb.layers.list", window, nil)
+	if err != nil {
+		return 0, "", false
 	}
-	return n
+	return copperLayerCountFromResult(res.Result)
 }

--- a/internal/app/pcb_route_critical_test.go
+++ b/internal/app/pcb_route_critical_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -115,5 +116,132 @@ func TestPlanPairRoute(t *testing.T) {
 	res2 := planPairRoute(comps, pair, map[string]bool{"USB_DP": true}, opt)
 	if res2.Status != "already-routed" {
 		t.Errorf("expected already-routed, got %+v", res2)
+	}
+}
+
+// ── T-11: copper-layer counting on a 2-layer board ──────────────────────────
+
+// layer 组一条 pcb.layers.list 里的 layer 项。
+func layer(id int, name, typ string, status int) map[string]any {
+	return map[string]any{"id": float64(id), "name": name, "type": typ, "layerStatus": float64(status)}
+}
+
+// twoLayerBoard 复刻实测(EasyEDA Pro 3.2.135)2 层板的 pcb.layers.list 形状:
+// 真正的两层铜是 type=TOP / BOTTOM(layerStatus=1),而 Inner1..Inner32 全部存在、
+// 全部 type=SIGNAL 且 layerStatus=0(EPCB_LayerStatus.NOT_USED,未启用)。
+func twoLayerBoard() []any {
+	out := []any{
+		layer(1, "Top Layer", "TOP", 1),
+		layer(2, "Bottom Layer", "BOTTOM", 1),
+		layer(3, "Top Silkscreen Layer", "TOP_SILK", 1),
+		layer(4, "Bottom Silkscreen Layer", "BOT_SILK", 1),
+		layer(12, "Multi-Layer", "MULTI", 1),
+	}
+	for i := 1; i <= 32; i++ {
+		out = append(out, layer(14+i, fmt.Sprintf("Inner%d", i), "SIGNAL", 0))
+	}
+	return out
+}
+
+func TestCopperLayerCountFromResult(t *testing.T) {
+	fourLayer := append([]any{}, twoLayerBoard()...)
+	for i, li := range fourLayer {
+		m := li.(map[string]any)
+		if m["name"] == "Inner1" || m["name"] == "Inner2" {
+			m["layerStatus"] = float64(1)
+			fourLayer[i] = m
+		}
+	}
+
+	cases := []struct {
+		name    string
+		result  map[string]any
+		want    int
+		wantOK  bool
+		wantSrc string
+	}{{
+		name:    "platform copperLayerCount wins",
+		result:  map[string]any{"copperLayerCount": float64(2), "layers": twoLayerBoard()},
+		want:    2,
+		wantOK:  true,
+		wantSrc: "pcb.layers.list.copperLayerCount",
+	}, {
+		// T-11 的回归:没有平台字段时,32 个未启用的 Inner 层不得被算成铜层。
+		name:    "2-layer board with 32 disabled inner layers counts 2",
+		result:  map[string]any{"layers": twoLayerBoard()},
+		want:    2,
+		wantOK:  true,
+		wantSrc: "pcb.layers.list.layers[] (enabled copper)",
+	}, {
+		name:    "4-layer board counts the two ENABLED inner layers",
+		result:  map[string]any{"layers": fourLayer},
+		want:    4,
+		wantOK:  true,
+		wantSrc: "pcb.layers.list.layers[] (enabled copper)",
+	}, {
+		name: "an enabled PLANE inner layer counts as copper",
+		result: map[string]any{"layers": []any{
+			layer(1, "Top Layer", "TOP", 1),
+			layer(2, "Bottom Layer", "BOTTOM", 1),
+			layer(15, "Inner1", "PLANE", 1),
+			layer(16, "Inner2", "SIGNAL", 2), // HIDDEN is USED, just not shown
+			layer(17, "Inner3", "SIGNAL", 0),
+		}},
+		want:    4,
+		wantOK:  true,
+		wantSrc: "pcb.layers.list.layers[] (enabled copper)",
+	}, {
+		name:   "a bogus platform count below 2 falls through to layers[]",
+		result: map[string]any{"copperLayerCount": float64(0), "layers": twoLayerBoard()},
+		want:   2,
+		wantOK: true,
+	}, {
+		name:   "nothing readable is reported as no evidence, not as 32",
+		result: map[string]any{},
+		want:   0,
+		wantOK: false,
+	}, {
+		name:   "only non-copper layers is no evidence",
+		result: map[string]any{"layers": []any{layer(3, "Top Silkscreen Layer", "TOP_SILK", 1)}},
+		want:   0,
+		wantOK: false,
+	}, {
+		// layerStatus 缺失时按「启用」算 —— 只有明确的 0 才排除。
+		name: "a layer without layerStatus counts as enabled",
+		result: map[string]any{"layers": []any{
+			map[string]any{"id": float64(1), "name": "Top Layer", "type": "TOP"},
+			map[string]any{"id": float64(2), "name": "Bottom Layer", "type": "BOTTOM"},
+		}},
+		want:   2,
+		wantOK: true,
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, src, ok := copperLayerCountFromResult(tc.result)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v (got %d from %q)", ok, tc.wantOK, got, src)
+			}
+			if got != tc.want {
+				t.Errorf("count = %d, want %d (source %q)", got, tc.want, src)
+			}
+			if tc.wantSrc != "" && src != tc.wantSrc {
+				t.Errorf("source = %q, want %q", src, tc.wantSrc)
+			}
+		})
+	}
+}
+
+// TestCopperLayerCountNeverMistakesTwoForFour 是 T-11 的门:2 层板绝不能落进
+// route-critical 的 power-planes 分支(该分支会 pcb.stackup.set{count:4} 改板)。
+func TestCopperLayerCountNeverMistakesTwoForFour(t *testing.T) {
+	for _, res := range []map[string]any{
+		{"copperLayerCount": float64(2), "layers": twoLayerBoard()},
+		{"layers": twoLayerBoard()},
+	} {
+		n, src, ok := copperLayerCountFromResult(res)
+		if !ok || n >= 4 {
+			t.Fatalf("2-layer board resolved to %d layers (ok=%v, source=%q) — power-planes would re-stack it", n, ok, src)
+		}
 	}
 }


### PR DESCRIPTION
`pcb route-critical` 把一块 2 层板按 4 层规划，实跑时把已经定稿的 2 层 PCB 改成了 4 层。

根因（在该板上实测，EasyEDA Pro 3.2.135）：

  $ easyeda pcb layers --project uv_sensor
  result.copperLayerCount = 2          <- 平台自己给的答案，正确
  result.count            = 260        <- layers[] 列出了所有「可能存在」的层
  layers[] 按 (type, layerStatus) 统计：
    (TOP,1) 1   (BOTTOM,1) 1   (TOP_SILK,1) 1   (BOT_SILK,1) 1   (MULTI,1) 1
    (SIGNAL,0) 32    <- Inner1..Inner32，layerStatus 0 = EPCB_LayerStatus.NOT_USED
    (PLANE,*) 0
    ... 另有 CUSTOM/MECHANICAL/装配/阻焊层

旧 copperLayerCount() 错在两点：

  1. 运行时的 `type` 值与 @jlceda/pro-api-types 里的 EPCB_LayerType 枚举 并不一致：外层铜是 "TOP" / "BOTTOM" 而不是 "SIGNAL"，只有内层才是 "SIGNAL"。按 `SIGNAL || PLANE` 统计，一个真实外层都数不到。
  2. 忽略了 layerStatus，32 个 NOT_USED 的内层全被算进去。

结果：这个函数对任何板子都返回 32，不只是这一块。32 >= 4 把 route-critical 带进 power-planes 分支，而该分支第一步就是 `pcb.stackup.set {count: 4}`。

修复：

  * copperLayerCountFromResult()：对 pcb.layers.list 结果的纯函数，表驱动 测试。优先取 result.copperLayerCount（连接器转发的 eda.pcb_Layer.getTheNumberOfCopperLayers()，这里读到 2 却一直没被用）， 否则再数 layers[]：type 为 TOP/BOTTOM/SIGNAL/PLANE 且 layerStatus != NOT_USED。读不到时报「无证据」而不是一个错误的数字。层数与其来源一并 写进 route-critical 的结果，分支选择可审计。
  * route-critical --spec：S0 spec 声明了 stackup.layers 时以 spec 为准； 活体板不一致则报硬错误并同时给出两边的修法——拒绝执行，而不是改叠层。
  * route-critical / power-planes --allow-stackup-change：runPowerPlanes 不再 无条件调用 pcb.stackup.set。已有 4+ 铜层的板无需改动；层数不足的板 除非显式传该标志否则拒绝，并提示 2 层板应走 `pcb power-pour`。

`go build ./cmd/easyeda` 通过，`go vet ./...` 干净，gofmt 干净。新增测试通过； `go test ./...` 与 main 一样只有 8 个 Windows 环境预存失败
（enrich-script / selfupdate / artifact-nesting），无新增。