### PR TITLE
fix: allow larger 3D model action payloads

### DIFF
--- a/internal/daemon/dispatch.go
+++ b/internal/daemon/dispatch.go
@@ -23,6 +23,10 @@ import (
 // callers can layer their own shorter timeouts on top.
 const dispatchTimeout = 60 * time.Second
 
+// actionRequestBodyLimit accommodates base64-encoded library assets such as
+// STEP models while keeping the localhost HTTP trust boundary explicitly bounded.
+const actionRequestBodyLimit = 32 << 20
+
 // dispatchTimeoutBounds clamp a caller-supplied Request.TimeoutMs. The daemon
 // answers slightly BEFORE the caller's own deadline (see requestTimeout) so the
 // caller gets a structured DISPATCH_FAILED, not a raw HTTP timeout.
@@ -127,7 +131,7 @@ func (s *Server) handleAction(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req protocol.Request
-	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&req); err != nil {
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, actionRequestBodyLimit)).Decode(&req); err != nil {
 		writeJSON(w, http.StatusBadRequest, errorResponse(req.ID, "BAD_REQUEST", "invalid action request body", err.Error()))
 		return
 	}

--- a/internal/daemon/dispatch_test.go
+++ b/internal/daemon/dispatch_test.go
@@ -1,14 +1,14 @@
 package daemon
 
 import (
-	"testing"
-	"time"
-
 	"encoding/json"
-	"github.com/zhoushoujianwork/easyeda-agent/internal/protocol"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"testing"
+	"time"
+
+	"github.com/zhoushoujianwork/easyeda-agent/internal/protocol"
 )
 
 func TestRequestTimeout(t *testing.T) {
@@ -30,6 +30,21 @@ func TestRequestTimeout(t *testing.T) {
 				t.Fatalf("requestTimeout(%d) = %v, want %v", tc.timeoutMs, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestActionRequestAllowsLarge3DModelPayload(t *testing.T) {
+	// system.health is daemon-local, so this isolates the shared request decoder
+	// without needing a live connector to consume the model payload.
+	s := New(Options{})
+	body := `{"action":"system.health","payload":{"dataBase64":"` + strings.Repeat("A", 2<<20) + `"}}`
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/action", strings.NewReader(body))
+
+	s.handleAction(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("2 MiB base64 action payload rejected: status=%d body=%s", rec.Code, rec.Body.String())
 	}
 }
 


### PR DESCRIPTION
3D model files are base64-encoded inside /action requests. The previous 1 MiB request-body limit rejected practical STEP files before library.model3d.create could process them.

Raise the shared daemon action limit to 32 MiB while keeping the localhost ingress explicitly bounded. Add a regression test with a 2 MiB model payload so the old failure cannot return.
